### PR TITLE
fix(#183): own-session handler audit — the two silent bugs, and a CI guard

### DIFF
--- a/backend/app/modules/agenda/service.py
+++ b/backend/app/modules/agenda/service.py
@@ -508,6 +508,7 @@ class AppointmentService:
                 "treatment_type": appointment.treatment_type,
                 "cabinet": appointment.cabinet,
             },
+            db=db,
         )
 
         await db.refresh(appointment, ["patient", "professional", "treatments"])
@@ -735,7 +736,7 @@ class AppointmentService:
             "no_show": EventType.APPOINTMENT_NO_SHOW,
         }.get(to_status)
         if specific is not None:
-            await event_bus.publish(specific, payload)
+            await event_bus.publish(specific, payload, db=db)
 
         return appointment
 

--- a/backend/app/modules/budget/__init__.py
+++ b/backend/app/modules/budget/__init__.py
@@ -126,10 +126,7 @@ class BudgetModule(BaseModule):
         ]
 
     def get_event_handlers(self) -> dict[str, Any]:
-        from .service import BudgetService
-
         return {
-            EventType.ODONTOGRAM_TREATMENT_PERFORMED: BudgetService.on_treatment_performed,
             EventType.TREATMENT_PLAN_TREATMENT_ADDED: self._on_treatment_added_to_plan,
             EventType.TREATMENT_PLAN_TREATMENT_REMOVED: self._on_treatment_removed_from_plan,
             EventType.TREATMENT_PLAN_BUDGET_SYNC_REQUESTED: self._on_sync_requested,

--- a/backend/app/modules/budget/service.py
+++ b/backend/app/modules/budget/service.py
@@ -809,21 +809,6 @@ class BudgetService:
         budget.total_tax = total_tax
         budget.total = items_total - global_discount
 
-    @staticmethod
-    async def on_treatment_performed(data: dict) -> None:
-        """Event handler for when a treatment is performed in odontogram.
-
-        Updates the linked budget item status if applicable.
-        """
-        # This will be called by the event bus when odontogram.treatment.performed is published
-        budget_item_id = data.get("budget_item_id")
-        if not budget_item_id:
-            return
-
-        # Get DB session from context (this would need to be passed differently in real impl)
-        # For now, this is a placeholder for the event handler
-        pass
-
 
 class BudgetHistoryService:
     """Service for budget history/audit operations."""

--- a/backend/app/modules/media/__init__.py
+++ b/backend/app/modules/media/__init__.py
@@ -5,10 +5,10 @@ from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.events import EventType
 from app.core.plugins import BaseModule
-from app.database import async_session_maker
 
 from .models import Document, MediaAttachment
 from .router import router
@@ -67,13 +67,14 @@ class MediaModule(BaseModule):
             EventType.PATIENT_ARCHIVED: self._on_patient_archived,
         }
 
-    async def _on_patient_archived(self, data: dict) -> None:
+    async def _on_patient_archived(self, data: dict, *, db: AsyncSession) -> None:
         """Cascade soft-archive of a patient's documents when they are
         archived.
 
-        The event bus calls handlers as ``handler(data)`` and publishes
-        before the request commits, so this opens its own session and
-        commits independently (same pattern as the recalls handler).
+        Transactional (ADR 0019): the cascade is part of archiving the
+        patient. On its own session it committed independently, so a request
+        that failed after the publish left the documents archived under a
+        patient that never was (issue #183).
         """
         patient_id = data.get("patient_id")
         clinic_id = data.get("clinic_id")
@@ -84,12 +85,6 @@ class MediaModule(BaseModule):
             )
             return
 
-        async with async_session_maker() as db:
-            try:
-                await DocumentService.archive_patient_documents(
-                    db, UUID(str(clinic_id)), UUID(str(patient_id))
-                )
-                await db.commit()
-            except Exception as exc:
-                logger.error("media._on_patient_archived failed: %s", exc, exc_info=True)
-                await db.rollback()
+        await DocumentService.archive_patient_documents(
+            db, UUID(str(clinic_id)), UUID(str(patient_id))
+        )

--- a/backend/app/modules/odontogram/service.py
+++ b/backend/app/modules/odontogram/service.py
@@ -862,6 +862,7 @@ class TreatmentService:
                 if publish_price and treatment.price_snapshot is not None
                 else None,
             },
+            db=db,
         )
         return treatment
 

--- a/backend/app/modules/patients/service.py
+++ b/backend/app/modules/patients/service.py
@@ -289,5 +289,6 @@ class PatientService:
         await event_bus.publish(
             EventType.PATIENT_ARCHIVED,
             {"patient_id": str(patient.id), "clinic_id": str(patient.clinic_id)},
+            db=db,
         )
         return patient

--- a/backend/app/modules/payments/events.py
+++ b/backend/app/modules/payments/events.py
@@ -19,6 +19,12 @@ calls ``perform(publish_price=False)`` so the performed event carries
 ``unit_price: None`` (skipped below); when the odontogram performs
 first, treatment_plan cancels the item's pending sessions so session
 events can never fire on top of the NULL row.
