### PR TITLE
feat(lab-orders): Add lab orders module, prosthodontic fields, and dashboard widget

### DIFF
--- a/backend/app/modules/lab_orders/CHANGELOG.md
+++ b/backend/app/modules/lab_orders/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog — lab_orders module
+
+## Unreleased
+
+- Initial version: lab order CRUD, status lifecycle (sent → in_progress →
+  ready → received / cancelled), patient + lab contact linkage with
+  enriched display names, EN/ES/FR translations.

--- a/backend/app/modules/lab_orders/CLAUDE.md
+++ b/backend/app/modules/lab_orders/CLAUDE.md
@@ -1,0 +1,68 @@
+# Lab orders module
+
+Tracks work sent to external labs for a specific patient (crown, bridge,
+denture, implant, etc.), with a status lifecycle from "sent" through to
+"received". Custom clinic module.
+
+## Public API
+
+Routes mounted at `/api/v1/lab-orders/`.
+
+- `GET    /lab-orders`          — list, filterable by patient/lab/status; `lab_orders.read`
+- `GET    /lab-orders/{id}`     — single order; `lab_orders.read`
+- `POST   /lab-orders`          — create (status always starts at `sent`); `lab_orders.write`
+- `PATCH  /lab-orders/{id}`     — edit / change status; `lab_orders.write`
+- `DELETE /lab-orders/{id}`     — hard delete; `lab_orders.write`
+
+List/get responses are enriched with `patient_name` and `lab_contact_name`
+(joined server-side) so the frontend never has to resolve IDs itself.
+
+## Dependencies
+
+`manifest.depends = ["patients", "contacts"]`.
+
+- FK to `patients.id` — whose work this is.
+- FK to `contacts.id` — which lab it was sent to (must be an existing
+  contact in the same clinic; validated in `service.py`, does not require
+  `contact_type == "lab"` specifically, since a clinic might file a mixed
+  lab/supplier under one contact).
+
+Both cross-branch FKs and the synchronous reads of `Patient`/`Contact` in
+`service.py` are allowed under ADR 0002 / 0003 because both modules are
+declared above.
+
+## Permissions
+
+`lab_orders.read`, `lab_orders.write`. Default role grants: admin full
+access; dentist/assistant/receptionist read+write; hygienist read-only.
+
+## Status lifecycle
+
+`sent → in_progress → ready → received`, with `cancelled` as an
+alternate terminal state. Setting `status=received` without an explicit
+`received_date` auto-stamps today's date.
+
+## Tools exposed
+
+| Tool | Category | Wraps | Permission |
+|---|---|---|---|
+| `list_lab_orders` | READ | `LabOrderService.list_orders` | `lab_orders.read` |
+| `create_lab_order` | WRITE | `LabOrderService.create_order` | `lab_orders.write` |
+| `update_lab_order_status` | WRITE | `LabOrderService.update_order` | `lab_orders.write` |
+
+## Events emitted / consumed
+
+None (kept simple for v0.1 — a natural extension would be publishing
+`lab_order.status_changed` for the future task-board module, Phase 5, to
+consume for handoff notifications).
+
+## Lifecycle
+
+- `installable=True`, `auto_install=True`, `removable=True`.
+- Migrations on the `lab_orders` Alembic branch, chained off the core
+  `0001` migration (cross-branch FKs to `patients`/`contacts` are safe;
+  the module loader installs dependencies first per `manifest.depends`).
+
+## CHANGELOG
+
+See `./CHANGELOG.md`.

--- a/backend/app/modules/lab_orders/__init__.py
+++ b/backend/app/modules/lab_orders/__init__.py
@@ -1,0 +1,71 @@
+"""Lab orders module — track work sent to external labs, per patient.
+
+Depends on ``patients`` (whose work this is) and ``contacts`` (Phase 2 —
+which lab it went to). Cross-branch FKs to both are allowed under ADR 0002
+because both are declared in ``manifest.depends`` below; the synchronous
+read of ``contacts`` in ``service.py`` follows ADR 0003.
+"""
+
+from fastapi import APIRouter
+
+from app.core.plugins import BaseModule
+
+from .models import LabOrder
+from .router import router
+
+
+class LabOrdersModule(BaseModule):
+    """Lab work order tracking, linked to a patient and an external lab contact."""
+
+    manifest = {
+        "name": "lab_orders",
+        "version": "0.1.0",
+        "summary": "Track lab work orders per patient — status from sent to received.",
+        "author": "Clinic Custom",
+        "license": "BSL-1.1",
+        "category": "community",
+        "depends": ["patients", "contacts"],
+        "installable": True,
+        "auto_install": True,
+        "removable": True,
+        "role_permissions": {
+            "admin": ["*"],
+            "dentist": ["read", "write"],
+            "hygienist": ["read"],
+            "assistant": ["read", "write"],
+            "receptionist": ["read", "write"],
+        },
+        "frontend": {
+            "layer_path": "frontend",
+            "navigation": [
+                {
+                    "label": "nav.labOrdersForm",
+                    "icon": "i-lucide-clipboard-plus",
+                    "to": "/lab-orders/new",
+                    "permission": "lab_orders.write",
+                    "order": 92,
+                },
+                {
+                    "label": "nav.labOrdersStatus",
+                    "icon": "i-lucide-flask-conical",
+                    "to": "/lab-orders",
+                    "permission": "lab_orders.read",
+                    "order": 92.5,
+                },
+            ],
+        },
+    }
+
+    def get_models(self) -> list:
+        return [LabOrder]
+
+    def get_router(self) -> APIRouter:
+        return router
+
+    def get_permissions(self) -> list[str]:
+        return ["read", "write"]
+
+    def get_tools(self) -> list:
+        from . import tools
+
+        return tools.get_tools()

--- a/backend/app/modules/lab_orders/frontend/components/LabOrdersDashboardWidget.vue
+++ b/backend/app/modules/lab_orders/frontend/components/LabOrdersDashboardWidget.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+const { t } = useI18n()
+const labOrdersApi = useLabOrders()
+
+const sentCount = ref<number | null>(null)
+const inProgressCount = ref<number | null>(null)
+const readyCount = ref<number | null>(null)
+const isLoading = ref(false)
+
+async function load() {
+  isLoading.value = true
+  try {
+    const [sent, inProgress, ready] = await Promise.all([
+      labOrdersApi.list({ order_status: 'sent', page: 1, page_size: 1 }),
+      labOrdersApi.list({ order_status: 'in_progress', page: 1, page_size: 1 }),
+      labOrdersApi.list({ order_status: 'ready', page: 1, page_size: 1 })
+    ])
+    sentCount.value = sent.total
+    inProgressCount.value = inProgress.total
+    readyCount.value = ready.total
+  } catch {
+    sentCount.value = null
+    inProgressCount.value = null
+    readyCount.value = null
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(load)
+
+const hasPending = computed(() =>
+  (sentCount.value ?? 0) + (inProgressCount.value ?? 0) + (readyCount.value ?? 0) > 0
+)
+</script>
+
+<template>
+  <UCard v-if="isLoading || hasPending" :ui="{ body: 'p-3' }">
+    <template #header>
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-flask-conical" class="w-4 h-4 text-default" />
+          <span class="font-medium">{{ t('labOrders.dashboard.title') }}</span>
+        </div>
+        <NuxtLink to="/lab-orders" class="text-primary-accent hover:underline text-caption">
+          {{ t('labOrders.dashboard.viewAll') }} →
+        </NuxtLink>
+      </div>
+    </template>
+
+    <USkeleton v-if="isLoading" class="h-12 w-full" />
+    <div v-else class="grid grid-cols-3 gap-2 text-center">
+      <div>
+        <div class="text-h2 text-default tnum">
+          {{ sentCount }}
+        </div>
+        <div class="text-caption text-subtle">
+          {{ t('labOrders.statuses.sent') }}
+        </div>
+      </div>
+      <div>
+        <div class="text-h2 text-default tnum">
+          {{ inProgressCount }}
+        </div>
+        <div class="text-caption text-subtle">
+          {{ t('labOrders.statuses.in_progress') }}
+        </div>
+      </div>
+      <div>
+        <div class="text-h2 text-warning tnum">
+          {{ readyCount }}
+        </div>
+        <div class="text-caption text-subtle">
+          {{ t('labOrders.statuses.ready') }}
+        </div>
+      </div>
+    </div>
+  </UCard>
+</template>

--- a/backend/app/modules/lab_orders/frontend/composables/useLabOrders.ts
+++ b/backend/app/modules/lab_orders/frontend/composables/useLabOrders.ts
@@ -1,0 +1,106 @@
+export type WorkType =
+  | 'crown'
+  | 'bridge'
+  | 'denture'
+  | 'implant'
+  | 'veneer'
+  | 'orthodontic'
+  | 'repair'
+  | 'other'
+
+export type OrderStatus = 'sent' | 'in_progress' | 'ready' | 'received' | 'cancelled'
+
+export type ImpressionType = 'alginate' | 'pvs_silicone' | 'digital_scan' | 'other'
+
+export const VITA_CLASSICAL_SHADES = [
+  'A1', 'A2', 'A3', 'A3.5', 'A4',
+  'B1', 'B2', 'B3', 'B4',
+  'C1', 'C2', 'C3', 'C4',
+  'D2', 'D3', 'D4'
+] as const
+export type Shade = typeof VITA_CLASSICAL_SHADES[number]
+
+export interface LabOrder {
+  id: string
+  clinic_id: string
+  patient_id: string
+  lab_contact_id: string
+  work_type: WorkType
+  tooth_reference?: string | null
+  impression_type?: ImpressionType | null
+  antagonist_info?: string | null
+  shade?: Shade | null
+  status: OrderStatus
+  sent_date: string
+  expected_date?: string | null
+  received_date?: string | null
+  notes?: string | null
+  created_by?: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface LabOrderCreatePayload {
+  patient_id: string
+  lab_contact_id: string
+  work_type: WorkType
+  tooth_reference?: string | null
+  impression_type?: ImpressionType | null
+  antagonist_info?: string | null
+  shade?: Shade | null
+  sent_date: string
+  expected_date?: string | null
+  notes?: string | null
+}
+
+export interface LabOrderUpdatePayload {
+  lab_contact_id?: string
+  work_type?: WorkType
+  tooth_reference?: string | null
+  impression_type?: ImpressionType | null
+  antagonist_info?: string | null
+  shade?: Shade | null
+  status?: OrderStatus
+  expected_date?: string | null
+  received_date?: string | null
+  notes?: string | null
+}
+
+interface ApiOk<T> { data: T, message?: string | null }
+interface ApiPaged<T> { data: T[], total: number, page: number, page_size: number }
+
+export interface LabOrderListFilters {
+  patient_id?: string
+  lab_contact_id?: string
+  order_status?: OrderStatus
+  page?: number
+  page_size?: number
+}
+
+export function useLabOrders() {
+  const api = useApi()
+
+  async function list(filters: LabOrderListFilters = {}): Promise<ApiPaged<LabOrder>> {
+    const qs = new URLSearchParams()
+    for (const [k, v] of Object.entries(filters)) {
+      if (v === undefined || v === null || v === '') continue
+      qs.append(k, String(v))
+    }
+    const url = `/api/v1/lab_orders/${qs.toString() ? `?${qs.toString()}` : ''}`
+    return await api.get<ApiPaged<LabOrder>>(url)
+  }
+
+  async function create(payload: LabOrderCreatePayload): Promise<ApiOk<LabOrder>> {
+    return await api.post<ApiOk<LabOrder>>('/api/v1/lab_orders/', payload)
+  }
+
+  async function update(id: string, payload: LabOrderUpdatePayload): Promise<ApiOk<LabOrder>> {
+    return await api.patch<ApiOk<LabOrder>>(`/api/v1/lab_orders/${id}`, payload)
+  }
+
+  async function remove(id: string): Promise<ApiOk<null>> {
+    return await api.del<ApiOk<null>>(`/api/v1/lab_orders/${id}`)
+  }
+
+  return { list, create, update, remove }
+}

--- a/backend/app/modules/lab_orders/frontend/i18n/locales/en.json
+++ b/backend/app/modules/lab_orders/frontend/i18n/locales/en.json
@@ -1,0 +1,48 @@
+{
+  "labOrders": {
+    "title": "Lab orders",
+    "add": "New lab order",
+    "sentDate": "Sent",
+    "patient": "Patient",
+    "lab": "Lab",
+    "workType": "Work type",
+    "tooth": "Tooth",
+    "status": "Status",
+    "expectedDate": "Expected date",
+    "notes": "Notes",
+    "filterByStatus": "Filter by status",
+    "selectPatient": "Select patient",
+    "selectLab": "Select lab",
+    "noLabsHint": "Add a lab under Contacts first before creating an order.",
+    "workTypes": {
+      "crown": "Crown",
+      "bridge": "Bridge",
+      "denture": "Denture",
+      "implant": "Implant",
+      "veneer": "Veneer",
+      "orthodontic": "Orthodontic appliance",
+      "other": "Other",
+      "repair": "Repair"
+    },
+    "statuses": {
+      "sent": "Sent",
+      "in_progress": "In progress",
+      "ready": "Ready",
+      "received": "Received",
+      "cancelled": "Cancelled"
+    },
+    "dashboard": {
+      "title": "Pending lab work",
+      "viewAll": "View all"
+    },
+    "impressionType": "Impression type",
+    "antagonistInfo": "Antagonist info",
+    "shade": "Shade (Vita Classical)",
+    "impressionTypes": {
+      "alginate": "Alginate",
+      "pvs_silicone": "PVS / Silicone",
+      "digital_scan": "Digital scan",
+      "other": "Other"
+    }
+  }
+}

--- a/backend/app/modules/lab_orders/frontend/i18n/locales/es.json
+++ b/backend/app/modules/lab_orders/frontend/i18n/locales/es.json
@@ -1,0 +1,48 @@
+{
+  "labOrders": {
+    "title": "Pedidos de laboratorio",
+    "add": "Nuevo pedido",
+    "sentDate": "Enviado",
+    "patient": "Paciente",
+    "lab": "Laboratorio",
+    "workType": "Tipo de trabajo",
+    "tooth": "Diente",
+    "status": "Estado",
+    "expectedDate": "Fecha estimada",
+    "notes": "Notas",
+    "filterByStatus": "Filtrar por estado",
+    "selectPatient": "Seleccionar paciente",
+    "selectLab": "Seleccionar laboratorio",
+    "noLabsHint": "Añade un laboratorio en Contactos antes de crear un pedido.",
+    "workTypes": {
+      "crown": "Corona",
+      "bridge": "Puente",
+      "denture": "Prótesis",
+      "implant": "Implante",
+      "veneer": "Carilla",
+      "orthodontic": "Aparato de ortodoncia",
+      "other": "Otro",
+      "repair": "Reparación"
+    },
+    "statuses": {
+      "sent": "Enviado",
+      "in_progress": "En proceso",
+      "ready": "Listo",
+      "received": "Recibido",
+      "cancelled": "Cancelado"
+    },
+    "dashboard": {
+      "title": "Trabajo de laboratorio pendiente",
+      "viewAll": "Ver todo"
+    },
+    "impressionType": "Tipo de impresión",
+    "antagonistInfo": "Info del antagonista",
+    "shade": "Color (Vita Classical)",
+    "impressionTypes": {
+      "alginate": "Alginato",
+      "pvs_silicone": "PVS / Silicona",
+      "digital_scan": "Escaneo digital",
+      "other": "Otro"
+    }
+  }
+}

--- a/backend/app/modules/lab_orders/frontend/i18n/locales/fr.json
+++ b/backend/app/modules/lab_orders/frontend/i18n/locales/fr.json
@@ -1,0 +1,48 @@
+{
+  "labOrders": {
+    "title": "Commandes de laboratoire",
+    "add": "Nouvelle commande",
+    "sentDate": "Envoyée",
+    "patient": "Patient",
+    "lab": "Laboratoire",
+    "workType": "Type de travail",
+    "tooth": "Dent",
+    "status": "Statut",
+    "expectedDate": "Date prévue",
+    "notes": "Notes",
+    "filterByStatus": "Filtrer par statut",
+    "selectPatient": "Sélectionner un patient",
+    "selectLab": "Sélectionner un laboratoire",
+    "noLabsHint": "Ajoutez d'abord un laboratoire dans Contacts avant de créer une commande.",
+    "workTypes": {
+      "crown": "Couronne",
+      "bridge": "Bridge",
+      "denture": "Prothèse",
+      "implant": "Implant",
+      "veneer": "Facette",
+      "orthodontic": "Appareil orthodontique",
+      "other": "Autre",
+      "repair": "Réparation"
+    },
+    "statuses": {
+      "sent": "Envoyée",
+      "in_progress": "En cours",
+      "ready": "Prête",
+      "received": "Reçue",
+      "cancelled": "Annulée"
+    },
+    "dashboard": {
+      "title": "Travaux de laboratoire en attente",
+      "viewAll": "Voir tout"
+    },
+    "impressionType": "Type d'empreinte",
+    "antagonistInfo": "Info antagoniste",
+    "shade": "Teinte (Vita Classical)",
+    "impressionTypes": {
+      "alginate": "Alginate",
+      "pvs_silicone": "PVS / Silicone",
+      "digital_scan": "Empreinte numérique",
+      "other": "Autre"
+    }
+  }
+}

--- a/backend/app/modules/lab_orders/frontend/nuxt.config.ts
+++ b/backend/app/modules/lab_orders/frontend/nuxt.config.ts
@@ -1,0 +1,11 @@
+// Nuxt layer for the `lab_orders` module.
+export default defineNuxtConfig({
+  i18n: {
+    locales: [
+      { code: 'en', file: 'en.json' },
+      { code: 'es', file: 'es.json' },
+      { code: 'fr', file: 'fr.json' }
+    ],
+    langDir: 'locales'
+  }
+})

--- a/backend/app/modules/lab_orders/frontend/pages/lab-orders/index.vue
+++ b/backend/app/modules/lab_orders/frontend/pages/lab-orders/index.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { PERMISSIONS } from '~~/app/config/permissions'
+import { useLabOrders, type LabOrder, type OrderStatus } from '../../composables/useLabOrders'
+
+definePageMeta({ middleware: ['auth'] })
+
+const { t } = useI18n()
+const { can } = usePermissions()
+const labOrdersApi = useLabOrders()
+
+if (!can(PERMISSIONS.labOrders.read)) {
+  await navigateTo('/')
+}
+
+const canWrite = computed(() => can(PERMISSIONS.labOrders.write))
+
+const STATUSES: OrderStatus[] = ['sent', 'in_progress', 'ready', 'received', 'cancelled']
+const statusOptions = computed(() => STATUSES.map(s => ({ value: s, label: t(`labOrders.statuses.${s}`) })))
+
+const items = ref<LabOrder[]>([])
+const loading = ref(false)
+const filterStatus = ref<OrderStatus | undefined>(undefined)
+
+async function load() {
+  loading.value = true
+  try {
+    const res = await labOrdersApi.list({ order_status: filterStatus.value, page: 1, page_size: 100 })
+    items.value = res.data
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+watch(filterStatus, load)
+
+async function setStatus(order: LabOrder, newStatus: OrderStatus) {
+  await labOrdersApi.update(order.id, { status: newStatus })
+  await load()
+}
+
+async function remove(id: string) {
+  await labOrdersApi.remove(id)
+  await load()
+}
+
+const columns = [
+  { accessorKey: 'sent_date', header: t('labOrders.sentDate') },
+  { accessorKey: 'patient_name', header: t('labOrders.patient') },
+  { accessorKey: 'lab_contact_name', header: t('labOrders.lab') },
+  { accessorKey: 'work_type', header: t('labOrders.workType') },
+  { accessorKey: 'tooth_reference', header: t('labOrders.tooth') },
+  { accessorKey: 'status', header: t('labOrders.status') },
+  { accessorKey: 'actions', header: '' }
+]
+</script>
+
+<template>
+  <div class="p-4 space-y-4">
+    <div class="flex items-center justify-between">
+      <h1 class="text-h2 text-default">
+        {{ t('labOrders.title') }}
+      </h1>
+      <UButton
+        v-if="canWrite"
+        icon="i-lucide-plus"
+        to="/lab-orders/new"
+      >
+        {{ t('labOrders.add') }}
+      </UButton>
+    </div>
+
+    <USelect
+      v-model="filterStatus"
+      :items="statusOptions"
+      :placeholder="t('labOrders.filterByStatus')"
+      class="max-w-xs"
+    />
+
+    <UTable
+      :data="items"
+      :columns="columns"
+      :loading="loading"
+    >
+      <template #work_type-cell="{ row }">
+        {{ t(`labOrders.workTypes.${row.original.work_type}`) }}
+      </template>
+      <template #status-cell="{ row }">
+        <USelect
+          v-if="canWrite"
+          :model-value="row.original.status"
+          :items="statusOptions"
+          size="xs"
+          @update:model-value="(v) => setStatus(row.original, v as OrderStatus)"
+        />
+        <span v-else>{{ t(`labOrders.statuses.${row.original.status}`) }}</span>
+      </template>
+      <template #actions-cell="{ row }">
+        <UButton
+          v-if="canWrite"
+          icon="i-lucide-trash-2"
+          variant="ghost"
+          color="error"
+          size="xs"
+          @click="remove(row.original.id)"
+        />
+      </template>
+    </UTable>
+  </div>
+</template>

--- a/backend/app/modules/lab_orders/frontend/pages/lab-orders/new.vue
+++ b/backend/app/modules/lab_orders/frontend/pages/lab-orders/new.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { PERMISSIONS } from '~~/app/config/permissions'
+import type { Patient } from '~/types'
+import { useLabOrders, type WorkType, type ImpressionType, type Shade, VITA_CLASSICAL_SHADES } from '../../composables/useLabOrders'
+
+definePageMeta({ middleware: ['auth'] })
+
+const { t } = useI18n()
+const { can } = usePermissions()
+const labOrdersApi = useLabOrders()
+const contactsApi = useContacts()
+
+if (!can(PERMISSIONS.labOrders.write)) {
+  await navigateTo('/lab-orders')
+}
+
+const WORK_TYPES: WorkType[] = ['crown', 'bridge', 'denture', 'implant', 'veneer', 'orthodontic', 'repair', 'other']
+const workTypeOptions = computed(() => WORK_TYPES.map(w => ({ value: w, label: t(`labOrders.workTypes.${w}`) })))
+
+const IMPRESSION_TYPES: ImpressionType[] = ['alginate', 'pvs_silicone', 'digital_scan', 'other']
+const impressionTypeOptions = computed(() => IMPRESSION_TYPES.map(i => ({ value: i, label: t(`labOrders.impressionTypes.${i}`) })))
+
+const shadeOptions = computed(() => VITA_CLASSICAL_SHADES.map(s => ({ value: s, label: s })))
+
+interface LabContactOption { id: string, name: string }
+const labContacts = ref<LabContactOption[]>([])
+const labContactOptions = computed(() =>
+  labContacts.value.map(c => ({ value: c.id, label: c.name }))
+)
+
+async function loadContacts() {
+  const res = await contactsApi.list({ contact_type: 'lab', page: 1, page_size: 100 })
+  labContacts.value = res.data.map((c: any) => ({ id: c.id, name: c.name }))
+}
+
+const saving = ref(false)
+const selectedPatient = ref<Patient | null>(null)
+const form = ref({
+  lab_contact_id: '',
+  work_type: 'crown' as WorkType,
+  tooth_reference: '',
+  impression_type: '' as ImpressionType | '',
+  antagonist_info: '',
+  shade: '',
+  sent_date: new Date().toISOString().slice(0, 10),
+  expected_date: '',
+  notes: ''
+})
+
+onMounted(async () => {
+  await loadContacts()
+  form.value.lab_contact_id = labContacts.value[0]?.id ?? ''
+})
+
+async function submit() {
+  if (!selectedPatient.value || !form.value.lab_contact_id) return
+  saving.value = true
+  try {
+    await labOrdersApi.create({
+      patient_id: selectedPatient.value.id,
+      lab_contact_id: form.value.lab_contact_id,
+      work_type: form.value.work_type,
+      tooth_reference: form.value.tooth_reference || null,
+      impression_type: form.value.impression_type || null,
+      antagonist_info: form.value.antagonist_info || null,
+      shade: (form.value.shade || null) as Shade | null,
+      sent_date: form.value.sent_date,
+      expected_date: form.value.expected_date || null,
+      notes: form.value.notes || null
+    })
+    await navigateTo('/lab-orders')
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="p-4 space-y-4 max-w-lg">
+    <h1 class="text-h2 text-default">
+      {{ t('labOrders.add') }}
+    </h1>
+
+    <p v-if="labContacts.length === 0" class="text-caption text-subtle">
+      {{ t('labOrders.noLabsHint') }}
+    </p>
+
+    <div class="space-y-4">
+      <PatientSearch v-model="selectedPatient" :placeholder="t('labOrders.selectPatient')" />
+      <USelect v-model="form.lab_contact_id" :items="labContactOptions" :placeholder="t('labOrders.selectLab')" />
+      <USelect v-model="form.work_type" :items="workTypeOptions" />
+      <UInput v-model="form.tooth_reference" :placeholder="t('labOrders.tooth')" />
+      <USelect v-model="form.impression_type" :items="impressionTypeOptions" :placeholder="t('labOrders.impressionType')" />
+      <UInput v-model="form.antagonist_info" :placeholder="t('labOrders.antagonistInfo')" />
+      <USelect v-model="form.shade" :items="shadeOptions" :placeholder="t('labOrders.shade')" />
+      <UInput v-model="form.sent_date" type="date" />
+      <UInput v-model="form.expected_date" type="date" :placeholder="t('labOrders.expectedDate')" />
+      <UInput v-model="form.notes" :placeholder="t('labOrders.notes')" />
+
+      <div class="flex justify-end gap-2">
+        <UButton variant="ghost" to="/lab-orders">
+          {{ t('actions.cancel') }}
+        </UButton>
+        <UButton :loading="saving" :disabled="!selectedPatient || !form.lab_contact_id" @click="submit">
+          {{ t('actions.save') }}
+        </UButton>
+      </div>
+    </div>
+  </div>
+</template>

--- a/backend/app/modules/lab_orders/frontend/plugins/slots.client.ts
+++ b/backend/app/modules/lab_orders/frontend/plugins/slots.client.ts
@@ -1,0 +1,11 @@
+import { defineAsyncComponent } from 'vue'
+import { registerSlot } from '~~/app/composables/useModuleSlots'
+
+export default defineNuxtPlugin(() => {
+  registerSlot('dashboard.attention', {
+    id: 'lab_orders.dashboard.pending',
+    component: defineAsyncComponent(() => import('../components/LabOrdersDashboardWidget.vue')),
+    permission: 'lab_orders.read',
+    order: 60
+  })
+})

--- a/backend/app/modules/lab_orders/migrations/versions/labo_0001_initial.py
+++ b/backend/app/modules/lab_orders/migrations/versions/labo_0001_initial.py
@@ -1,0 +1,65 @@
+"""lab_orders: initial schema.
+
+Tables:
+    - ``lab_orders`` — work orders sent to external labs for a patient.
+
+Cross-branch FKs to ``patients`` and ``contacts`` are safe here: both are
+declared in this module's ``manifest.depends``, so the module loader
+installs them first (ADR 0002).
+
+Lives on its own Alembic branch (``lab_orders``) per ADR 0002.
+
+Revision ID: labo_0001
+Revises:
+Create Date: 2026-07-16
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "labo_0001"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = ("lab_orders",)
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "lab_orders",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("clinic_id", sa.UUID(), nullable=False),
+        sa.Column("patient_id", sa.UUID(), nullable=False),
+        sa.Column("lab_contact_id", sa.UUID(), nullable=False),
+        sa.Column("work_type", sa.String(length=20), nullable=False),
+        sa.Column("tooth_reference", sa.String(length=50), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="sent"),
+        sa.Column("sent_date", sa.Date(), nullable=False),
+        sa.Column("expected_date", sa.Date(), nullable=True),
+        sa.Column("received_date", sa.Date(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_by", sa.UUID(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["clinic_id"], ["clinics.id"]),
+        sa.ForeignKeyConstraint(["patient_id"], ["patients.id"]),
+        sa.ForeignKeyConstraint(["lab_contact_id"], ["contacts.id"]),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_lab_orders_clinic_id", "lab_orders", ["clinic_id"])
+    op.create_index("ix_lab_orders_patient_id", "lab_orders", ["patient_id"])
+    op.create_index("ix_lab_orders_lab_contact_id", "lab_orders", ["lab_contact_id"])
+    op.create_index("ix_lab_orders_work_type", "lab_orders", ["work_type"])
+    op.create_index("ix_lab_orders_status", "lab_orders", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_lab_orders_status", table_name="lab_orders")
+    op.drop_index("ix_lab_orders_work_type", table_name="lab_orders")
+    op.drop_index("ix_lab_orders_lab_contact_id", table_name="lab_orders")
+    op.drop_index("ix_lab_orders_patient_id", table_name="lab_orders")
+    op.drop_index("ix_lab_orders_clinic_id", table_name="lab_orders")
+    op.drop_table("lab_orders")

--- a/backend/app/modules/lab_orders/migrations/versions/labo_0002_add_prosthodontic_fields.py
+++ b/backend/app/modules/lab_orders/migrations/versions/labo_0002_add_prosthodontic_fields.py
@@ -1,0 +1,32 @@
+"""lab_orders: add impression_type, antagonist_info, shade (Phase 7).
+
+Also widens ``work_type`` to include "repair" — no schema change needed
+for that since the column is a plain String(20), not a DB-level enum.
+
+Revision ID: labo_0002
+Revises: labo_0001
+Create Date: 2026-07-19
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "labo_0002"
+down_revision: str | None = "labo_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("lab_orders", sa.Column("impression_type", sa.String(length=20), nullable=True))
+    op.add_column("lab_orders", sa.Column("antagonist_info", sa.String(length=500), nullable=True))
+    op.add_column("lab_orders", sa.Column("shade", sa.String(length=10), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("lab_orders", "shade")
+    op.drop_column("lab_orders", "antagonist_info")
+    op.drop_column("lab_orders", "impression_type")

--- a/backend/app/modules/lab_orders/models.py
+++ b/backend/app/modules/lab_orders/models.py
@@ -1,0 +1,45 @@
+"""LabOrder entity — a piece of work sent to an external lab for a patient.
+
+Cross-branch FKs to ``patients`` and ``contacts`` are allowed because both
+are listed in this module's ``manifest.depends`` (see ADR 0002 / 0003).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from uuid import uuid4
+
+from sqlalchemy import Date, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base, TimestampMixin
+
+WORK_TYPES = ("crown", "bridge", "denture", "implant", "veneer", "orthodontic", "repair", "other")
+ORDER_STATUSES = ("sent", "in_progress", "ready", "received", "cancelled")
+IMPRESSION_TYPES = ("alginate", "pvs_silicone", "digital_scan", "other")
+
+
+class LabOrder(Base, TimestampMixin):
+    """A work order sent to an external lab for a specific patient."""
+
+    __tablename__ = "lab_orders"
+
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    clinic_id: Mapped[UUID] = mapped_column(ForeignKey("clinics.id"), index=True)
+    patient_id: Mapped[UUID] = mapped_column(ForeignKey("patients.id"), index=True)
+    lab_contact_id: Mapped[UUID] = mapped_column(ForeignKey("contacts.id"), index=True)
+
+    work_type: Mapped[str] = mapped_column(String(20), index=True)
+    tooth_reference: Mapped[str | None] = mapped_column(String(50))
+    impression_type: Mapped[str | None] = mapped_column(String(20))
+    antagonist_info: Mapped[str | None] = mapped_column(String(500))
+    shade: Mapped[str | None] = mapped_column(String(10))
+    status: Mapped[str] = mapped_column(String(20), index=True, default="sent")
+
+    sent_date: Mapped[date] = mapped_column(Date)
+    expected_date: Mapped[date | None] = mapped_column(Date)
+    received_date: Mapped[date | None] = mapped_column(Date)
+
+    notes: Mapped[str | None] = mapped_column(Text)
+    created_by: Mapped[UUID | None] = mapped_column(ForeignKey("users.id"))

--- a/backend/app/modules/lab_orders/router.py
+++ b/backend/app/modules/lab_orders/router.py
@@ -1,0 +1,85 @@
+"""Lab orders HTTP surface. Mounts under ``/api/v1/lab-orders/*``."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.dependencies import ClinicContext, get_clinic_context, require_permission
+from app.core.schemas import ApiResponse, PaginatedApiResponse
+from app.database import get_db
+
+from .schemas import LabOrderCreate, LabOrderResponse, LabOrderUpdate
+from .service import LabOrderService
+
+router = APIRouter()
+
+
+@router.get("/", response_model=PaginatedApiResponse[LabOrderResponse])
+async def list_lab_orders(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("lab_orders.read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    patient_id: UUID | None = Query(default=None),
+    lab_contact_id: UUID | None = Query(default=None),
+    order_status: str | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+) -> PaginatedApiResponse[LabOrderResponse]:
+    orders, total = await LabOrderService.list_order_responses(
+        db, ctx.clinic_id, patient_id, lab_contact_id, order_status, page, page_size
+    )
+    return PaginatedApiResponse(
+        data=[LabOrderResponse.model_validate(o) for o in orders],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/{order_id}", response_model=ApiResponse[LabOrderResponse])
+async def get_lab_order(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("lab_orders.read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    order_id: UUID,
+) -> ApiResponse[LabOrderResponse]:
+    order = await LabOrderService.get_order_response(db, ctx.clinic_id, order_id)
+    return ApiResponse(data=LabOrderResponse.model_validate(order))
+
+
+@router.post("/", response_model=ApiResponse[LabOrderResponse])
+async def create_lab_order(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("lab_orders.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    payload: LabOrderCreate,
+) -> ApiResponse[LabOrderResponse]:
+    order = await LabOrderService.create_order(db, ctx.clinic_id, payload, ctx.user_id)
+    enriched = await LabOrderService.get_order_response(db, ctx.clinic_id, order.id)
+    return ApiResponse(data=LabOrderResponse.model_validate(enriched))
+
+
+@router.patch("/{order_id}", response_model=ApiResponse[LabOrderResponse])
+async def update_lab_order(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("lab_orders.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    order_id: UUID,
+    payload: LabOrderUpdate,
+) -> ApiResponse[LabOrderResponse]:
+    order = await LabOrderService.update_order(db, ctx.clinic_id, order_id, payload)
+    enriched = await LabOrderService.get_order_response(db, ctx.clinic_id, order.id)
+    return ApiResponse(data=LabOrderResponse.model_validate(enriched))
+
+
+@router.delete("/{order_id}", response_model=ApiResponse[None])
+async def delete_lab_order(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("lab_orders.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    order_id: UUID,
+) -> ApiResponse[None]:
+    await LabOrderService.delete_order(db, ctx.clinic_id, order_id)
+    return ApiResponse(data=None)

--- a/backend/app/modules/lab_orders/schemas.py
+++ b/backend/app/modules/lab_orders/schemas.py
@@ -1,0 +1,72 @@
+"""Pydantic schemas for the lab_orders module."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+WorkType = Literal[
+    "crown", "bridge", "denture", "implant", "veneer", "orthodontic", "repair", "other"
+]
+OrderStatus = Literal["sent", "in_progress", "ready", "received", "cancelled"]
+ImpressionType = Literal["alginate", "pvs_silicone", "digital_scan", "other"]
+# Vita Classical shade guide (16 shades, no D1).
+ShadeSelection = Literal[
+    "A1", "A2", "A3", "A3.5", "A4",
+    "B1", "B2", "B3", "B4",
+    "C1", "C2", "C3", "C4",
+    "D2", "D3", "D4",
+]
+
+
+class LabOrderCreate(BaseModel):
+    patient_id: UUID
+    lab_contact_id: UUID
+    work_type: WorkType
+    tooth_reference: str | None = Field(default=None, max_length=50)
+    impression_type: ImpressionType | None = None
+    antagonist_info: str | None = Field(default=None, max_length=500)
+    shade: ShadeSelection | None = None
+    sent_date: date
+    expected_date: date | None = None
+    notes: str | None = Field(default=None, max_length=2000)
+
+
+class LabOrderUpdate(BaseModel):
+    lab_contact_id: UUID | None = None
+    work_type: WorkType | None = None
+    tooth_reference: str | None = Field(default=None, max_length=50)
+    impression_type: ImpressionType | None = None
+    antagonist_info: str | None = Field(default=None, max_length=500)
+    shade: ShadeSelection | None = None
+    status: OrderStatus | None = None
+    expected_date: date | None = None
+    received_date: date | None = None
+    notes: str | None = Field(default=None, max_length=2000)
+
+
+class LabOrderResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    clinic_id: UUID
+    patient_id: UUID
+    patient_name: str
+    lab_contact_id: UUID
+    lab_contact_name: str
+    work_type: WorkType
+    tooth_reference: str | None
+    impression_type: ImpressionType | None
+    antagonist_info: str | None
+    shade: ShadeSelection | None
+    status: OrderStatus
+    sent_date: date
+    expected_date: date | None
+    received_date: date | None
+    notes: str | None
+    created_by: UUID | None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/modules/lab_orders/service.py
+++ b/backend/app/modules/lab_orders/service.py
@@ -1,0 +1,221 @@
+"""LabOrderService — business logic for lab work order CRUD and status tracking."""
+
+from __future__ import annotations
+
+from datetime import date
+from uuid import UUID
+
+from fastapi import HTTPException, status as http_status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.events import event_bus
+
+# Synchronous cross-module reads of `patients` and `contacts` — allowed
+# because both are listed in this module's manifest.depends (ADR 0002 / 0003).
+from app.modules.contacts.models import Contact
+from app.modules.patients.models import Patient
+
+from .models import LabOrder
+from .schemas import LabOrderCreate, LabOrderUpdate
+
+
+def _to_response_dict(order: LabOrder, patient_name: str, lab_contact_name: str) -> dict:
+    return {
+        "id": order.id,
+        "clinic_id": order.clinic_id,
+        "patient_id": order.patient_id,
+        "patient_name": patient_name,
+        "lab_contact_id": order.lab_contact_id,
+        "lab_contact_name": lab_contact_name,
+        "work_type": order.work_type,
+        "tooth_reference": order.tooth_reference,
+        "impression_type": order.impression_type,
+        "antagonist_info": order.antagonist_info,
+        "shade": order.shade,
+        "status": order.status,
+        "sent_date": order.sent_date,
+        "expected_date": order.expected_date,
+        "received_date": order.received_date,
+        "notes": order.notes,
+        "created_by": order.created_by,
+        "created_at": order.created_at,
+        "updated_at": order.updated_at,
+    }
+
+
+class LabOrderService:
+    @staticmethod
+    async def _assert_contact_exists(db: AsyncSession, clinic_id: UUID, contact_id: UUID) -> None:
+        stmt = select(Contact.id).where(Contact.id == contact_id, Contact.clinic_id == clinic_id)
+        found = (await db.execute(stmt)).scalar_one_or_none()
+        if found is None:
+            raise HTTPException(
+                status_code=http_status.HTTP_400_BAD_REQUEST,
+                detail="lab_contact_id does not match a contact in this clinic",
+            )
+
+    @staticmethod
+    async def _enrich(db: AsyncSession, orders: list[LabOrder]) -> list[dict]:
+        """Batch-fetch patient and contact names for a page of orders."""
+        if not orders:
+            return []
+
+        patient_ids = {o.patient_id for o in orders}
+        contact_ids = {o.lab_contact_id for o in orders}
+
+        patients = (
+            (await db.execute(select(Patient).where(Patient.id.in_(patient_ids))))
+            .scalars()
+            .all()
+        )
+        contacts = (
+            (await db.execute(select(Contact).where(Contact.id.in_(contact_ids))))
+            .scalars()
+            .all()
+        )
+        patient_names = {p.id: p.full_name for p in patients}
+        contact_names = {c.id: c.name for c in contacts}
+
+        return [
+            _to_response_dict(
+                o,
+                patient_names.get(o.patient_id, "—"),
+                contact_names.get(o.lab_contact_id, "—"),
+            )
+            for o in orders
+        ]
+
+    @staticmethod
+    async def list_order_responses(
+        db: AsyncSession,
+        clinic_id: UUID,
+        patient_id: UUID | None = None,
+        lab_contact_id: UUID | None = None,
+        order_status: str | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[dict], int]:
+        orders, total = await LabOrderService.list_orders(
+            db, clinic_id, patient_id, lab_contact_id, order_status, page, page_size
+        )
+        return await LabOrderService._enrich(db, orders), total
+
+    @staticmethod
+    async def get_order_response(db: AsyncSession, clinic_id: UUID, order_id: UUID) -> dict:
+        order = await LabOrderService.get_order(db, clinic_id, order_id)
+        enriched = await LabOrderService._enrich(db, [order])
+        return enriched[0]
+
+    @staticmethod
+    async def create_order(
+        db: AsyncSession, clinic_id: UUID, payload: LabOrderCreate, created_by: UUID | None
+    ) -> LabOrder:
+        await LabOrderService._assert_contact_exists(db, clinic_id, payload.lab_contact_id)
+        order = LabOrder(
+            clinic_id=clinic_id,
+            patient_id=payload.patient_id,
+            lab_contact_id=payload.lab_contact_id,
+            work_type=payload.work_type,
+            tooth_reference=payload.tooth_reference,
+            impression_type=payload.impression_type,
+            antagonist_info=payload.antagonist_info,
+            shade=payload.shade,
+            sent_date=payload.sent_date,
+            expected_date=payload.expected_date,
+            notes=payload.notes,
+            status="sent",
+            created_by=created_by,
+        )
+        db.add(order)
+        await db.commit()
+        await db.refresh(order)
+        return order
+
+    @staticmethod
+    async def list_orders(
+        db: AsyncSession,
+        clinic_id: UUID,
+        patient_id: UUID | None = None,
+        lab_contact_id: UUID | None = None,
+        order_status: str | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[LabOrder], int]:
+        stmt = select(LabOrder).where(LabOrder.clinic_id == clinic_id)
+        if patient_id:
+            stmt = stmt.where(LabOrder.patient_id == patient_id)
+        if lab_contact_id:
+            stmt = stmt.where(LabOrder.lab_contact_id == lab_contact_id)
+        if order_status:
+            stmt = stmt.where(LabOrder.status == order_status)
+
+        count_stmt = select(func.count()).select_from(stmt.subquery())
+        total = (await db.execute(count_stmt)).scalar_one()
+
+        stmt = (
+            stmt.order_by(LabOrder.sent_date.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+        rows = (await db.execute(stmt)).scalars().all()
+        return list(rows), total
+
+    @staticmethod
+    async def get_order(db: AsyncSession, clinic_id: UUID, order_id: UUID) -> LabOrder:
+        stmt = select(LabOrder).where(LabOrder.id == order_id, LabOrder.clinic_id == clinic_id)
+        order = (await db.execute(stmt)).scalar_one_or_none()
+        if order is None:
+            raise HTTPException(
+                status_code=http_status.HTTP_404_NOT_FOUND, detail="Lab order not found"
+            )
+        return order
+
+    @staticmethod
+    async def update_order(
+        db: AsyncSession, clinic_id: UUID, order_id: UUID, payload: LabOrderUpdate
+    ) -> LabOrder:
+        order = await LabOrderService.get_order(db, clinic_id, order_id)
+        if payload.lab_contact_id is not None:
+            await LabOrderService._assert_contact_exists(db, clinic_id, payload.lab_contact_id)
+
+        old_status = order.status
+        data = payload.model_dump(exclude_unset=True)
+        # Convenience: marking an order "received" auto-stamps today's date
+        # if the caller didn't supply one explicitly.
+        if data.get("status") == "received" and "received_date" not in data:
+            data["received_date"] = date.today()
+
+        for field, value in data.items():
+            setattr(order, field, value)
+        await db.commit()
+        await db.refresh(order)
+
+        # Phase 6: lets the `tasks` module auto-create a handoff task when
+        # an order becomes "ready", without lab_orders needing to know
+        # tasks exists — tasks subscribes to this, lab_orders just announces
+        # it. Plain string event, not in the core EventType enum, since
+        # this is a custom-module connector, not a core event.
+        # Guard on old_status != order.status (not just "status" in data) so
+        # a repeated/duplicate request with the same status can never
+        # publish twice and create duplicate tasks.
+        if "status" in data and order.status != old_status:
+            await event_bus.publish(
+                "lab_order.status_changed",
+                {
+                    "clinic_id": str(clinic_id),
+                    "order_id": str(order.id),
+                    "patient_id": str(order.patient_id),
+                    "status": order.status,
+                    "work_type": order.work_type,
+                    "tooth_reference": order.tooth_reference,
+                },
+            )
+
+        return order
+
+    @staticmethod
+    async def delete_order(db: AsyncSession, clinic_id: UUID, order_id: UUID) -> None:
+        order = await LabOrderService.get_order(db, clinic_id, order_id)
+        await db.delete(order)
+        await db.commit()

--- a/backend/app/modules/lab_orders/tools.py
+++ b/backend/app/modules/lab_orders/tools.py
@@ -1,0 +1,110 @@
+"""Agent tools for the lab_orders module. Thin wrappers over LabOrderService."""
+
+from __future__ import annotations
+
+from datetime import date as date_cls
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from app.core.agents import AgentContext, Tool, ToolCategory
+
+from .schemas import LabOrderCreate, OrderStatus, WorkType
+from .service import LabOrderService
+
+
+class ListLabOrdersArgs(BaseModel):
+    patient_id: UUID | None = None
+    order_status: OrderStatus | None = None
+    limit: int = Field(default=20, ge=1, le=100)
+
+
+class CreateLabOrderArgs(BaseModel):
+    patient_id: UUID
+    lab_contact_id: UUID
+    work_type: WorkType
+    tooth_reference: str | None = None
+    sent_date: date_cls
+    expected_date: date_cls | None = None
+    notes: str | None = None
+
+
+class UpdateLabOrderStatusArgs(BaseModel):
+    order_id: UUID
+    status: OrderStatus
+
+
+def _order_summary(order) -> dict:
+    return {
+        "id": str(order.id),
+        "patient_id": str(order.patient_id),
+        "lab_contact_id": str(order.lab_contact_id),
+        "work_type": order.work_type,
+        "status": order.status,
+        "sent_date": order.sent_date,
+        "expected_date": order.expected_date,
+    }
+
+
+async def _list_lab_orders(ctx: AgentContext, params: ListLabOrdersArgs) -> dict:
+    items, total = await LabOrderService.list_orders(
+        ctx.db,
+        ctx.clinic_id,
+        patient_id=params.patient_id,
+        order_status=params.order_status,
+        page=1,
+        page_size=params.limit,
+    )
+    return {"total": total, "lab_orders": [_order_summary(o) for o in items]}
+
+
+async def _create_lab_order(ctx: AgentContext, params: CreateLabOrderArgs) -> dict:
+    payload = LabOrderCreate(
+        patient_id=params.patient_id,
+        lab_contact_id=params.lab_contact_id,
+        work_type=params.work_type,
+        tooth_reference=params.tooth_reference,
+        sent_date=params.sent_date,
+        expected_date=params.expected_date,
+        notes=params.notes,
+    )
+    order = await LabOrderService.create_order(ctx.db, ctx.clinic_id, payload, ctx.user_id)
+    return _order_summary(order)
+
+
+async def _update_lab_order_status(ctx: AgentContext, params: UpdateLabOrderStatusArgs) -> dict:
+    from .schemas import LabOrderUpdate
+
+    order = await LabOrderService.update_order(
+        ctx.db, ctx.clinic_id, params.order_id, LabOrderUpdate(status=params.status)
+    )
+    return _order_summary(order)
+
+
+def get_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="list_lab_orders",
+            description="List lab work orders, optionally filtered by patient or status.",
+            parameters=ListLabOrdersArgs,
+            handler=_list_lab_orders,
+            permissions=["lab_orders.read"],
+            category=ToolCategory.READ,
+        ),
+        Tool(
+            name="create_lab_order",
+            description="Send a new lab work order for a patient (crown, bridge, denture, etc.).",
+            parameters=CreateLabOrderArgs,
+            handler=_create_lab_order,
+            permissions=["lab_orders.write"],
+            category=ToolCategory.WRITE,
+        ),
+        Tool(
+            name="update_lab_order_status",
+            description="Update the status of a lab order (sent, in_progress, ready, received, cancelled).",
+            parameters=UpdateLabOrderStatusArgs,
+            handler=_update_lab_order_status,
+            permissions=["lab_orders.write"],
+            category=ToolCategory.WRITE,
+        ),
+    ]


### PR DESCRIPTION
Implements end-to-end lab order tracking:

Adds backend/app/modules/lab_orders/ complete with models, schemas, service layer, and router.

Includes migrations labo_0001_initial.py and labo_0002_add_prosthodontic_fields.py.

Adds frontend components, pages (/lab-orders), i18n locales (EN, ES, FR), and LabOrdersDashboardWidget.vue.