+
+Both handlers are **transactional** (ADR 0019): revenue is booked in the
+same transaction as the treatment that earned it. On their own session they
+committed independently, so a request that failed after the publish left an
+earned entry for a treatment that never existed — and ``treatment_id``
+carries no FK to stop it (issue #183).
 """
 
 from __future__ import annotations
@@ -30,8 +36,7 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-
-from app.database import async_session_maker
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from .models import PatientEarnedEntry
 
@@ -73,6 +78,7 @@ async def _upsert_earned_entry(
     data: dict[str, Any],
     source_event: str,
     *,
+    db: AsyncSession,
     source_session_id: UUID | None = None,
     amount_override: Any = None,
     description: str | None = None,
@@ -109,39 +115,33 @@ async def _upsert_earned_entry(
     catalog_item_id = _parse_uuid(data.get("catalog_item_id"))
     professional_id = _parse_uuid(data.get("performed_by") or data.get("professional_id"))
 
-    async with async_session_maker() as db:
-        try:
-            stmt = (
-                pg_insert(PatientEarnedEntry)
-                .values(
-                    clinic_id=clinic_id,
-                    patient_id=patient_id,
-                    treatment_id=treatment_id,
-                    catalog_item_id=catalog_item_id,
-                    source_session_id=source_session_id,
-                    description=description,
-                    amount=amount,
-                    performed_at=performed_at,
-                    professional_id=professional_id,
-                    source_event=source_event,
-                )
-                # Bare form: swallows conflicts on the composite constraint
-                # AND the partial NULL-session index alike.
-                .on_conflict_do_nothing()
-            )
-            await db.execute(stmt)
-            await db.commit()
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error("Failed to upsert PatientEarnedEntry: %s", exc, exc_info=True)
-            await db.rollback()
+    stmt = (
+        pg_insert(PatientEarnedEntry)
+        .values(
+            clinic_id=clinic_id,
+            patient_id=patient_id,
+            treatment_id=treatment_id,
+            catalog_item_id=catalog_item_id,
+            source_session_id=source_session_id,
+            description=description,
+            amount=amount,
+            performed_at=performed_at,
+            professional_id=professional_id,
+            source_event=source_event,
+        )
+        # Bare form: swallows conflicts on the composite constraint
+        # AND the partial NULL-session index alike.
+        .on_conflict_do_nothing()
+    )
+    await db.execute(stmt)
 
 
-async def on_treatment_performed(data: dict[str, Any]) -> None:
+async def on_treatment_performed(data: dict[str, Any], *, db: AsyncSession) -> None:
     """Handler for ``odontogram.treatment.performed`` (single-session row)."""
-    await _upsert_earned_entry(data, source_event="odontogram.treatment.performed")
+    await _upsert_earned_entry(data, source_event="odontogram.treatment.performed", db=db)
 
 
-async def on_session_completed(data: dict[str, Any]) -> None:
+async def on_session_completed(data: dict[str, Any], *, db: AsyncSession) -> None:
     """Handler for ``treatment_plan.item_session_completed``.
 
     Books a per-session earned row keyed on ``(treatment_id,
@@ -154,6 +154,7 @@ async def on_session_completed(data: dict[str, Any]) -> None:
     await _upsert_earned_entry(
         data,
         source_event="treatment_plan.item_session_completed",
+        db=db,
         source_session_id=session_id,
         amount_override=data.get("amount"),
         description=description if isinstance(description, str) else None,

--- a/backend/app/modules/recalls/events.py
+++ b/backend/app/modules/recalls/events.py
@@ -6,6 +6,14 @@ payloads — recalls never imports another module's models, except
 ``Patient`` (which is in ``manifest.depends``) for read-side queries.
 
 Registered in :class:`~app.modules.recalls.RecallsModule.get_event_handlers`.
+
+All state-changing handlers here are **transactional** (ADR 0019): they
+declare ``db`` and run inside the publisher's session. A recall's link to an
+appointment is an FK to ``appointments.id``, so an own-session handler cannot
+even write it before the publisher commits — the row is invisible to a second
+connection and the FK check fails (issue #183). Running in-tx also keeps the
+recall's state and the appointment's state from diverging when one of them
+rolls back.
 """
 
 from __future__ import annotations
@@ -16,8 +24,7 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select
-
-from app.database import async_session_maker
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from .models import Recall
 from .service import RecallService, RecallSettingsService
@@ -36,9 +43,13 @@ def _safe_uuid(raw: Any) -> UUID | None:
         return None
 
 
-async def on_appointment_scheduled(data: dict[str, Any]) -> None:
+async def on_appointment_scheduled(data: dict[str, Any], *, db: AsyncSession) -> None:
     """Auto-link a pending recall to the new appointment when the
     clinic's setting allows it.
+
+    Transactional: ``Recall.linked_appointment_id`` is an FK to the
+    appointment the publisher has only flushed, so this has to run on the
+    publisher's session.
 
     Match policy (V1): same patient + the appointment date is on or
     after the recall's ``due_month`` (which is day-1 of the target
@@ -61,83 +72,72 @@ async def on_appointment_scheduled(data: dict[str, Any]) -> None:
     except (TypeError, ValueError):
         return
 
-    async with async_session_maker() as db:
-        try:
-            settings = await RecallSettingsService.get_or_create(db, clinic_id)
-            if not settings.auto_link_on_appointment_scheduled:
-                return
-            await RecallService.auto_link_for_appointment(
-                db,
-                clinic_id=clinic_id,
-                patient_id=patient_id,
-                appointment_id=appointment_id,
-                appointment_date=start_time.date(),
-            )
-            await db.commit()
-        except Exception as exc:  # pragma: no cover — defensive
-            logger.error("recalls.on_appointment_scheduled failed: %s", exc, exc_info=True)
-            await db.rollback()
-
-
-async def on_appointment_completed(data: dict[str, Any]) -> None:
-    """If a recall was linked to the completed appointment, mark it done."""
-    appointment_id = _safe_uuid(data.get("appointment_id"))
-    clinic_id = _safe_uuid(data.get("clinic_id"))
-    if not (appointment_id and clinic_id):
+    settings = await RecallSettingsService.get_or_create(db, clinic_id)
+    if not settings.auto_link_on_appointment_scheduled:
         return
-
-    async with async_session_maker() as db:
-        try:
-            result = await db.execute(
-                select(Recall).where(
-                    Recall.clinic_id == clinic_id,
-                    Recall.linked_appointment_id == appointment_id,
-                    Recall.status.in_(("contacted_scheduled", "pending")),
-                )
-            )
-            for recall in result.scalars().all():
-                await RecallService.mark_done(
-                    db,
-                    clinic_id=clinic_id,
-                    recall_id=recall.id,
-                    by_user=None,
-                    commit=False,
-                )
-            await db.commit()
-        except Exception as exc:
-            logger.error("recalls.on_appointment_completed failed: %s", exc, exc_info=True)
-            await db.rollback()
+    await RecallService.auto_link_for_appointment(
+        db,
+        clinic_id=clinic_id,
+        patient_id=patient_id,
+        appointment_id=appointment_id,
+        appointment_date=start_time.date(),
+    )
 
 
-async def on_appointment_cancelled(data: dict[str, Any]) -> None:
-    """Unlink the cancelled appointment from any recall and revert
-    the recall to ``pending`` so it shows up on the call list again.
+async def on_appointment_completed(data: dict[str, Any], *, db: AsyncSession) -> None:
+    """If a recall was linked to the completed appointment, mark it done.
+
+    Transactional: the recall closes with the appointment or not at all.
     """
     appointment_id = _safe_uuid(data.get("appointment_id"))
     clinic_id = _safe_uuid(data.get("clinic_id"))
     if not (appointment_id and clinic_id):
         return
 
-    async with async_session_maker() as db:
-        try:
-            result = await db.execute(
-                select(Recall).where(
-                    Recall.clinic_id == clinic_id,
-                    Recall.linked_appointment_id == appointment_id,
-                )
-            )
-            now = datetime.now(UTC)
-            for recall in result.scalars().all():
-                if recall.status in ("done", "cancelled"):
-                    continue
-                recall.linked_appointment_id = None
-                if recall.status == "contacted_scheduled":
-                    recall.status = "pending"
-                recall.updated_at = now
-            await db.commit()
-        except Exception as exc:
-            logger.error("recalls.on_appointment_cancelled failed: %s", exc, exc_info=True)
-            await db.rollback()
+    result = await db.execute(
+        select(Recall).where(
+            Recall.clinic_id == clinic_id,
+            Recall.linked_appointment_id == appointment_id,
+            Recall.status.in_(("contacted_scheduled", "pending")),
+        )
+    )
+    for recall in result.scalars().all():
+        await RecallService.mark_done(
+            db,
+            clinic_id=clinic_id,
+            recall_id=recall.id,
+            by_user=None,
+            commit=False,
+        )
+
+
+async def on_appointment_cancelled(data: dict[str, Any], *, db: AsyncSession) -> None:
+    """Unlink the cancelled appointment from any recall and revert
+    the recall to ``pending`` so it shows up on the call list again.
+
+    Transactional: leaving a recall pointing at a cancelled appointment
+    (or freeing it for a cancellation that rolled back) both put the call
+    list out of sync with the agenda.
+    """
+    appointment_id = _safe_uuid(data.get("appointment_id"))
+    clinic_id = _safe_uuid(data.get("clinic_id"))
+    if not (appointment_id and clinic_id):
+        return
+
+    result = await db.execute(
+        select(Recall).where(
+            Recall.clinic_id == clinic_id,
+            Recall.linked_appointment_id == appointment_id,
+        )
+    )
+    now = datetime.now(UTC)
+    for recall in result.scalars().all():
+        if recall.status in ("done", "cancelled"):
+            continue
+        recall.linked_appointment_id = None
+        if recall.status == "contacted_scheduled":
+            recall.status = "pending"
+        recall.updated_at = now
 
 
 async def on_treatment_plan_completed(data: dict[str, Any]) -> None:
@@ -149,6 +149,8 @@ async def on_treatment_plan_completed(data: dict[str, Any]) -> None:
     The handler still runs so module manifests / event catalogs stay
     consistent and so we have a place to extend later (e.g. notify a
     pro of upcoming auto-suggestions). For now it just logs.
+
+    own-session: payload-only, no DB access at all.
     """
     if not data.get("treatment_category_key"):
         return
@@ -160,30 +162,27 @@ async def on_treatment_plan_completed(data: dict[str, Any]) -> None:
     )
 
 
-async def on_patient_archived(data: dict[str, Any]) -> None:
+async def on_patient_archived(data: dict[str, Any], *, db: AsyncSession) -> None:
     """Move active recalls to the ``needs_review`` bucket when the
     patient is archived. Never deletes — the call list filter keeps
     them out of the active queue while preserving history.
+
+    Transactional: this is a cascade of the archive, so it lives or dies
+    with it. Otherwise a failed archive leaves the recalls parked.
     """
     patient_id = _safe_uuid(data.get("patient_id"))
     clinic_id = _safe_uuid(data.get("clinic_id"))
     if not patient_id:
         return
 
-    async with async_session_maker() as db:
-        try:
-            stmt = select(Recall).where(
-                Recall.patient_id == patient_id,
-                Recall.status.in_(("pending", "contacted_no_answer", "contacted_scheduled")),
-            )
-            if clinic_id:
-                stmt = stmt.where(Recall.clinic_id == clinic_id)
-            result = await db.execute(stmt)
-            now = datetime.now(UTC)
-            for recall in result.scalars().all():
-                recall.status = "needs_review"
-                recall.updated_at = now
-            await db.commit()
-        except Exception as exc:
-            logger.error("recalls.on_patient_archived failed: %s", exc, exc_info=True)
-            await db.rollback()
+    stmt = select(Recall).where(
+        Recall.patient_id == patient_id,
+        Recall.status.in_(("pending", "contacted_no_answer", "contacted_scheduled")),
+    )
+    if clinic_id:
+        stmt = stmt.where(Recall.clinic_id == clinic_id)
+    result = await db.execute(stmt)
+    now = datetime.now(UTC)
+    for recall in result.scalars().all():
+        recall.status = "needs_review"
+        recall.updated_at = now

--- a/backend/app/modules/treatment_plan/service.py
+++ b/backend/app/modules/treatment_plan/service.py
@@ -907,6 +907,7 @@ class TreatmentPlanService:
                 "completed_by": str(user_id),
                 "occurred_at": session.completed_at.isoformat(),
             },
+            db=db,
         )
 
         # Item finalizes when every session is in a terminal state and at

--- a/backend/tests/modules/media/test_patient_archived_cascade.py
+++ b/backend/tests/modules/media/test_patient_archived_cascade.py
@@ -1,17 +1,15 @@
-"""The `patient.archived` → document soft-archive cascade (audit #95).
+"""The `patient.archived` → document soft-archive cascade (audit #95, #183).
 
 Two regressions are covered:
 
 * the publisher must include ``clinic_id`` in the payload (it didn't);
-* the media handler must accept the bus calling convention
-  ``handler(data)`` — its old ``(self, db, data)`` signature raised
-  ``TypeError`` on every archive.
+* the cascade must actually run and be atomic with the archive.
 
-The end-to-end "documents actually get archived" path is not asserted
-here: the handler opens its own ``async_session_maker`` session (bound to
-the import-time event loop), which pytest-asyncio's per-test loop can't
-drive. That path is covered by ``DocumentService.archive_patient_documents``'s
-own tests; the two regressions above are what broke.
+The handler used to open its own ``async_session_maker`` session, which made
+the end-to-end path untestable (the session is bound to the import-time event
+loop) *and* non-atomic: it committed the archived documents even when the
+request that archived the patient rolled back. It is transactional now
+(ADR 0019), so both are covered here.
 """
 
 from __future__ import annotations
@@ -19,13 +17,32 @@ from __future__ import annotations
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth.models import Clinic
+from app.core.auth.models import Clinic, User
 from app.core.events import EventType, event_bus
-from app.modules.media import MediaModule
+from app.modules.media.models import Document
 from app.modules.patients.models import Patient
 from app.modules.patients.service import PatientService
+
+
+async def _document(db: AsyncSession, clinic: Clinic, patient: Patient) -> Document:
+    user_id = (await db.execute(select(User))).scalars().first().id
+    doc = Document(
+        clinic_id=clinic.id,
+        patient_id=patient.id,
+        document_type="other",
+        title="Consentimiento",
+        original_filename="consent.pdf",
+        storage_path=f"/tmp/{uuid4()}.pdf",
+        mime_type="application/pdf",
+        file_size=1024,
+        uploaded_by=user_id,
+    )
+    db.add(doc)
+    await db.flush()
+    return doc
 
 
 @pytest.mark.asyncio
@@ -51,12 +68,38 @@ async def test_archive_patient_payload_includes_clinic_id(
 
 
 @pytest.mark.asyncio
-async def test_media_handler_accepts_bus_calling_convention(
+async def test_archiving_a_patient_archives_their_documents(
+    test_clinic: Clinic,
+    test_patient: Patient,
     db_session: AsyncSession,
 ) -> None:
-    # The bus calls ``handler(data)``. Under the old ``(self, db, data)``
-    # signature this passed the dict as ``db`` and raised TypeError for
-    # the missing ``data``. A payload without ``clinic_id`` returns early
-    # before touching a session, so this isolates the signature fix.
-    module = MediaModule()
-    await module._on_patient_archived({"patient_id": str(uuid4())})
+    doc = await _document(db_session, test_clinic, test_patient)
+
+    await PatientService.archive_patient(db_session, test_patient)
+
+    await db_session.refresh(doc)
+    assert doc.status == "archived"
+
+
+@pytest.mark.asyncio
+async def test_cascade_rolls_back_with_the_archive(
+    test_clinic: Clinic,
+    test_patient: Patient,
+    db_session: AsyncSession,
+) -> None:
+    """The cascade runs on the publisher's session, so an archive that never
+    commits leaves the documents alone. On its own session the handler
+    committed them regardless (issue #183)."""
+    doc = await _document(db_session, test_clinic, test_patient)
+    await db_session.commit()
+    # A rollback expires every mapped instance, so reading an attribute off
+    # one afterwards would lazy-load outside the async context. Keep the ids.
+    doc_id, patient_id = doc.id, test_patient.id
+
+    await PatientService.archive_patient(db_session, test_patient)
+    await db_session.rollback()
+
+    doc_status = await db_session.scalar(select(Document.status).where(Document.id == doc_id))
+    patient_status = await db_session.scalar(select(Patient.status).where(Patient.id == patient_id))
+    assert doc_status == "active"
+    assert patient_status != "archived"

--- a/backend/tests/modules/recalls/test_auto_link_on_schedule.py
+++ b/backend/tests/modules/recalls/test_auto_link_on_schedule.py
@@ -1,0 +1,118 @@
+"""``appointment.scheduled`` → auto-link a pending recall (issue #183).
+
+``Recall.linked_appointment_id`` is an FK to ``appointments.id``. While this
+handler opened its own session it wrote that FK from a second connection,
+against an appointment the publisher had only flushed — invisible there, so
+Postgres rejected the write, the bus swallowed the error and the auto-link
+silently never happened. The handler is transactional now (ADR 0019).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.models import Clinic, ClinicMembership, User
+from app.modules.patients.models import Patient
+from app.modules.recalls.models import Recall
+
+
+@pytest_asyncio.fixture
+async def dentist_id(db_session: AsyncSession, test_clinic: Clinic) -> str:
+    """Appointments require a dentist/hygienist of the clinic."""
+    from app.core.auth.service import hash_password
+
+    dentist = User(
+        email=f"dentist-{uuid4().hex[:8]}@test.clinic",
+        password_hash=hash_password("TestPass1234"),
+        first_name="Ada",
+        last_name="Lovelace",
+    )
+    db_session.add(dentist)
+    await db_session.flush()
+    db_session.add(ClinicMembership(user_id=dentist.id, clinic_id=test_clinic.id, role="dentist"))
+    await db_session.flush()
+    return str(dentist.id)
+
+
+async def _schedule(client: AsyncClient, headers: dict, patient_id: str, professional_id: str):
+    return await client.post(
+        "/api/v1/agenda/appointments",
+        headers=headers,
+        json={
+            "patient_id": patient_id,
+            "professional_id": professional_id,
+            "cabinet": "Gabinete 1",
+            "start_time": "2026-09-10T09:00:00Z",
+            "end_time": "2026-09-10T09:30:00Z",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_scheduling_an_appointment_links_the_pending_recall(
+    client: AsyncClient,
+    auth_headers: dict,
+    test_clinic: Clinic,
+    test_patient: Patient,
+    db_session: AsyncSession,
+    dentist_id: str,
+) -> None:
+    created = await client.post(
+        "/api/v1/recalls/",
+        headers=auth_headers,
+        json={
+            "patient_id": str(test_patient.id),
+            "due_month": "2026-08-01",
+            "reason": "hygiene",
+            "priority": "normal",
+        },
+    )
+    assert created.status_code == 201, created.text
+    recall_id = created.json()["data"]["id"]
+
+    res = await _schedule(client, auth_headers, str(test_patient.id), dentist_id)
+    assert res.status_code == 201, res.text
+    appointment_id = res.json()["data"]["id"]
+
+    recall = await db_session.get(Recall, recall_id)
+    await db_session.refresh(recall)
+    assert str(recall.linked_appointment_id) == appointment_id
+    assert recall.status == "contacted_scheduled"
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_recalls_are_left_alone(
+    client: AsyncClient,
+    auth_headers: dict,
+    test_clinic: Clinic,
+    test_patient: Patient,
+    db_session: AsyncSession,
+    dentist_id: str,
+) -> None:
+    """Two candidates → reception links manually; the handler must not guess."""
+    for reason in ("hygiene", "checkup"):
+        res = await client.post(
+            "/api/v1/recalls/",
+            headers=auth_headers,
+            json={
+                "patient_id": str(test_patient.id),
+                "due_month": "2026-08-01",
+                "reason": reason,
+                "priority": "normal",
+            },
+        )
+        assert res.status_code == 201, res.text
+
+    res = await _schedule(client, auth_headers, str(test_patient.id), dentist_id)
+    assert res.status_code == 201, res.text
+
+    linked = await db_session.scalars(
+        select(Recall.linked_appointment_id).where(Recall.patient_id == test_patient.id)
+    )
+    assert set(linked.all()) == {None}

--- a/backend/tests/test_event_bus_transactional.py
+++ b/backend/tests/test_event_bus_transactional.py
@@ -7,6 +7,9 @@ fire-and-log contract.
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
+
 import pytest
 
 from app.core.events.bus import EventBus
@@ -59,3 +62,112 @@ async def test_transactional_handler_requires_db_at_publish() -> None:
     bus.subscribe("t.evt", transactional)
     with pytest.raises(RuntimeError, match="transactional publish"):
         await bus.publish("t.evt", {})
+
+
+# ---------------------------------------------------------------------------
+# Static contract check (issue #183)
+# ---------------------------------------------------------------------------
+#
+# A transactional handler raises ``RuntimeError`` when its event is published
+# without ``db=``. That is a loud failure, but only on the code path that
+# publishes it. This walks every registered handler and every publish site in
+# ``app/`` so a publisher that forgets ``db=db`` fails in CI instead of in a
+# clinic.
+
+
+def _transactional_events() -> set[str]:
+    """Event names that have at least one transactional subscriber."""
+    from app.core.events.bus import _wants_db
+    from app.core.plugins import module_registry
+
+    return {
+        event
+        for module in module_registry.list_modules()
+        for event, handler in module.get_event_handlers().items()
+        if _wants_db(handler)
+    }
+
+
+def _event_constants(app_root: Path) -> dict[tuple[str, str], str]:
+    """``(ClassName, ATTR) -> "event.name"`` for every event-constant class.
+
+    Covers ``EventType`` and module-local ones such as
+    ``OdontogramEventType`` without importing anything.
+    """
+    constants: dict[tuple[str, str], str] = {}
+    for path in app_root.rglob("*.py"):
+        for node in ast.walk(ast.parse(path.read_text(), filename=str(path))):
+            if not (isinstance(node, ast.ClassDef) and node.name.endswith("EventType")):
+                continue
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.Assign)
+                    and isinstance(stmt.value, ast.Constant)
+                    and isinstance(stmt.value.value, str)
+                    and len(stmt.targets) == 1
+                    and isinstance(stmt.targets[0], ast.Name)
+                ):
+                    constants[(node.name, stmt.targets[0].id)] = stmt.value.value
+    return constants
+
+
+def _resolve(node: ast.expr, constants: dict[tuple[str, str], str]) -> str | None:
+    """Resolve an expression to an event name, or ``None`` if not static."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+        return constants.get((node.value.id, node.attr))
+    return None
+
+
+def _publish_sites() -> list[tuple[str, int, frozenset[str], bool]]:
+    """Every ``event_bus.publish(...)`` in ``app/``.
+
+    Returns (file, line, candidate event names, passes ``db=``). A publish
+    whose first argument is not a static constant (a dispatch table, a
+    forwarded parameter) can't be pinned down, so its candidate set becomes
+    *every* event referenced in that file — over-approximating towards
+    "needs db=" rather than silently letting a dynamic site through.
+    """
+    app_root = Path(__file__).resolve().parent.parent / "app"
+    constants = _event_constants(app_root)
+    sites = []
+    for path in sorted(app_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        in_file = frozenset(
+            name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute) and (name := _resolve(node, constants))
+        )
+        for node in ast.walk(tree):
+            func = getattr(node, "func", None)
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(func, ast.Attribute)
+                and func.attr == "publish"
+                and getattr(func.value, "id", None) == "event_bus"
+                and node.args
+            ):
+                continue
+            resolved = _resolve(node.args[0], constants)
+            candidates = frozenset({resolved}) if resolved else in_file
+            has_db = any(kw.arg == "db" for kw in node.keywords)
+            sites.append((str(path.relative_to(app_root.parent)), node.lineno, candidates, has_db))
+    return sites
+
+
+def test_every_publisher_of_a_transactional_event_passes_db() -> None:
+    """ADR 0019: a transactional handler needs its publisher to offer a session.
+
+    The bus raises at publish time, but only on the path that publishes. This
+    catches the same mistake in CI, on every path.
+    """
+    transactional = _transactional_events()
+    offenders = [
+        f"{file}:{line} publishes {', '.join(sorted(candidates & transactional))} without db="
+        for file, line, candidates, has_db in _publish_sites()
+        if not has_db and candidates & transactional
+    ]
+    assert not offenders, "Publishers missing db= for a transactional handler:\n" + "\n".join(
+        offenders
+    )

--- a/backend/tests/test_patient_timeline.py
+++ b/backend/tests/test_patient_timeline.py
@@ -366,14 +366,19 @@ async def test_event_bus_dispatch_reaches_handler(
 ):
     """Regression: the bus calls ``handler(data)`` — one arg. Handlers must
     match this signature. This test would have caught the old
-    ``(self, db, data)`` bug."""
+    ``(self, db, data)`` bug.
+
+    ``db=`` is required because other modules subscribe to this event
+    transactionally (ADR 0019); timeline's own handlers stay own-session and
+    ignore it.
+    """
     payload = {
         **_base_payload(test_clinic, test_patient),
         "appointment_id": str(uuid4()),
         "treatment_type": "Revisión",
         "end_time": datetime.now(UTC).isoformat(),
     }
-    await event_bus.publish(EventType.APPOINTMENT_COMPLETED, payload)
+    await event_bus.publish(EventType.APPOINTMENT_COMPLETED, payload, db=db_session)
 
     # ``publish`` awaits every subscriber inline, so the timeline row
     # is already written by the time we get here.

--- a/backend/tests/test_treatments.py
+++ b/backend/tests/test_treatments.py
@@ -1,7 +1,7 @@
 """Tests for the unified /treatments API (header + children model)."""
 
 from decimal import Decimal
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from httpx import AsyncClient
@@ -582,3 +582,69 @@ async def test_no_scope_no_teeth_raises(
         },
     )
     assert r.status_code == 422
+
+
+# ----------------------------------------------------------------------------
+# Earned ledger (payments subscribes transactionally — ADR 0019, issue #183)
+# ----------------------------------------------------------------------------
+
+
+async def _earned_rows(db_session: AsyncSession, treatment_id) -> list:
+    from sqlalchemy import select
+
+    from app.modules.payments.models import PatientEarnedEntry
+
+    result = await db_session.execute(
+        select(PatientEarnedEntry).where(PatientEarnedEntry.treatment_id == treatment_id)
+    )
+    return list(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_perform_books_the_earned_entry(
+    client: AsyncClient, auth_headers: dict, setup: dict, db_session: AsyncSession
+) -> None:
+    create = await client.post(
+        f"/api/v1/odontogram/patients/{setup['patient_id']}/treatments",
+        headers=auth_headers,
+        json={"catalog_item_id": setup["crown_id"], "tooth_numbers": [26], "status": "planned"},
+    )
+    tid = create.json()["data"]["id"]
+
+    r = await client.patch(
+        f"/api/v1/odontogram/treatments/{tid}/perform", headers=auth_headers, json={}
+    )
+    assert r.status_code == 200
+
+    rows = await _earned_rows(db_session, UUID(tid))
+    assert len(rows) == 1
+    assert rows[0].amount == Decimal("500.00")
+
+
+@pytest.mark.asyncio
+async def test_earned_entry_rolls_back_with_the_treatment(
+    client: AsyncClient, auth_headers: dict, setup: dict, db_session: AsyncSession
+) -> None:
+    """Revenue is booked in the publisher's transaction.
+
+    The handler used to open its own session and commit there, so a request
+    that failed after ``perform`` left an earned entry for a treatment that
+    never happened — ``treatment_id`` carries no FK to catch it (issue #183).
+    """
+    from app.modules.odontogram.service import TreatmentService
+
+    create = await client.post(
+        f"/api/v1/odontogram/patients/{setup['patient_id']}/treatments",
+        headers=auth_headers,
+        json={"catalog_item_id": setup["crown_id"], "tooth_numbers": [27], "status": "planned"},
+    )
+    tid = UUID(create.json()["data"]["id"])
+    me = await client.get("/api/v1/auth/me", headers=auth_headers)
+    user_id = UUID(me.json()["data"]["user"]["id"])
+
+    await TreatmentService.perform(db_session, UUID(setup["clinic_id"]), tid, user_id)
+    assert await _earned_rows(db_session, tid), "earned entry should exist inside the tx"
+
+    await db_session.rollback()
+
+    assert await _earned_rows(db_session, tid) == []

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -76,7 +76,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 | `odontogram.tooth.updated` | `EventType.ODONTOGRAM_TOOTH_UPDATED` | `odontogram` | — |
 | `odontogram.treatment.added` | `EventType.ODONTOGRAM_TREATMENT_ADDED` | `odontogram` | — |
 | `odontogram.treatment.deleted` | `EventType.ODONTOGRAM_TREATMENT_DELETED` | `odontogram` | — |
-| `odontogram.treatment.performed` | `EventType.ODONTOGRAM_TREATMENT_PERFORMED` | `odontogram` | `budget`, `patient_timeline`, `payments`, `periodontogram`, `treatment_plan` |
+| `odontogram.treatment.performed` | `EventType.ODONTOGRAM_TREATMENT_PERFORMED` | `odontogram` | `patient_timeline`, `payments`, `periodontogram`, `treatment_plan` |
 | `odontogram.treatment.status_changed` | `EventType.ODONTOGRAM_TREATMENT_STATUS_CHANGED` | `odontogram` | — |
 | `patient.archived` | `EventType.PATIENT_ARCHIVED` | `patients` | `media`, `periodontogram`, `recalls` |
 | `patient.created` | `EventType.PATIENT_CREATED` | `patients` | `notifications` |
@@ -114,7 +114,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.AGENDA_VISIT_NOTE_UPDATED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:859`
+  - `agenda` — `backend/app/modules/agenda/service.py:860`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -122,14 +122,14 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_CABINET_CHANGED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:796`
+  - `agenda` — `backend/app/modules/agenda/service.py:797`
 - **Subscribers:** —
 
 ### `appointment.cancelled`
 
 - **Constant:** `EventType.APPOINTMENT_CANCELLED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:734`
+  - `agenda` — `backend/app/modules/agenda/service.py:735`
 - **Subscribers:**
   - `copilot`
   - `notifications`
@@ -141,7 +141,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_CHECKED_IN`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:731`
+  - `agenda` — `backend/app/modules/agenda/service.py:732`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -149,7 +149,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_COMPLETED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:733`
+  - `agenda` — `backend/app/modules/agenda/service.py:734`
 - **Subscribers:**
   - `patient_timeline`
   - `recalls`
@@ -159,7 +159,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_CONFIRMED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:730`
+  - `agenda` — `backend/app/modules/agenda/service.py:731`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -167,7 +167,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_IN_TREATMENT`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:732`
+  - `agenda` — `backend/app/modules/agenda/service.py:733`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -175,7 +175,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_NO_SHOW`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:735`
+  - `agenda` — `backend/app/modules/agenda/service.py:736`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -194,14 +194,14 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_STATUS_CHANGED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:725`
+  - `agenda` — `backend/app/modules/agenda/service.py:726`
 - **Subscribers:** —
 
 ### `appointment.updated`
 
 - **Constant:** `EventType.APPOINTMENT_UPDATED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:626`
+  - `agenda` — `backend/app/modules/agenda/service.py:627`
 - **Subscribers:**
   - `schedules`
 
@@ -610,7 +610,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.ODONTOGRAM_TREATMENT_DELETED`
 - **Publishers:**
-  - `odontogram` — `backend/app/modules/odontogram/service.py:887`
+  - `odontogram` — `backend/app/modules/odontogram/service.py:888`
 - **Subscribers:** —
 
 ### `odontogram.treatment.performed`
@@ -619,7 +619,6 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Publishers:**
   - `odontogram` — `backend/app/modules/odontogram/service.py:828`
 - **Subscribers:**
-  - `budget`
   - `patient_timeline`
   - `payments`
   - `periodontogram`
@@ -751,7 +750,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_BUDGET_SYNC_REQUESTED`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1291`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1292`
 - **Subscribers:**
   - `budget`
 
@@ -759,7 +758,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_CLOSED`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1773`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1774`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -767,7 +766,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_CONFIRMED`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1633`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1634`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -783,7 +782,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_ITEM_COMPLETED_WITHOUT_NOTE`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1001`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1002`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -806,7 +805,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_REACTIVATED`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1819`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1820`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -830,7 +829,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Constant:** `EventType.TREATMENT_PLAN_TREATMENT_COMPLETED`
 - **Publishers:**
   - `treatment_plan` — `backend/app/modules/treatment_plan/events.py:88`
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:986`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:987`
 - **Subscribers:**
   - `patient_timeline`
   - `recalls`

--- a/docs/modules-catalog.md
+++ b/docs/modules-catalog.md
@@ -13,7 +13,7 @@ Maintained by `backend/scripts/generate_catalogs.py`. CI fails if a manifest cha
 | `accounting_export` | 0.1.0 | official | billing, payments | manual | yes | 2 | 0 | 0 | yes |
 | `agenda` | 0.4.0 | official | patients, catalog, odontogram | auto | no | 4 | 11 | 1 | yes |
 | `billing` | 0.1.0 | official | patients, catalog, budget, payments | auto | no | 3 | 3 | 3 | yes |
-| `budget` | 0.1.0 | official | patients, catalog, odontogram | auto | no | 5 | 9 | 4 | yes |
+| `budget` | 0.1.0 | official | patients, catalog, odontogram | auto | no | 5 | 9 | 3 | yes |
 | `catalog` | 0.1.0 | official | — | auto | no | 3 | 0 | 1 | yes |
 | `clinical_notes` | 0.2.0 | official | patients, odontogram, treatment_plan, media, agenda | auto | no | 2 | 6 | 0 | yes |
 | `copilot` | 0.1.0 | official | — | auto | yes | 5 | 3 | 1 | yes |
@@ -134,7 +134,6 @@ Dental treatment quotes, versioning, signatures.
   - `budget.superseded`
   - `budget.viewed`
 - **Events consumed:**
-  - `odontogram.treatment.performed`
   - `treatment_plan.budget_sync_requested`
   - `treatment_plan.treatment_added`
   - `treatment_plan.treatment_removed`


### PR DESCRIPTION
Closes part of #183 (audit of own-session event handlers, ADR 0019).

`EventBus.publish` runs handlers inline, **before the publisher commits**. A handler that opens its own session gets a second connection, and under READ COMMITTED that connection cannot see rows the publisher has only flushed. #178 proved it for money; this is the audit of the other 44 call sites.

It is not a theoretical risk. Two of the findings are live, silent production bugs:

**1. Recalls auto-link has never worked through the API.** `Recall.linked_appointment_id` is an FK to `appointments.id`. The handler wrote it from its own session while the publisher had only flushed the appointment, so Postgres rejected the write:

```
ForeignKeyViolationError: insert or update on table "recalls" violates
foreign key constraint "recalls_linked_appointment_id_fkey"
```

…and the handler's `except Exception: logger.error(...)` swallowed it. The feature had zero test coverage. `tests/modules/recalls/test_auto_link_on_schedule.py` reproduces the failure on `main` and passes here.

**2. Earned revenue could outlive the treatment that earned it.** `payments._upsert_earned_entry` committed on its own session, so a request that failed after `perform()` published left the entry behind — and `PatientEarnedEntry.treatment_id` deliberately carries no FK to catch it.

## What's in this PR (phases 1–3)

- **CI guard** — `test_every_publisher_of_a_transactional_event_passes_db` walks every registered handler and every `event_bus.publish` in `app/`, and fails when a publisher of a transactionally-consumed event omits `db=`. Dynamic publish sites (dispatch tables, forwarded parameters) are over-approximated towards "needs `db=`" rather than skipped. It caught three real misses while this branch was being written.
- **recalls** (4 handlers) and **media** (1) run in the publisher's transaction. They mirror agenda/patients state, so they belong in the same unit of work rather than committing next to a request that may still roll back.
- **payments** (2 handlers) book the earned ledger in-tx. Idempotency keys and the `on_conflict_do_nothing` upsert are untouched.
- Deleted `BudgetService.on_treatment_performed`: a `pass` with a "placeholder for the event handler" comment, subscribed to the bus and doing nothing.

## Tests

Each fix ships a regression test that fails on `main`:

| Test | On `main` | Here |
|---|---|---|
| `recalls/test_auto_link_on_schedule.py` | FK violation, recall unlinked | linked |
| `media/test_patient_archived_cascade.py::test_cascade_rolls_back_with_the_archive` | documents stay archived | rolled back |
| `test_treatments.py::test_earned_entry_rolls_back_with_the_treatment` | orphan entry survives | gone |

The media cascade was untestable end-to-end while it owned its session (bound to the import-time event loop); it is covered now, rollback included.

Phases 4–6 (the budget ↔ treatment_plan family, notifications, docs) follow in a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
