### PR TITLE
fix(#183): plan ↔ budget and notifications handlers in-tx; docs stop teaching publish-after-commit

### DIFF
--- a/backend/app/core/events/types.py
+++ b/backend/app/core/events/types.py
@@ -16,7 +16,8 @@ class EventType:
     # country, currency, timezone, language, vat_preset, created_by,
     # source). Modules react by seeding their defaults (catalog, billing
     # series, cabinet, hours) — handlers must be idempotent and open their
-    # own DB session.
+    # own DB session (this is the one event published *after* the
+    # publisher commits, so there is nothing uncommitted to miss).
     CLINIC_CREATED = "clinic.created"
 
     # Patient events
@@ -70,16 +71,15 @@ class EventType:
     # cancelled_by, occurred_at). NOT published when the cancellation is
     # initiated by ``treatment_plan.reopen()`` — the plan module already
     # owns that transition (``publish_event=False``); an echo here would
-    # deadlock against the publisher's open transaction.
+    # send the plan through a reopen it is already performing.
     BUDGET_CANCELLED = "budget.cancelled"
     # A terminal budget (rejected/expired/cancelled) was cloned to a new
     # draft version ("Resend"). The plan's ``budget_id`` link must follow
-    # the new version; plan status is untouched. Published AFTER the
-    # request transaction commits (sole deviation from the pre-commit
-    # pattern) so the treatment_plan handler can repoint an FK at the new
-    # row from its own session. Payload carries (clinic_id, budget_id
-    # [old], new_budget_id, patient_id, plan_id, version [new],
-    # resent_by, occurred_at).
+    # the new version; plan status is untouched. Published before commit
+    # like everything else: the treatment_plan handler is transactional
+    # (ADR 0019) so the new row is visible to it. Payload carries
+    # (clinic_id, budget_id [old], new_budget_id, patient_id, plan_id,
+    # version [new], resent_by, occurred_at).
     BUDGET_SUPERSEDED = "budget.superseded"
     # Patient opened the public link (first time). Payload carries
     # (budget_id, plan_id, patient_id, viewed_at, ip_hash). Idempotent.

--- a/backend/app/modules/agenda/CHANGELOG.md
+++ b/backend/app/modules/agenda/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#183): appointment events are published with `db=` so recalls, treatment_plan and notifications react inside the request's transaction (ADR 0019).
 - feat(onboarding): subscribe to `clinic.created` — create one default cabinet for a new clinic.
 
 - fix(timezones): the mobile day view (free-slot engine, timeline,

--- a/backend/app/modules/agenda/events.py
+++ b/backend/app/modules/agenda/events.py
@@ -26,6 +26,10 @@ _DEFAULT_CABINET_NAME = {
 
 
 async def on_clinic_created(data: dict[str, Any]) -> None:
+    """own-session (issue #183): ``clinic.created`` is published after
+    ``POST /auth/setup`` commits, so there are no uncommitted rows to miss —
+    and seeding a fresh clinic must not stretch the signup transaction.
+    """
     clinic_id_raw = data.get("clinic_id")
     if not clinic_id_raw:
         return

--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- docs(#183): `on_clinic_created` documented as own-session — published after setup commits, and seeding series must not stretch the signup transaction.
 - fix(#178): budget ↔ invoice bridge (`payment_bridge.py`). Payments
   allocated to a budget are imputed to that budget's open invoices
   (FIFO, preferring the invoice being collected on) and unlinked on

--- a/backend/app/modules/billing/CLAUDE.md
+++ b/backend/app/modules/billing/CLAUDE.md
@@ -42,7 +42,7 @@ by tests in `tests/test_module_tools.py`.
 |---|---|---|---|
 | `payment.allocated` | `events.py:on_payment_allocated` | transactional (ADR 0019) | `payment_bridge.reconcile_payment` — mirror the payment's budget allocations onto `invoice_payments` of that budget's open invoices (FIFO, preferred invoice first via `context.prefer_invoice_id`), unlink LIFO on reallocation, recompute status. Issue #178. |
 | `payment.refunded` | `events.py:on_payment_refunded` | transactional | Recompute status of invoices linked to the refunded payment. |
-| `clinic.created` | `events.py:on_clinic_created` | own session | Default `FAC` / `RECT` series. |
+| `clinic.created` | `events.py:on_clinic_created` | own session (published after setup commits) | Default `FAC` / `RECT` series. |
 
 The legacy ``budget.completed`` subscription was removed in 2026-04 —
 that event was never published.

--- a/backend/app/modules/billing/events.py
+++ b/backend/app/modules/billing/events.py
@@ -97,6 +97,10 @@ async def on_clinic_created(data: dict[str, Any]) -> None:
     """Seed ``FAC`` (invoice) + ``RECT`` (credit note) default series.
 
     Idempotent: skipped when the clinic already has any series.
+
+    own-session (issue #183): ``clinic.created`` is published after
+    ``POST /auth/setup`` commits, so there is nothing uncommitted to miss —
+    and seeding must not stretch the signup transaction.
     """
     clinic_id_raw = data.get("clinic_id")
     if not clinic_id_raw:

--- a/backend/app/modules/billing/router.py
+++ b/backend/app/modules/billing/router.py
@@ -704,6 +704,7 @@ async def send_invoice_email(
             "recipient_email": patient.email if patient and data.send_email else None,
             "custom_message": data.custom_message,
         },
+        db=db,
     )
 
     # Add history entry

--- a/backend/app/modules/budget/CHANGELOG.md
+++ b/backend/app/modules/budget/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- fix(#183): the three plan-sync handlers are transactional (ADR 0019); a failed mirror now fails the request instead of leaving the quote out of sync with the plan.
+- fix(#183): `budget.superseded` is published before commit like every other event — the treatment_plan handler shares the session, so the FK to the new budget row resolves. Removes the documented "sole deviation from the publish-before-commit pattern".
+- chore: drop `BudgetService.on_treatment_performed`, a no-op placeholder subscribed to `odontogram.treatment.performed`.
 - feat(events): `budget.accepted` payload now carries `items[]` with a
   per-line ex-tax `net_amount` (line discount + prorated global
   discount) so `treatment_plan` can reprice sessions from the snapshot

--- a/backend/app/modules/budget/CLAUDE.md
+++ b/backend/app/modules/budget/CLAUDE.md
@@ -100,24 +100,26 @@ contract.
 - **Snapshot-only event handlers.** `_on_treatment_added_to_plan` and
   friends consume the data carried in the payload (catalog_item_id,
   tooth, surfaces, unit_price, budget_id) — no fetches against the
-  publisher's tables.
+  publisher's tables. They are transactional (ADR 0019, issue #183): the
+  quote mirrors the plan inside the publisher's transaction, so a failed
+  mirror fails the request instead of silently dropping a line.
 - **Plan reverse-lookup uses raw SQL** (`_lookup_plan` /
   `_lookup_plan_id`) instead of importing the `TreatmentPlan` model, so
   event payloads can carry `plan_id` without violating ADR 0003. It
   deliberately does NOT walk the `parent_budget_id` chain — a stale old
   version must resolve to no plan once the link moved on.
-- **`budget.superseded` publishes AFTER commit** (in the `/resend`
-  router) — the sole deviation from the publish-before-commit pattern.
-  The treatment_plan handler points `treatment_plans.budget_id` (an FK)
-  at the new budget row from its own session; pre-commit that row is
-  invisible → FK violation the bus swallows → relink silently lost. Do
-  not "normalize" this back.
+- **`budget.superseded` publishes before commit**, like every other
+  event. It used to be the sole deviation: the treatment_plan handler
+  points `treatment_plans.budget_id` (an FK) at the new budget row, which
+  from its own session was invisible → FK violation the bus swallowed →
+  relink silently lost. The handler is transactional now (ADR 0019,
+  issue #183), so the row is visible and the workaround is gone.
 - **`cancel_budget(publish_event=False)` is for plan-initiated
-  cancels.** `treatment_plan.reopen()` cancels the budget inside its
-  own transaction; an echoed `budget.cancelled` there would make the
-  handler write the plan row the publisher holds locked (the bus awaits
-  handlers inline) → hang. Direct staff cancels keep the default and
-  publish.
+  cancels.** `treatment_plan.reopen()` cancels the budget inside its own
+  transaction; an echoed `budget.cancelled` would send the plan through a
+  reopen it is already performing. Direct staff cancels keep the default
+  and publish. (Pre-#183 this was also a deadlock guard — the handler ran
+  on its own session; it shares the publisher's now.)
 - **`pricing.allocate_global_discount` is the only proration formula.**
   The global discount is applied to the VAT-inclusive items total in
   `_recalculate_totals`; every per-line consumer (the `budget.accepted`

--- a/backend/app/modules/budget/__init__.py
+++ b/backend/app/modules/budget/__init__.py
@@ -7,11 +7,11 @@ from uuid import UUID
 
 from fastapi import APIRouter
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.events.types import EventType
 from app.core.plugins import BaseModule
 from app.core.scheduling import ScheduledJob
-from app.database import async_session_maker
 
 from .models import Budget, BudgetAccessLog, BudgetHistory, BudgetItem, BudgetSignature
 from .public_router import public_router
@@ -132,7 +132,7 @@ class BudgetModule(BaseModule):
             EventType.TREATMENT_PLAN_BUDGET_SYNC_REQUESTED: self._on_sync_requested,
         }
 
-    async def _on_treatment_added_to_plan(self, data: dict[str, Any]) -> None:
+    async def _on_treatment_added_to_plan(self, data: dict[str, Any], *, db: AsyncSession) -> None:
         """Create BudgetItem when a treatment is added to a plan.
 
         Snapshot-only: the publisher (treatment_plan) sends a denormalized
@@ -140,6 +140,10 @@ class BudgetModule(BaseModule):
         ``surfaces`` and ``unit_price`` so this handler does not import
         models from modules outside ``budget``'s ``manifest.depends``.
         See ADR 0003.
+
+        Transactional (ADR 0019): the quote mirrors the plan line for line.
+        Committing separately let the mirror fail on its own and leave the
+        budget short of an item nobody noticed (issue #183).
         """
         from .service import BudgetItemService, BudgetService
 
@@ -159,43 +163,38 @@ class BudgetModule(BaseModule):
             # nothing to mirror.
             return
 
-        async with async_session_maker() as db:
-            try:
-                budget = await db.get(Budget, UUID(budget_id_raw))
-                if not budget or budget.status != "draft":
-                    return
+        budget = await db.get(Budget, UUID(budget_id_raw))
+        if not budget or budget.status != "draft":
+            return
 
-                await BudgetItemService.create_item(
-                    db,
-                    UUID(clinic_id),
-                    UUID(budget_id_raw),
-                    {
-                        "catalog_item_id": UUID(catalog_item_id_raw),
-                        "quantity": 1,
-                        "treatment_id": UUID(treatment_id_raw),
-                        "tooth_number": tooth_number,
-                        "surfaces": surfaces,
-                        "unit_price": (
-                            Decimal(unit_price_raw) if unit_price_raw is not None else None
-                        ),
-                    },
-                )
+        await BudgetItemService.create_item(
+            db,
+            UUID(clinic_id),
+            UUID(budget_id_raw),
+            {
+                "catalog_item_id": UUID(catalog_item_id_raw),
+                "quantity": 1,
+                "treatment_id": UUID(treatment_id_raw),
+                "tooth_number": tooth_number,
+                "surfaces": surfaces,
+                "unit_price": (Decimal(unit_price_raw) if unit_price_raw is not None else None),
+            },
+        )
 
-                await BudgetService._recalculate_totals(db, budget)
-                await db.commit()
+        await BudgetService._recalculate_totals(db, budget)
+        logger.info("Added budget item for plan %s", plan_id)
 
-                logger.info("Added budget item for plan %s", plan_id)
-
-            except Exception as e:
-                logger.error("Error adding budget item from plan: %s", e, exc_info=True)
-                await db.rollback()
-
-    async def _on_treatment_removed_from_plan(self, data: dict[str, Any]) -> None:
+    async def _on_treatment_removed_from_plan(
+        self, data: dict[str, Any], *, db: AsyncSession
+    ) -> None:
         """Remove BudgetItem when a treatment is removed from a plan.
 
         Snapshot-only: the publisher includes ``budget_id`` so this
         handler does not need to read ``TreatmentPlan`` from another
         module (ADR 0003).
+
+        Transactional (ADR 0019): same reason as the add — the quote and the
+        plan move together.
         """
         from .service import BudgetService
 
@@ -207,36 +206,31 @@ class BudgetModule(BaseModule):
         if not plan_id or not clinic_id or not treatment_id_raw or not budget_id_raw:
             return
 
-        async with async_session_maker() as db:
-            try:
-                budget = await db.get(Budget, UUID(budget_id_raw))
-                if not budget or budget.status != "draft":
-                    return
+        budget = await db.get(Budget, UUID(budget_id_raw))
+        if not budget or budget.status != "draft":
+            return
 
-                item_result = await db.execute(
-                    select(BudgetItem).where(
-                        BudgetItem.budget_id == UUID(budget_id_raw),
-                        BudgetItem.treatment_id == UUID(treatment_id_raw),
-                    )
-                )
-                item = item_result.scalar_one_or_none()
-                if item:
-                    await db.delete(item)
-                    await BudgetService._recalculate_totals(db, budget)
-                    await db.commit()
-                    logger.info("Removed budget item for plan %s", plan_id)
+        item_result = await db.execute(
+            select(BudgetItem).where(
+                BudgetItem.budget_id == UUID(budget_id_raw),
+                BudgetItem.treatment_id == UUID(treatment_id_raw),
+            )
+        )
+        item = item_result.scalar_one_or_none()
+        if item:
+            await db.delete(item)
+            await BudgetService._recalculate_totals(db, budget)
+            logger.info("Removed budget item for plan %s", plan_id)
 
-            except Exception as e:
-                logger.error("Error removing budget item from plan: %s", e, exc_info=True)
-                await db.rollback()
-
-    async def _on_sync_requested(self, data: dict[str, Any]) -> None:
+    async def _on_sync_requested(self, data: dict[str, Any], *, db: AsyncSession) -> None:
         """Synchronize all plan items with the budget.
 
         Snapshot-only: the publisher includes ``items`` (a list of
         denormalized item snapshots). This handler reconciles the
         budget without reading treatment_plan / odontogram models
         (ADR 0003).
+
+        Transactional (ADR 0019): a half-applied sync is worse than none.
         """
         from .service import BudgetItemService, BudgetService
 
@@ -248,53 +242,41 @@ class BudgetModule(BaseModule):
         if not plan_id or not budget_id_raw or not clinic_id:
             return
 
-        async with async_session_maker() as db:
-            try:
-                budget = await db.get(Budget, UUID(budget_id_raw))
-                if not budget or budget.status != "draft":
-                    logger.warning("Cannot sync non-draft budget %s", budget_id_raw)
-                    return
+        budget = await db.get(Budget, UUID(budget_id_raw))
+        if not budget or budget.status != "draft":
+            logger.warning("Cannot sync non-draft budget %s", budget_id_raw)
+            return
 
-                existing_result = await db.execute(
-                    select(BudgetItem).where(
-                        BudgetItem.budget_id == UUID(budget_id_raw),
-                        BudgetItem.treatment_id.isnot(None),
-                    )
-                )
-                existing_treatment_ids = {
-                    item.treatment_id for item in existing_result.scalars().all()
-                }
+        existing_result = await db.execute(
+            select(BudgetItem).where(
+                BudgetItem.budget_id == UUID(budget_id_raw),
+                BudgetItem.treatment_id.isnot(None),
+            )
+        )
+        existing_treatment_ids = {item.treatment_id for item in existing_result.scalars().all()}
 
-                for snap in items_payload:
-                    treatment_id_raw = snap.get("treatment_id")
-                    catalog_item_id_raw = snap.get("catalog_item_id")
-                    if not treatment_id_raw or not catalog_item_id_raw:
-                        continue
-                    treatment_uuid = UUID(treatment_id_raw)
-                    if treatment_uuid in existing_treatment_ids:
-                        continue
-                    unit_price_raw = snap.get("unit_price")
-                    await BudgetItemService.create_item(
-                        db,
-                        UUID(clinic_id),
-                        UUID(budget_id_raw),
-                        {
-                            "catalog_item_id": UUID(catalog_item_id_raw),
-                            "quantity": 1,
-                            "treatment_id": treatment_uuid,
-                            "tooth_number": snap.get("tooth_number"),
-                            "surfaces": snap.get("surfaces"),
-                            "unit_price": (
-                                Decimal(unit_price_raw) if unit_price_raw is not None else None
-                            ),
-                        },
-                    )
+        for snap in items_payload:
+            treatment_id_raw = snap.get("treatment_id")
+            catalog_item_id_raw = snap.get("catalog_item_id")
+            if not treatment_id_raw or not catalog_item_id_raw:
+                continue
+            treatment_uuid = UUID(treatment_id_raw)
+            if treatment_uuid in existing_treatment_ids:
+                continue
+            unit_price_raw = snap.get("unit_price")
+            await BudgetItemService.create_item(
+                db,
+                UUID(clinic_id),
+                UUID(budget_id_raw),
+                {
+                    "catalog_item_id": UUID(catalog_item_id_raw),
+                    "quantity": 1,
+                    "treatment_id": treatment_uuid,
+                    "tooth_number": snap.get("tooth_number"),
+                    "surfaces": snap.get("surfaces"),
+                    "unit_price": (Decimal(unit_price_raw) if unit_price_raw is not None else None),
+                },
+            )
 
-                await BudgetService._recalculate_totals(db, budget)
-                await db.commit()
-
-                logger.info("Synced plan %s with budget %s", plan_id, budget_id_raw)
-
-            except Exception as e:
-                logger.error("Error syncing plan with budget: %s", e, exc_info=True)
-                await db.rollback()
+        await BudgetService._recalculate_totals(db, budget)
+        logger.info("Synced plan %s with budget %s", plan_id, budget_id_raw)

--- a/backend/app/modules/budget/router.py
+++ b/backend/app/modules/budget/router.py
@@ -560,12 +560,6 @@ async def resend_budget(
     plan_ref = await BudgetWorkflowService._lookup_plan(db, budget.id)
     response = ApiResponse(data=BudgetResponse.model_validate(new_budget))
 
-    # Sole deviation from the publish-before-commit pattern: the
-    # treatment_plan handler must point an FK at the new budget row from
-    # its own session. Published pre-commit, that row is invisible → FK
-    # violation the bus would swallow → relink silently lost. Commit
-    # first (get_db's trailing commit becomes a no-op), then publish.
-    await db.commit()
     if plan_ref is not None:
         await event_bus.publish(
             EventType.BUDGET_SUPERSEDED,
@@ -579,6 +573,7 @@ async def resend_budget(
                 "resent_by": str(ctx.user_id),
                 "occurred_at": datetime.now(UTC).isoformat(),
             },
+            db=db,
         )
     return response
 

--- a/backend/app/modules/budget/workflow.py
+++ b/backend/app/modules/budget/workflow.py
@@ -327,6 +327,7 @@ class BudgetWorkflowService:
                 "items": items_snapshot,
                 "occurred_at": datetime.now(UTC).isoformat(),
             },
+            db=db,
         )
 
         return budget
@@ -403,6 +404,7 @@ class BudgetWorkflowService:
                 "rejection_note": note,
                 "occurred_at": datetime.now(UTC).isoformat(),
             },
+            db=db,
         )
 
         return budget
@@ -421,8 +423,8 @@ class BudgetWorkflowService:
         reopen to ``draft`` (issue #162). ``publish_event=False`` is for
         callers that already own the plan transition — namely
         ``TreatmentPlanService.reopen()``, which cancels the budget from
-        inside its own transaction: an echo event there would make the
-        handler write the plan row the publisher holds locked → hang.
+        inside its own transaction: the echoed event would send the plan
+        back through a reopen it is already performing.
         """
         if not BudgetWorkflowService.can_transition(budget.status, "cancelled"):
             raise BudgetWorkflowError(f"Cannot cancel budget from status '{budget.status}'")
@@ -444,9 +446,6 @@ class BudgetWorkflowService:
         await db.flush()
 
         if publish_event:
-            # Safe pre-commit publish: our transaction only holds locks
-            # on budgets/budget_history; the handler writes only the
-            # (long-committed) treatment_plans row.
             plan_id = await BudgetWorkflowService._lookup_plan_id(db, budget.id)
             await event_bus.publish(
                 EventType.BUDGET_CANCELLED,
@@ -460,6 +459,7 @@ class BudgetWorkflowService:
                     "cancelled_by": str(cancelled_by),
                     "occurred_at": datetime.now(UTC).isoformat(),
                 },
+                db=db,
             )
 
         return budget
@@ -608,6 +608,7 @@ class BudgetWorkflowService:
                 "cancelled_at": datetime.now(UTC).isoformat(),
                 "cancelled_by": str(cancelled_by),
             },
+            db=db,
         )
         return budget
 

--- a/backend/app/modules/budget/workflow.py
+++ b/backend/app/modules/budget/workflow.py
@@ -170,6 +170,7 @@ class BudgetWorkflowService:
                 "recipient_email": recipient_email,
                 "custom_message": custom_message,
             },
+            db=db,
         )
 
         return budget

--- a/backend/app/modules/catalog/CHANGELOG.md
+++ b/backend/app/modules/catalog/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- docs(#183): `on_clinic_created` documented as own-session — `clinic.created` is published after setup commits, and seeding must not stretch the signup transaction.
 - feat(onboarding): getting-started rule `catalog-empty` (frontend plugin) — flags a clinic with no catalog items on the dashboard card.
 
 - feat(onboarding): subscribe to `clinic.created` — seed VAT types by country preset (`VAT_PRESETS`: `es` | `generic`), categories and the default catalog for every new clinic; `seed_catalog(..., vat_preset, with_prices)` (non-EUR → prices 0).

--- a/backend/app/modules/catalog/events.py
+++ b/backend/app/modules/catalog/events.py
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 
 
 async def on_clinic_created(data: dict[str, Any]) -> None:
+    """own-session (issue #183): ``clinic.created`` is published after
+    ``POST /auth/setup`` commits, so there are no uncommitted rows to miss —
+    and seeding a fresh clinic must not stretch the signup transaction.
+    """
     clinic_id_raw = data.get("clinic_id")
     if not clinic_id_raw:
         return

--- a/backend/app/modules/copilot/events.py
+++ b/backend/app/modules/copilot/events.py
@@ -35,7 +35,13 @@ async def _end_of_local_day(db, clinic_id: UUID, now_utc: datetime) -> datetime:
 
 
 async def on_appointment_cancelled(data: dict) -> None:
-    """A cancellation frees a slot — nudge staff to fill it from recalls."""
+    """A cancellation frees a slot — nudge staff to fill it from recalls.
+
+    own-session (issue #183): payload-only, and deliberately not
+    transactional — a nudge is advisory, it must never be able to fail the
+    cancellation. Worst case a rolled-back cancellation leaves a nudge that
+    expires at midnight anyway.
+    """
     appointment_id = data.get("appointment_id")
     clinic_id = data.get("clinic_id")
     if not appointment_id or not clinic_id:

--- a/backend/app/modules/media/CHANGELOG.md
+++ b/backend/app/modules/media/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#183): `patient.archived` cascade is transactional (ADR 0019) — the documents are archived with the patient, and no longer stay archived when the request rolls back. Covered end-to-end now that it shares the publisher's session.
 - fix(events): repair the `patient.archived` cascade, which had never
   run (audit event-bus #1, #95). The handler signature took
   `(self, db, data)` but the bus calls `handler(data)`, raising

--- a/backend/app/modules/notifications/CHANGELOG.md
+++ b/backend/app/modules/notifications/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#183): the six event handlers are transactional (ADR 0019) and no longer fire `asyncio.create_task` at a fresh session. That task raced the request's commit, and lost for `patient.created`: the patient row was invisible, so the **welcome message was never queued**. Each body runs in a savepoint — queueing must not be able to fail the appointment it announces.
+- refactor: `NotificationGateway.enqueue` flushes instead of committing; the session's owner (`get_db`, or the scheduler job) commits.
 - feat(onboarding): optional getting-started rule `smtp` — suggests configuring the email sender.
 
 - i18n: add Tamil locale (`notifications-ta.json`) with full UI coverage.

--- a/backend/app/modules/notifications/gateway.py
+++ b/backend/app/modules/notifications/gateway.py
@@ -186,8 +186,12 @@ class NotificationGateway:
             next_attempt_at=datetime.now(UTC),
         )
         db.add(msg)
-        await db.commit()
-        await db.refresh(msg)
+        # Flush, don't commit: whoever owns the session decides when the
+        # message becomes real. In a request that is ``get_db``; for a
+        # transactional event handler it is the publisher, so a rolled-back
+        # request queues nothing (ADR 0019). The scheduler jobs that own
+        # their session commit explicitly.
+        await db.flush()
         await NotificationGateway._publish(msg, EventType.NOTIFICATION_QUEUED)
         return msg
 
@@ -532,8 +536,7 @@ class NotificationGateway:
             triggered_by_user_id=triggered_by_user_id,
         )
         db.add(msg)
-        await db.commit()
-        await db.refresh(msg)
+        await db.flush()
         return msg
 
     @staticmethod

--- a/backend/app/modules/notifications/handlers.py
+++ b/backend/app/modules/notifications/handlers.py
@@ -1,17 +1,27 @@
 """Event handlers for the notifications module.
 
-These handlers listen to events from other modules and trigger
-notification emails when appropriate.
+These handlers listen to events from other modules and queue notifications
+when appropriate.
+
+All of them are **transactional** (ADR 0019): they read the publisher's own
+rows and queue a ``CommunicationMessage`` on its session. Nothing is sent
+here — ``NotificationGateway.dispatch_outbox`` (scheduler) owns the network
+I/O, so there is no external side effect inside the transaction.
+
+Each body runs inside a **savepoint**: queueing a message is best-effort and
+must never fail the appointment, patient or invoice it announces, but an
+error still has to unwind cleanly or the publisher's transaction would be
+left unusable. The outer transaction rolling back discards the queued
+message too, which is the point — no confirmation email for an appointment
+that was never booked (issue #183).
 """
 
-import asyncio
 import logging
 from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select
-
-from app.database import async_session_maker
+from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
@@ -20,16 +30,16 @@ class NotificationHandlers:
     """Event handlers for notification triggers."""
 
     @staticmethod
-    def on_appointment_scheduled(data: dict[str, Any]) -> None:
+    async def on_appointment_scheduled(data: dict[str, Any], *, db: AsyncSession) -> None:
         """Handle appointment.scheduled event.
 
-        Sends appointment confirmation email to patient.
-        """
-        asyncio.create_task(NotificationHandlers._handle_appointment_scheduled(data))
+        Queues the appointment confirmation for the patient.
 
-    @staticmethod
-    async def _handle_appointment_scheduled(data: dict[str, Any]) -> None:
-        """Async handler for appointment scheduled."""
+        Transactional (ADR 0019): queues the message on the publisher's
+        session. Nothing is sent here — the outbox tick owns the network
+        I/O — so a rolled-back request queues nothing, and the rows this
+        reads are the publisher's own (issue #183).
+        """
         from app.modules.agenda.models import Appointment
         from app.modules.notifications.gateway import NotificationGateway
         from app.modules.patients.models import Patient
@@ -38,7 +48,7 @@ class NotificationHandlers:
             clinic_id = UUID(data["clinic_id"])
             appointment_id = UUID(data["appointment_id"])
 
-            async with async_session_maker() as db:
+            async with db.begin_nested():
                 # Get appointment with patient
                 result = await db.execute(
                     select(Appointment).where(Appointment.id == appointment_id)
@@ -88,7 +98,7 @@ class NotificationHandlers:
                     "clinic_address": clinic.address if clinic else None,
                 }
 
-                # Send notification
+                # Queue it — the outbox tick does the sending.
                 await NotificationGateway.enqueue(
                     db=db,
                     clinic_id=clinic_id,
@@ -103,16 +113,16 @@ class NotificationHandlers:
             logger.error(f"Error handling appointment.scheduled: {e}", exc_info=True)
 
     @staticmethod
-    def on_appointment_cancelled(data: dict[str, Any]) -> None:
+    async def on_appointment_cancelled(data: dict[str, Any], *, db: AsyncSession) -> None:
         """Handle appointment.cancelled event.
 
-        Sends appointment cancellation email to patient.
-        """
-        asyncio.create_task(NotificationHandlers._handle_appointment_cancelled(data))
+        Queues the cancellation notice for the patient.
 
-    @staticmethod
-    async def _handle_appointment_cancelled(data: dict[str, Any]) -> None:
-        """Async handler for appointment cancelled."""
+        Transactional (ADR 0019): queues the message on the publisher's
+        session. Nothing is sent here — the outbox tick owns the network
+        I/O — so a rolled-back request queues nothing, and the rows this
+        reads are the publisher's own (issue #183).
+        """
         from app.modules.agenda.models import Appointment
         from app.modules.notifications.gateway import NotificationGateway
         from app.modules.patients.models import Patient
@@ -122,7 +132,7 @@ class NotificationHandlers:
             appointment_id = UUID(data["appointment_id"])
             cancellation_reason = data.get("reason")
 
-            async with async_session_maker() as db:
+            async with db.begin_nested():
                 # Get appointment
                 result = await db.execute(
                     select(Appointment).where(Appointment.id == appointment_id)
@@ -182,16 +192,16 @@ class NotificationHandlers:
             logger.error(f"Error handling appointment.cancelled: {e}", exc_info=True)
 
     @staticmethod
-    def on_patient_created(data: dict[str, Any]) -> None:
+    async def on_patient_created(data: dict[str, Any], *, db: AsyncSession) -> None:
         """Handle patient.created event.
 
-        Sends welcome email to new patient (if auto_send is enabled).
-        """
-        asyncio.create_task(NotificationHandlers._handle_patient_created(data))
+        Queues the welcome message for the new patient (if auto_send is enabled).
 
-    @staticmethod
-    async def _handle_patient_created(data: dict[str, Any]) -> None:
-        """Async handler for patient created."""
+        Transactional (ADR 0019): queues the message on the publisher's
+        session. Nothing is sent here — the outbox tick owns the network
+        I/O — so a rolled-back request queues nothing, and the rows this
+        reads are the publisher's own (issue #183).
+        """
         from app.modules.notifications.gateway import NotificationGateway
         from app.modules.patients.models import Patient
 
@@ -199,7 +209,7 @@ class NotificationHandlers:
             clinic_id = UUID(data["clinic_id"])
             patient_id = UUID(data["patient_id"])
 
-            async with async_session_maker() as db:
+            async with db.begin_nested():
                 # Get patient
                 result = await db.execute(select(Patient).where(Patient.id == patient_id))
                 patient = result.scalar_one_or_none()
@@ -234,15 +244,16 @@ class NotificationHandlers:
             logger.error(f"Error handling patient.created: {e}", exc_info=True)
 
     @staticmethod
-    def on_budget_sent(data: dict[str, Any]) -> None:
+    async def on_budget_sent(data: dict[str, Any], *, db: AsyncSession) -> None:
         """Handle budget.sent event.
 
-        Sends budget email to patient.
-        """
-        asyncio.create_task(NotificationHandlers._handle_budget_sent(data))
+        Queues the budget email for the patient.
 
-    @staticmethod
-    async def _handle_budget_sent(data: dict[str, Any]) -> None:
+        Transactional (ADR 0019): queues the message on the publisher's
+        session. Nothing is sent here — the outbox tick owns the network
+        I/O — so a rolled-back request queues nothing, and the rows this
+        reads are the publisher's own (issue #183).
+        """
         """Async handler for budget sent.
 
         Only sends email if send_method is "email".
@@ -264,7 +275,7 @@ class NotificationHandlers:
             clinic_id = UUID(data["clinic_id"])
             budget_id = UUID(data["budget_id"])
 
-            async with async_session_maker() as db:
+            async with db.begin_nested():
                 # Get budget with items
                 result = await db.execute(select(Budget).where(Budget.id == budget_id))
                 budget = result.scalar_one_or_none()
@@ -343,15 +354,16 @@ class NotificationHandlers:
             logger.error(f"Error handling budget.sent: {e}", exc_info=True)
 
     @staticmethod
-    def on_invoice_sent(data: dict[str, Any]) -> None:
+    async def on_invoice_sent(data: dict[str, Any], *, db: AsyncSession) -> None:
         """Handle invoice.sent event.
 
-        Sends invoice email to patient.
-        """
-        asyncio.create_task(NotificationHandlers._handle_invoice_sent(data))
+        Queues the invoice email for the patient.
 
-    @staticmethod
-    async def _handle_invoice_sent(data: dict[str, Any]) -> None:
+        Transactional (ADR 0019): queues the message on the publisher's
+        session. Nothing is sent here — the outbox tick owns the network
+        I/O — so a rolled-back request queues nothing, and the rows this
+        reads are the publisher's own (issue #183).
+        """
         """Async handler for invoice sent.
 
         Only sends email if send_method is "email".
@@ -373,7 +385,7 @@ class NotificationHandlers:
             clinic_id = UUID(data["clinic_id"])
             invoice_id = UUID(data["invoice_id"])
 
-            async with async_session_maker() as db:
+            async with db.begin_nested():
                 # Get invoice with items
                 result = await db.execute(select(Invoice).where(Invoice.id == invoice_id))
                 invoice = result.scalar_one_or_none()
@@ -447,16 +459,16 @@ class NotificationHandlers:
             logger.error(f"Error handling invoice.sent: {e}", exc_info=True)
 
     @staticmethod
-    def on_budget_accepted(data: dict[str, Any]) -> None:
+    async def on_budget_accepted(data: dict[str, Any], *, db: AsyncSession) -> None:
         """Handle budget.accepted event.
 
-        Sends budget acceptance confirmation to patient.
-        """
-        asyncio.create_task(NotificationHandlers._handle_budget_accepted(data))
+        Queues the budget acceptance confirmation for the patient.
 
-    @staticmethod
-    async def _handle_budget_accepted(data: dict[str, Any]) -> None:
-        """Async handler for budget accepted."""
+        Transactional (ADR 0019): queues the message on the publisher's
+        session. Nothing is sent here — the outbox tick owns the network
+        I/O — so a rolled-back request queues nothing, and the rows this
+        reads are the publisher's own (issue #183).
+        """
         from app.modules.budget.models import Budget
         from app.modules.notifications.gateway import NotificationGateway
         from app.modules.patients.models import Patient
@@ -465,7 +477,7 @@ class NotificationHandlers:
             clinic_id = UUID(data["clinic_id"])
             budget_id = UUID(data["budget_id"])
 
-            async with async_session_maker() as db:
+            async with db.begin_nested():
                 # Get budget
                 result = await db.execute(select(Budget).where(Budget.id == budget_id))
                 budget = result.scalar_one_or_none()

--- a/backend/app/modules/notifications/tasks.py
+++ b/backend/app/modules/notifications/tasks.py
@@ -154,6 +154,11 @@ async def process_appointment_reminders() -> None:
                             f"Queued reminder for appointment {appointment.id} to {patient.email}"
                         )
 
+            # This job owns its session, so it commits what ``enqueue``
+            # flushed. Once for the whole sweep: the ``dedup_key`` makes a
+            # re-run after a failure a no-op.
+            await db.commit()
+
         if reminders_sent > 0 or reminders_skipped > 0:
             logger.info(
                 f"Reminder job complete: {reminders_sent} sent, {reminders_skipped} skipped"
@@ -241,6 +246,7 @@ async def send_single_reminder(appointment_id: UUID, clinic_id: UUID) -> bool:
                 force_send=True,
                 dedup_key=f"appointment_reminder:{appointment.id}",
             )
+            await db.commit()  # own session → own commit (``enqueue`` only flushes)
 
             return msg is not None and msg.status != "skipped"
 

--- a/backend/app/modules/odontogram/CHANGELOG.md
+++ b/backend/app/modules/odontogram/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#183): `TreatmentService.perform` publishes with `db=` so the payments earned ledger and the plan-item completion run in its transaction (ADR 0019).
 - feat(events): `TreatmentService.perform` accepts `publish_price=False`
   to emit `odontogram.treatment.performed` with `unit_price: null` —
   the caller declares the revenue already attributed elsewhere

--- a/backend/app/modules/patient_timeline/CHANGELOG.md
+++ b/backend/app/modules/patient_timeline/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- docs(#183): handlers documented as own-session/payload-only — the timeline records what the payload carries and must never be able to fail the event it logs.
 - i18n: add `pt` fallback to treatment name resolution in the demo
   timeline seed.
 

--- a/backend/app/modules/patient_timeline/events.py
+++ b/backend/app/modules/patient_timeline/events.py
@@ -4,8 +4,10 @@ Every handler follows the same contract:
 
 - Signature ``async def on_*(data: dict) -> None`` — matches the event bus
   calling convention (``handler(data)``).
-- Opens its own DB session via :func:`async_session_maker`.
-- Commits on success, rolls back on failure.
+- Opens its own DB session via :func:`async_session_maker`, commits on
+  success and rolls back on failure — deliberately own-session (ADR 0019,
+  audited in issue #183): the timeline is a log and must never be able to
+  fail the event it is logging.
 - Never imports models from other modules. Everything it needs must come in
   the ``data`` dict. Keeps the timeline module removable in isolation — the
   whole point of the patient_timeline split in Fase B.3.
@@ -70,6 +72,11 @@ async def _record(
 
     Centralizes session management + error handling so each specific handler
     stays declarative.
+
+    own-session (issue #183): every handler in this module is payload-only —
+    the timeline records what the payload says happened and never re-reads
+    the publisher's rows, and ``source_id`` is polymorphic with no FK. The
+    timeline is a log: it must not be able to fail the thing it is logging.
     """
     ids = _required_ids(data, "clinic_id", "patient_id", source_id_key)
     if ids is None:

--- a/backend/app/modules/patients/CHANGELOG.md
+++ b/backend/app/modules/patients/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#183): `patient.created` / `patient.archived` are published with `db=` so the notifications, recalls and media handlers see the row and roll back with it (ADR 0019).
 - feat(onboarding): optional getting-started rule `first-patient` — suggests creating the first patient.
 
 - fix(timezones): visit summary card renders appointment date/hour as

--- a/backend/app/modules/patients/service.py
+++ b/backend/app/modules/patients/service.py
@@ -256,6 +256,7 @@ class PatientService:
         await event_bus.publish(
             EventType.PATIENT_CREATED,
             {"patient_id": str(patient.id), "clinic_id": str(clinic_id)},
+            db=db,
         )
         return patient
 

--- a/backend/app/modules/payments/CHANGELOG.md
+++ b/backend/app/modules/payments/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#183): the earned-ledger handlers are transactional (ADR 0019). Revenue is booked in the same transaction as the treatment; a failed request no longer leaves an orphan `PatientEarnedEntry` (there is no FK to `treatments` to catch one).
 - fix(#178): `payment.allocated` and `payment.refunded` are published
   transactionally (`db=db`, ADR 0019) so billing mirrors budget
   allocations onto invoices and recomputes status inside the same

--- a/backend/app/modules/periodontogram/CHANGELOG.md
+++ b/backend/app/modules/periodontogram/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- docs(#183): both event handlers documented as own-session/payload-only, with a note that PR-3's real cleanup should be transactional (ADR 0019).
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 
 - style(lint): first ESLint pass over this module's frontend layer —

--- a/backend/app/modules/periodontogram/events.py
+++ b/backend/app/modules/periodontogram/events.py
@@ -19,6 +19,10 @@ async def on_odontogram_treatment_performed(data: dict[str, Any]) -> None:
     Today: no-op (logging). PR-3 will refresh the active draft's
     ``is_implant`` / ``is_present`` flags when a treatment that changes
     the physical state of the tooth is recorded.
+
+    own-session: payload-only, no DB access (issue #183). When PR-3 gives it
+    real work, re-read §6 of creating-modules.md — refreshing flags off the
+    publisher's rows would make it transactional.
     """
     logger.debug(
         "periodontogram: odontogram.treatment.performed received: %s",
@@ -32,6 +36,9 @@ async def on_patient_archived(data: dict[str, Any]) -> None:
     PR-3 will move this from a logging stub to a real cleanup. For now
     the partial unique index already protects against draft re-use
     against an archived patient.
+
+    own-session: payload-only, no DB access (issue #183). The real cleanup
+    is a cascade of the archive, so PR-3 should make it transactional.
     """
     logger.debug(
         "periodontogram: patient.archived received: %s",

--- a/backend/app/modules/recalls/CHANGELOG.md
+++ b/backend/app/modules/recalls/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#183): the four event handlers are transactional (ADR 0019). `on_appointment_scheduled` writes `linked_appointment_id`, an FK to the appointment the publisher has only flushed — from its own session that write was rejected and swallowed, so **auto-link never worked** through the API.
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 
 - style(lint): first ESLint pass over this module's frontend layer —

--- a/backend/app/modules/schedules/CHANGELOG.md
+++ b/backend/app/modules/schedules/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- docs(#183): `on_clinic_created` documented as own-session (published after setup commits); the appointment handlers are payload-only logging.
 - feat(onboarding): `ClinicHoursQuickModal` — inline weekly-hours editor with two presets, used as the getting-started mini-modal.
 
 - feat(onboarding): getting-started rule `clinic-hours` — flags clinics still on the 24/7 default template.

--- a/backend/app/modules/schedules/events.py
+++ b/backend/app/modules/schedules/events.py
@@ -21,6 +21,10 @@ logger = logging.getLogger(__name__)
 
 
 async def on_clinic_created(data: dict[str, Any]) -> None:
+    """own-session (issue #183): ``clinic.created`` is published after
+    ``POST /auth/setup`` commits, so there are no uncommitted rows to miss —
+    and seeding a fresh clinic must not stretch the signup transaction.
+    """
     clinic_id_raw = data.get("clinic_id")
     if not clinic_id_raw:
         return
@@ -41,6 +45,7 @@ async def on_clinic_created(data: dict[str, Any]) -> None:
 
 
 async def on_appointment_scheduled(data: dict) -> None:
+    """own-session: payload-only, no DB access (analytics placeholder)."""
     logger.debug("schedules: appointment.scheduled received: %s", data.get("appointment_id"))
 
 

--- a/backend/app/modules/treatment_plan/CHANGELOG.md
+++ b/backend/app/modules/treatment_plan/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#183): the seven event handlers are transactional (ADR 0019). `on_appointment_completed` was reading `completed_in_appointment` flags the publisher had only flushed, so it closed nothing. The `SKIP LOCKED` in `on_treatment_performed` is gone — it only existed to dodge a deadlock between the handler's own session and the publisher awaiting it.
 - fix(sessions): accepting a quote now reprices the plan's pending
   sessions to the accepted line amounts (line + global discount, ex-tax),
   so `item_session_completed` — and the payments earned ledger — book the

--- a/backend/app/modules/treatment_plan/CLAUDE.md
+++ b/backend/app/modules/treatment_plan/CLAUDE.md
@@ -118,11 +118,16 @@ Clinical-note created events (`clinical_notes.{administrative,diagnosis,treatmen
   not freeze the plan. Mirrored in `PlanDetailView.vue` and
   keep the two predicates in sync. (`TreatmentPlanDetail.vue` was
   dead code and was removed in #167.)
+- **Every handler in `events.py` is transactional** (ADR 0019, issue
+  #183): it declares `db` and runs inside the publisher's session, so
+  plan and budget move together or not at all. A handler that publishes
+  forwards `db=db`.
 - **Budget-side reopens go through `reopen_from_budget`,** which never
-  writes the budget row: the publisher's open transaction holds it
-  locked and the bus awaits handlers inline — calling `reopen()` from a
-  handler would hang. `reopen()` itself cancels the linked budget with
-  `publish_event=False` for the symmetric reason.
+  writes the budget row — the publisher is already cancelling it, and
+  `reopen()` would cancel it again and echo `budget.cancelled` straight
+  back into this module. `reopen()` itself cancels the linked budget with
+  `publish_event=False` for the symmetric reason. (Both used to be about
+  lock avoidance; sharing the publisher's session removed that half.)
 - **Plan ↔ budget item sync goes through events**, not direct calls.
   Adding a treatment to a plan publishes
   `treatment_plan.treatment_added` with a denormalized snapshot

--- a/backend/app/modules/treatment_plan/events.py
+++ b/backend/app/modules/treatment_plan/events.py
@@ -1,6 +1,15 @@
 """Treatment plan module event handlers.
 
 Listens to events from other modules and reacts accordingly.
+
+Every handler here is **transactional** (ADR 0019): it declares ``db`` and
+runs inside the publisher's session. The plan mirrors budget and agenda
+state, so the two have to move together — on its own session a handler read
+rows the publisher had only flushed (stale), competed for locks with it, and
+committed changes the publisher could still roll back (issue #183).
+
+A handler that publishes forwards its ``db`` so subscribers further down the
+chain keep the same guarantee.
 """
 
 import logging
@@ -12,7 +21,6 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.events import event_bus
-from app.database import async_session_maker
 
 from .models import PlannedTreatmentItem, PlannedTreatmentItemSession
 
@@ -43,10 +51,13 @@ async def _resolve_treatment_category_key(db: AsyncSession, treatment_id: UUID) 
     return result.scalar_one_or_none()
 
 
-async def on_appointment_completed(data: dict[str, Any]) -> None:
+async def on_appointment_completed(data: dict[str, Any], *, db: AsyncSession) -> None:
     """Handle appointment completed event.
 
-    When an appointment is completed, mark associated planned treatments as completed.
+    When an appointment is completed, mark associated planned treatments as
+    completed. Transactional: it reads ``completed_in_appointment`` flags the
+    publisher has only flushed — a second session saw the pre-visit values and
+    closed nothing (issue #183).
     """
     appointment_id = data.get("appointment_id")
     clinic_id = data.get("clinic_id")
@@ -55,68 +66,65 @@ async def on_appointment_completed(data: dict[str, Any]) -> None:
         logger.warning("on_appointment_completed: missing appointment_id or clinic_id")
         return
 
-    async with async_session_maker() as db:
-        try:
-            # Import here to avoid circular imports
-            from app.modules.agenda.models import AppointmentTreatment
+    # Import here to avoid circular imports
+    from app.modules.agenda.models import AppointmentTreatment
 
-            # Get completed treatments from the appointment
-            result = await db.execute(
-                select(AppointmentTreatment).where(
-                    AppointmentTreatment.appointment_id == UUID(appointment_id),
-                    AppointmentTreatment.completed_in_appointment == True,  # noqa: E712
-                )
+    from .service import TreatmentPlanService
+
+    result = await db.execute(
+        select(AppointmentTreatment).where(
+            AppointmentTreatment.appointment_id == UUID(appointment_id),
+            AppointmentTreatment.completed_in_appointment == True,  # noqa: E712
+        )
+    )
+    completed_treatments = result.scalars().all()
+
+    for apt_treatment in completed_treatments:
+        # Find planned item that references this treatment
+        if not apt_treatment.planned_treatment_item_id:
+            continue
+        item_result = await db.execute(
+            select(PlannedTreatmentItem).where(
+                PlannedTreatmentItem.id == apt_treatment.planned_treatment_item_id,
+                PlannedTreatmentItem.clinic_id == UUID(clinic_id),
             )
-            completed_treatments = result.scalars().all()
+        )
+        item = item_result.scalar_one_or_none()
+        if not item or item.status == "completed":
+            continue
 
-            for apt_treatment in completed_treatments:
-                # Find planned item that references this treatment
-                if apt_treatment.planned_treatment_item_id:
-                    item_result = await db.execute(
-                        select(PlannedTreatmentItem).where(
-                            PlannedTreatmentItem.id == apt_treatment.planned_treatment_item_id,
-                            PlannedTreatmentItem.clinic_id == UUID(clinic_id),
-                        )
-                    )
-                    item = item_result.scalar_one_or_none()
+        item.status = "completed"
+        item.completed_without_appointment = False
 
-                    if item and item.status != "completed":
-                        item.status = "completed"
-                        item.completed_without_appointment = False
+        category_key = await _resolve_treatment_category_key(db, item.treatment_id)
+        await event_bus.publish(
+            "treatment_plan.treatment_completed",
+            {
+                "plan_id": str(item.treatment_plan_id),
+                "item_id": str(item.id),
+                "treatment_id": str(item.treatment_id),
+                "clinic_id": clinic_id,
+                "patient_id": data.get("patient_id"),
+                "triggered_by": "appointment_completed",
+                "treatment_category_key": category_key,
+            },
+            db=db,
+        )
 
-                        category_key = await _resolve_treatment_category_key(db, item.treatment_id)
-                        await event_bus.publish(
-                            "treatment_plan.treatment_completed",
-                            {
-                                "plan_id": str(item.treatment_plan_id),
-                                "item_id": str(item.id),
-                                "treatment_id": str(item.treatment_id),
-                                "clinic_id": clinic_id,
-                                "patient_id": data.get("patient_id"),
-                                "triggered_by": "appointment_completed",
-                                "treatment_category_key": category_key,
-                            },
-                        )
+        # Check if plan should auto-complete
+        await TreatmentPlanService._check_and_complete_plan(
+            db, UUID(clinic_id), item.treatment_plan_id
+        )
 
-                        # Check if plan should auto-complete
-                        from .service import TreatmentPlanService
-
-                        await TreatmentPlanService._check_and_complete_plan(
-                            db, UUID(clinic_id), item.treatment_plan_id
-                        )
-
-            await db.commit()
-            logger.info(
-                f"Processed appointment completion for {len(completed_treatments)} treatments"
-            )
-
-        except Exception as e:
-            logger.error(f"Error processing appointment completion: {e}", exc_info=True)
-            await db.rollback()
+    logger.info("Processed appointment completion for %d treatments", len(completed_treatments))
 
 
-async def on_budget_accepted(data: dict[str, Any]) -> None:
+async def on_budget_accepted(data: dict[str, Any], *, db: AsyncSession) -> None:
     """Activate the linked plan when its budget is accepted.
+
+    Transactional: an accepted budget whose plan failed to activate is a
+    silent divergence between the two modules — the error used to be logged
+    and swallowed.
 
     Idempotent: ``TreatmentPlanService.accept_from_budget`` is a no-op
     when the plan is already active. The plan_id is read from the
@@ -143,20 +151,14 @@ async def on_budget_accepted(data: dict[str, Any]) -> None:
         if i.get("treatment_id") and i.get("net_amount") is not None
     }
 
-    async with async_session_maker() as db:
-        try:
-            await TreatmentPlanService.accept_from_budget(
-                db, UUID(clinic_id), UUID(plan_id), line_amounts
-            )
-            await db.commit()
-        except Exception as e:
-            logger.error(f"Error processing budget acceptance: {e}", exc_info=True)
-            await db.rollback()
+    await TreatmentPlanService.accept_from_budget(db, UUID(clinic_id), UUID(plan_id), line_amounts)
 
 
-async def on_budget_rejected(data: dict[str, Any]) -> None:
+async def on_budget_rejected(data: dict[str, Any], *, db: AsyncSession) -> None:
     """Close the linked plan with ``rejected_by_patient`` when the
     patient rejects the budget. Idempotent.
+
+    Transactional: plan and budget must not disagree about the rejection.
     """
     clinic_id = data.get("clinic_id")
     plan_id = data.get("plan_id")
@@ -167,25 +169,18 @@ async def on_budget_rejected(data: dict[str, Any]) -> None:
 
     from .service import TreatmentPlanService
 
-    async with async_session_maker() as db:
-        try:
-            await TreatmentPlanService.reject_from_budget(
-                db, UUID(clinic_id), UUID(plan_id), rejection_note=note
-            )
-            await db.commit()
-        except Exception as e:
-            logger.error(f"Error processing budget rejection: {e}", exc_info=True)
-            await db.rollback()
+    await TreatmentPlanService.reject_from_budget(
+        db, UUID(clinic_id), UUID(plan_id), rejection_note=note
+    )
 
 
-async def on_budget_renegotiated(data: dict[str, Any]) -> None:
+async def on_budget_renegotiated(data: dict[str, Any], *, db: AsyncSession) -> None:
     """Reopen the linked plan back to ``draft`` when reception
     cancels a sent budget for renegotiation.
 
-    Uses ``reopen_from_budget``, which never writes the budget row:
-    the publisher's still-open transaction holds a lock on it, and the
-    bus awaits handlers inline — calling ``reopen()`` here (which
-    cancels the budget) would hang on that lock.
+    Uses ``reopen_from_budget``, which never writes the budget row: the
+    publisher is already cancelling it, and ``reopen()`` would cancel it
+    again and echo another ``budget.cancelled`` back into this module.
     """
     clinic_id = data.get("clinic_id")
     plan_id = data.get("plan_id")
@@ -195,21 +190,17 @@ async def on_budget_renegotiated(data: dict[str, Any]) -> None:
 
     from .service import TreatmentPlanService
 
-    async with async_session_maker() as db:
-        try:
-            await TreatmentPlanService.reopen_from_budget(db, UUID(clinic_id), UUID(plan_id))
-            await db.commit()
-        except Exception as e:
-            logger.error(f"Error processing budget renegotiation: {e}", exc_info=True)
-            await db.rollback()
+    await TreatmentPlanService.reopen_from_budget(db, UUID(clinic_id), UUID(plan_id))
 
 
-async def on_budget_cancelled(data: dict[str, Any]) -> None:
+async def on_budget_cancelled(data: dict[str, Any], *, db: AsyncSession) -> None:
     """Reopen the linked pending plan to ``draft`` when staff cancels
     its budget directly from the budgets module (issue #162).
 
     Idempotent: non-pending plans are a warn + no-op inside
     ``reopen_from_budget``. Standalone budgets carry no ``plan_id``.
+
+    Transactional: the plan reopens with the cancellation or not at all.
     """
     clinic_id = data.get("clinic_id")
     plan_id = data.get("plan_id")
@@ -219,18 +210,16 @@ async def on_budget_cancelled(data: dict[str, Any]) -> None:
 
     from .service import TreatmentPlanService
 
-    async with async_session_maker() as db:
-        try:
-            await TreatmentPlanService.reopen_from_budget(db, UUID(clinic_id), UUID(plan_id))
-            await db.commit()
-        except Exception as e:
-            logger.error(f"Error processing budget cancellation: {e}", exc_info=True)
-            await db.rollback()
+    await TreatmentPlanService.reopen_from_budget(db, UUID(clinic_id), UUID(plan_id))
 
 
-async def on_budget_superseded(data: dict[str, Any]) -> None:
+async def on_budget_superseded(data: dict[str, Any], *, db: AsyncSession) -> None:
     """Repoint the plan's budget link when a terminal budget is cloned
     to a new draft version ("Resend", issue #162).
+
+    Transactional: ``treatment_plans.budget_id`` is an FK to the new budget
+    row, which only exists inside the publisher's transaction. This used to
+    force the publisher to commit before publishing (issue #183).
 
     Relinks only while the plan still points at the superseded budget —
     idempotent on redelivery, and a no-op if the plan already moved on
@@ -247,22 +236,23 @@ async def on_budget_superseded(data: dict[str, Any]) -> None:
 
     from .service import TreatmentPlanService
 
-    async with async_session_maker() as db:
-        try:
-            plan = await TreatmentPlanService.get(db, UUID(clinic_id), UUID(plan_id))
-            if plan and str(plan.budget_id) == old_budget_id:
-                plan.budget_id = UUID(new_budget_id)
-                await db.commit()
-        except Exception as e:
-            logger.error(f"Error processing budget supersede: {e}", exc_info=True)
-            await db.rollback()
+    plan = await TreatmentPlanService.get(db, UUID(clinic_id), UUID(plan_id))
+    if plan and str(plan.budget_id) == old_budget_id:
+        plan.budget_id = UUID(new_budget_id)
 
 
-async def on_treatment_performed(data: dict[str, Any]) -> None:
+async def on_treatment_performed(data: dict[str, Any], *, db: AsyncSession) -> None:
     """Handle treatment performed from odontogram.
 
-    Mark the corresponding planned item as completed when the odontogram performs
-    a Treatment that belongs to an active plan item.
+    Mark the corresponding planned item as completed when the odontogram
+    performs a Treatment that belongs to an active plan item.
+
+    Transactional: this also runs as a sub-step of
+    ``TreatmentPlanService.complete_item``, which has already flushed its own
+    ``status='completed'`` UPDATE on this row. Sharing the publisher's session
+    means sharing its locks, so there is nothing left to wait for — the old
+    own-session version had to ``SKIP LOCKED`` past the row to avoid
+    deadlocking against the publisher it was awaiting (issue #183).
     """
     treatment_id = data.get("treatment_id")
     clinic_id = data.get("clinic_id")
@@ -271,70 +261,51 @@ async def on_treatment_performed(data: dict[str, Any]) -> None:
         logger.warning("on_treatment_performed: missing treatment_id or clinic_id")
         return
 
-    async with async_session_maker() as db:
-        try:
-            # ``SKIP LOCKED`` avoids a deadlock when this handler runs as a
-            # sub-step of ``TreatmentPlanService.complete_item``: the parent
-            # transaction already holds a row lock on this item (it flushed
-            # its own ``status='completed'`` UPDATE before publishing the
-            # event). Without ``SKIP LOCKED`` the handler would open a new
-            # session, block waiting for the parent to commit, and the
-            # parent would block waiting for this handler to return —
-            # surfaced as a request timeout in the client. When the lock is
-            # held we treat the originator as responsible for the
-            # state transition and exit silently; the parent's UPDATE
-            # achieves the same end state.
-            result = await db.execute(
-                select(PlannedTreatmentItem)
-                .where(
-                    PlannedTreatmentItem.treatment_id == UUID(treatment_id),
-                    PlannedTreatmentItem.clinic_id == UUID(clinic_id),
-                    PlannedTreatmentItem.status == "pending",
-                )
-                .with_for_update(skip_locked=True)
-            )
-            item = result.scalar_one_or_none()
+    from .service import TreatmentPlanService
 
-            if item:
-                item.status = "completed"
-                item.completed_without_appointment = True
+    result = await db.execute(
+        select(PlannedTreatmentItem)
+        .where(
+            PlannedTreatmentItem.treatment_id == UUID(treatment_id),
+            PlannedTreatmentItem.clinic_id == UUID(clinic_id),
+            PlannedTreatmentItem.status == "pending",
+        )
+        .with_for_update()
+    )
+    item = result.scalar_one_or_none()
+    if item is None:
+        return
 
-                # The odontogram-performed event already carried the full
-                # price to the payments earned ledger. Cancel the item's
-                # pending sessions (no session events) so they can't be
-                # completed later and book the same money a second time.
-                await db.execute(
-                    update(PlannedTreatmentItemSession)
-                    .where(
-                        PlannedTreatmentItemSession.plan_item_id == item.id,
-                        PlannedTreatmentItemSession.status == "pending",
-                    )
-                    .values(status="cancelled")
-                )
+    item.status = "completed"
+    item.completed_without_appointment = True
 
-                category_key = await _resolve_treatment_category_key(db, item.treatment_id)
-                await event_bus.publish(
-                    "treatment_plan.treatment_completed",
-                    {
-                        "plan_id": str(item.treatment_plan_id),
-                        "item_id": str(item.id),
-                        "treatment_id": treatment_id,
-                        "clinic_id": clinic_id,
-                        "patient_id": data.get("patient_id"),
-                        "triggered_by": "odontogram_performed",
-                        "treatment_category_key": category_key,
-                    },
-                )
+    # The odontogram-performed event already carried the full price to the
+    # payments earned ledger. Cancel the item's pending sessions (no session
+    # events) so they can't be completed later and book the same money a
+    # second time.
+    await db.execute(
+        update(PlannedTreatmentItemSession)
+        .where(
+            PlannedTreatmentItemSession.plan_item_id == item.id,
+            PlannedTreatmentItemSession.status == "pending",
+        )
+        .values(status="cancelled")
+    )
 
-                from .service import TreatmentPlanService
+    category_key = await _resolve_treatment_category_key(db, item.treatment_id)
+    await event_bus.publish(
+        "treatment_plan.treatment_completed",
+        {
+            "plan_id": str(item.treatment_plan_id),
+            "item_id": str(item.id),
+            "treatment_id": treatment_id,
+            "clinic_id": clinic_id,
+            "patient_id": data.get("patient_id"),
+            "triggered_by": "odontogram_performed",
+            "treatment_category_key": category_key,
+        },
+        db=db,
+    )
 
-                await TreatmentPlanService._check_and_complete_plan(
-                    db, UUID(clinic_id), item.treatment_plan_id
-                )
-
-                await db.commit()
-                logger.info("Marked planned item %s as completed from odontogram", item.id)
-
-        except Exception as e:
-            logger.error("Error processing treatment performed: %s", e, exc_info=True)
-            await db.rollback()
+    await TreatmentPlanService._check_and_complete_plan(db, UUID(clinic_id), item.treatment_plan_id)
+    logger.info("Marked planned item %s as completed from odontogram", item.id)

--- a/backend/app/modules/treatment_plan/service.py
+++ b/backend/app/modules/treatment_plan/service.py
@@ -641,6 +641,7 @@ class TreatmentPlanService:
                     str(item.assigned_professional_id) if item.assigned_professional_id else None
                 ),
             },
+            db=db,
         )
 
         return item
@@ -825,6 +826,7 @@ class TreatmentPlanService:
                 "clinic_id": str(clinic_id),
                 "budget_id": str(plan.budget_id) if plan.budget_id else None,
             },
+            db=db,
         )
 
         return True
@@ -1297,6 +1299,7 @@ class TreatmentPlanService:
                 "clinic_id": str(clinic_id),
                 "items": items_payload,
             },
+            db=db,
         )
 
         return True

--- a/backend/app/modules/verifactu/CHANGELOG.md
+++ b/backend/app/modules/verifactu/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- docs(#183): `on_invoice_paid` documented as own-session/payload-only (ADR 0019).
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 
 - style(lint): first ESLint pass over this module's frontend layer —

--- a/backend/app/modules/verifactu/events.py
+++ b/backend/app/modules/verifactu/events.py
@@ -10,6 +10,8 @@ logger = logging.getLogger(__name__)
 async def on_invoice_paid(data: dict) -> None:
     """Placeholder. Currently AEAT does not require payment reporting
     for Veri*Factu — the registration covers the issuing event. We hook
-    it here so we can extend later (e.g., suplido reporting)."""
+    it here so we can extend later (e.g., suplido reporting).
+
+    own-session: payload-only, no DB access (issue #183)."""
 
     logger.debug("verifactu: invoice.paid received: %s", data.get("invoice_id"))

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -227,3 +227,71 @@ async def test_cannot_delete_system_template(
     )
 
     assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Event handlers queue on the publisher's session (issue #183)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_creating_a_patient_queues_the_welcome_message(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession, test_clinic
+):
+    """The handler used to re-read the patient from its own session, in a
+    task racing the request's commit. The row was invisible there, so it
+    returned early and the welcome message was never queued."""
+    from sqlalchemy import select
+
+    from app.modules.notifications.models import CommunicationMessage
+
+    res = await client.post(
+        "/api/v1/patients",
+        headers=auth_headers,
+        json={
+            "first_name": "Nuevo",
+            "last_name": "Paciente",
+            "email": "nuevo@paciente.example.com",
+        },
+    )
+    assert res.status_code == 201, res.text
+
+    queued = (
+        (
+            await db_session.execute(
+                select(CommunicationMessage).where(
+                    CommunicationMessage.to_address == "nuevo@paciente.example.com"
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(queued) == 1
+    assert queued[0].template_key == "welcome"
+    assert queued[0].status in ("queued", "skipped")
+
+
+@pytest.mark.asyncio
+async def test_nothing_is_queued_when_the_request_rolls_back(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession, test_clinic
+):
+    """No welcome message for a patient that was never created."""
+    from sqlalchemy import select
+
+    from app.modules.notifications.models import CommunicationMessage
+    from app.modules.patients.service import PatientService
+
+    await PatientService.create_patient(
+        db_session,
+        test_clinic.id,
+        {"first_name": "Fantasma", "last_name": "Nunca", "email": "fantasma@paciente.example.com"},
+    )
+    await db_session.rollback()
+
+    queued = await db_session.scalar(
+        select(CommunicationMessage.id).where(
+            CommunicationMessage.to_address == "fantasma@paciente.example.com"
+        )
+    )
+    assert queued is None

--- a/backend/tests/test_plan_budget_lifecycle.py
+++ b/backend/tests/test_plan_budget_lifecycle.py
@@ -1,11 +1,11 @@
 """Cross-module round-trips for the plan ↔ budget lifecycle (issue #162).
 
-Harness note: the ``client`` fixture's ``get_db`` override never commits,
-while event handlers open their OWN sessions via ``async_session_maker``.
-Any HTTP call that triggers a handler therefore needs the relevant rows
-committed FIRST (``_sync`` before the call) so the handler can see them,
-and committed + expired AFTER (``_sync`` again) so the test session sees
-the handler's writes instead of stale identity-map state.
+Harness note: the plan ↔ budget handlers are transactional (ADR 0019) — they
+run on the publisher's session, so they see the request's own writes and the
+test sees theirs. ``_sync`` remains for the events still handled
+own-session (patient_timeline and friends): it commits so those handlers can
+see the rows, and expires so the test session picks up their writes instead
+of stale identity-map state.
 """
 
 from uuid import UUID, uuid4
@@ -358,7 +358,8 @@ async def test_on_budget_superseded_idempotent(
             "plan_id": plan_id,
             "budget_id": str(uuid4()),  # not the budget the plan points at
             "new_budget_id": str(uuid4()),
-        }
+        },
+        db=db_session,
     )
     db_session.expire_all()
     plan = await _get_plan(client, auth_headers, plan_id)
@@ -460,3 +461,49 @@ async def test_reopen_with_expired_budget_does_not_500(
 
     result = await db_session.execute(select(Budget.status).where(Budget.id == UUID(budget_id)))
     assert result.scalar_one() == "expired", "terminal budget must be left alone"
+
+
+# ---------------------------------------------------------------------------
+# Atomicity — plan and budget agree or neither moves (issue #183)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_budget_acceptance_rolls_back_when_the_plan_cannot_activate(
+    db_session: AsyncSession,
+    client: AsyncClient,
+    auth_headers: dict,
+    setup: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The plan activation used to run on its own session with the error
+    logged and swallowed: the budget ended up accepted next to a plan that
+    never activated, and nothing surfaced it."""
+    from app.modules.treatment_plan.service import TreatmentPlanService
+
+    plan_id, _ = await _create_plan_with_items(client, auth_headers, setup, [16])
+    budget_id = await _confirm_plan(client, auth_headers, plan_id)
+    await _sync(db_session)
+    await _send_budget(client, auth_headers, budget_id)
+    await _sync(db_session)
+
+    async def _boom(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("plan activation failed")
+
+    monkeypatch.setattr(TreatmentPlanService, "accept_from_budget", _boom)
+
+    with pytest.raises(RuntimeError, match="plan activation failed"):
+        await client.post(
+            f"/api/v1/budget/budgets/{budget_id}/accept",
+            headers=auth_headers,
+            json={
+                "signature": {
+                    "signed_by_name": "Rosa Vega",
+                    "relationship_to_patient": "patient",
+                }
+            },
+        )
+
+    await db_session.rollback()
+    status = await db_session.scalar(select(Budget.status).where(Budget.id == UUID(budget_id)))
+    assert status == "sent", "a failed plan activation must not leave the budget accepted"

--- a/backend/tests/test_treatment_plan.py
+++ b/backend/tests/test_treatment_plan.py
@@ -1400,8 +1400,9 @@ async def test_odontogram_perform_first_cancels_pending_sessions(
         treatment_id = next(
             i["treatment_id"] for i in item_resp.json()["data"]["items"] if i["id"] == item_id
         )
-        # The handler opens its own DB connection — commit the shared test
-        # session so the planned item is visible to it.
+        # The plan handler runs on the publisher's session now (ADR 0019), so
+        # it sees uncommitted rows; the commit only keeps the identity map of
+        # the shared test session honest for the assertions below.
         await db_session.commit()
         r = await client.patch(
             f"/api/v1/odontogram/treatments/{treatment_id}/perform",

--- a/docs/adr/0019-transactional-event-handlers.md
+++ b/docs/adr/0019-transactional-event-handlers.md
@@ -80,7 +80,7 @@ First users: `payments` publishes `payment.allocated` and
   its second connection couldn't see), `notifications` never queued the
   welcome message for a patient created through the API, and
   `budget.superseded` had already been worked around by committing before
-  publishing. 24 handlers moved to the transactional contract; the rest are
+  publishing. 23 handlers moved to the transactional contract; the rest are
   payload-only or fire after the publisher commits, and say so in their
   docstring. Three workarounds (`SKIP LOCKED`, the commit-first publish, a
   lock-avoidance flag rationale) went away with them.

--- a/docs/adr/0019-transactional-event-handlers.md
+++ b/docs/adr/0019-transactional-event-handlers.md
@@ -74,8 +74,16 @@ First users: `payments` publishes `payment.allocated` and
   introspection; a typo (`session`) silently downgrades the handler to
   own-session. Reviewers check the signature when a handler is meant
   to be transactional.
-- Existing own-session handlers may carry the same latent bug (reading
-  before commit). Audited separately — see issue #183.
+- Existing own-session handlers carried the same latent bug. The audit
+  (issue #183) found three instances of it, two of them live and silent:
+  `recalls` could never link a recall to a new appointment (FK to a row
+  its second connection couldn't see), `notifications` never queued the
+  welcome message for a patient created through the API, and
+  `budget.superseded` had already been worked around by committing before
+  publishing. 24 handlers moved to the transactional contract; the rest are
+  payload-only or fire after the publisher commits, and say so in their
+  docstring. Three workarounds (`SKIP LOCKED`, the commit-first publish, a
+  lock-avoidance flag rationale) went away with them.
 
 ## Alternatives considered
 
@@ -98,6 +106,9 @@ First users: `payments` publishes `payment.allocated` and
 - `grep -rn "async_session_maker" backend/app/modules/*/events.py`
   lists own-session handlers; any of them that reads publisher-written
   rows is a candidate for `db`.
+- `test_every_publisher_of_a_transactional_event_passes_db` (same file)
+  walks the registry and every publish site in `app/`, so a publisher
+  that forgets `db=` fails CI instead of raising in production.
 
 ## References
 

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -209,7 +209,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.BUDGET_ACCEPTED`
 - **Publishers:**
-  - `budget` — `backend/app/modules/budget/workflow.py:316`
+  - `budget` — `backend/app/modules/budget/workflow.py:317`
 - **Subscribers:**
   - `notifications`
   - `patient_timeline`
@@ -233,7 +233,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.BUDGET_EXPIRED`
 - **Publishers:**
-  - `budget` — `backend/app/modules/budget/workflow.py:519`
+  - `budget` — `backend/app/modules/budget/workflow.py:520`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -241,7 +241,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.BUDGET_REJECTED`
 - **Publishers:**
-  - `budget` — `backend/app/modules/budget/workflow.py:394`
+  - `budget` — `backend/app/modules/budget/workflow.py:396`
 - **Subscribers:**
   - `patient_timeline`
   - `treatment_plan`
@@ -250,7 +250,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.BUDGET_REMINDER_SENT`
 - **Publishers:**
-  - `budget` — `backend/app/modules/budget/workflow.py:655`
+  - `budget` — `backend/app/modules/budget/workflow.py:657`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -258,7 +258,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.BUDGET_RENEGOTIATED`
 - **Publishers:**
-  - `budget` — `backend/app/modules/budget/workflow.py:600`
+  - `budget` — `backend/app/modules/budget/workflow.py:601`
 - **Subscribers:**
   - `patient_timeline`
   - `treatment_plan`
@@ -276,7 +276,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.BUDGET_SUPERSEDED`
 - **Publishers:**
-  - `budget` — `backend/app/modules/budget/router.py:570`
+  - `budget` — `backend/app/modules/budget/router.py:564`
 - **Subscribers:**
   - `treatment_plan`
 
@@ -284,7 +284,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.BUDGET_VIEWED`
 - **Publishers:**
-  - `budget` — `backend/app/modules/budget/workflow.py:628`
+  - `budget` — `backend/app/modules/budget/workflow.py:630`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -409,7 +409,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.EMAIL_FAILED`
 - **Publishers:**
-  - `notifications` — `backend/app/modules/notifications/gateway.py:562`
+  - `notifications` — `backend/app/modules/notifications/gateway.py:565`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -417,7 +417,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.EMAIL_SENT`
 - **Publishers:**
-  - `notifications` — `backend/app/modules/notifications/gateway.py:560`
+  - `notifications` — `backend/app/modules/notifications/gateway.py:563`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -546,28 +546,28 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.NOTIFICATION_DELIVERED`
 - **Publishers:**
-  - `notifications` — `backend/app/modules/notifications/gateway.py:322`
+  - `notifications` — `backend/app/modules/notifications/gateway.py:326`
 - **Subscribers:** —
 
 ### `notification.failed`
 
 - **Constant:** `EventType.NOTIFICATION_FAILED`
 - **Publishers:**
-  - `notifications` — `backend/app/modules/notifications/gateway.py:292`
+  - `notifications` — `backend/app/modules/notifications/gateway.py:296`
 - **Subscribers:** —
 
 ### `notification.queued`
 
 - **Constant:** `EventType.NOTIFICATION_QUEUED`
 - **Publishers:**
-  - `notifications` — `backend/app/modules/notifications/gateway.py:191`
+  - `notifications` — `backend/app/modules/notifications/gateway.py:195`
 - **Subscribers:** —
 
 ### `notification.reply_received`
 
 - **Constant:** `EventType.NOTIFICATION_REPLY_RECEIVED`
 - **Publishers:**
-  - `notifications` — `backend/app/modules/notifications/gateway.py:382`
+  - `notifications` — `backend/app/modules/notifications/gateway.py:386`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -575,7 +575,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.NOTIFICATION_SENT`
 - **Publishers:**
-  - `notifications` — `backend/app/modules/notifications/gateway.py:279`
+  - `notifications` — `backend/app/modules/notifications/gateway.py:283`
 - **Subscribers:** —
 
 ### `odontogram.condition.changed`
@@ -635,7 +635,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.PATIENT_ARCHIVED`
 - **Publishers:**
-  - `patients` — `backend/app/modules/patients/service.py:289`
+  - `patients` — `backend/app/modules/patients/service.py:290`
 - **Subscribers:**
   - `media`
   - `periodontogram`
@@ -661,7 +661,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.PATIENT_UPDATED`
 - **Publishers:**
-  - `patients` — `backend/app/modules/patients/service.py:274`
+  - `patients` — `backend/app/modules/patients/service.py:275`
 - **Subscribers:** —
 
 ### `payment.allocated`
@@ -750,7 +750,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_BUDGET_SYNC_REQUESTED`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1292`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1294`
 - **Subscribers:**
   - `budget`
 
@@ -758,7 +758,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_CLOSED`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1774`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1777`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -766,7 +766,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_CONFIRMED`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1634`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1637`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -782,7 +782,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_ITEM_COMPLETED_WITHOUT_NOTE`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1002`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1004`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -790,7 +790,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_ITEM_SESSION_COMPLETED`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:895`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:897`
 - **Subscribers:**
   - `payments`
 
@@ -798,14 +798,14 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_ITEMS_REORDERED`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:755`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:756`
 - **Subscribers:** —
 
 ### `treatment_plan.reactivated`
 
 - **Constant:** `EventType.TREATMENT_PLAN_REACTIVATED`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1820`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:1823`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -828,8 +828,8 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_TREATMENT_COMPLETED`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/events.py:88`
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:987`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/events.py:100`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:989`
 - **Subscribers:**
   - `patient_timeline`
   - `recalls`
@@ -838,7 +838,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.TREATMENT_PLAN_TREATMENT_REMOVED`
 - **Publishers:**
-  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:819`
+  - `treatment_plan` — `backend/app/modules/treatment_plan/service.py:820`
 - **Subscribers:**
   - `budget`
 

--- a/docs/technical/agenda/events.md
+++ b/docs/technical/agenda/events.md
@@ -43,7 +43,9 @@ Payloads carry `clinic_id`, `appointment_id`, and (where relevant)
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, **after the DB commit succeeds**.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add the row to the table above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.

--- a/docs/technical/budget/events.md
+++ b/docs/technical/budget/events.md
@@ -28,17 +28,24 @@ treatment_plan models (ADR 0003). It is `null` for standalone budgets.
 
 ## Subscribed
 
+All three run **transactionally** (ADR 0019): they declare `db` and mirror
+the plan inside the publisher's transaction, so a failed mirror fails the
+request instead of quietly dropping a line (issue #183).
+
 | Event | Handler | Effect |
 |-------|---------|--------|
-| `odontogram.treatment.performed` | `__init__.py` → `BudgetService.on_treatment_performed` | Mark matching line items done. |
 | `treatment_plan.budget_sync_requested` | `__init__.py::_on_sync_requested` | Rebuild draft-budget lines from the snapshot payload. |
 | `treatment_plan.treatment_added` | `__init__.py::_on_treatment_added_to_plan` | Add matching line to the linked draft budget (no-op on non-draft). |
 | `treatment_plan.treatment_removed` | `__init__.py::_on_treatment_removed_from_plan` | Remove matching line from the linked draft budget. |
 
+`odontogram.treatment.performed` used to appear here; the handler was a
+`pass` placeholder and was removed in #183.
+
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, after the DB commit succeeds.
+2. Publish from a service method, after `flush` — and pass `db=db` so
+   transactional subscribers can join the transaction (ADR 0019).
 3. Add the row to the table(s) above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.

--- a/docs/technical/catalog/events.md
+++ b/docs/technical/catalog/events.md
@@ -21,7 +21,9 @@ _This module does not publish any events._
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, after the DB commit succeeds.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add the row to the table(s) above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.

--- a/docs/technical/clinical_notes/events.md
+++ b/docs/technical/clinical_notes/events.md
@@ -38,7 +38,9 @@ returns `{}`).
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, **after the DB commit succeeds**.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add the row to the table above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.

--- a/docs/technical/copilot/events.md
+++ b/docs/technical/copilot/events.md
@@ -29,5 +29,7 @@ in v1. (Every tool call is already recorded in `agent_audit_logs`.)
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from the router/service after the DB commit succeeds.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add a row above and re-run `python backend/scripts/generate_catalogs.py`.

--- a/docs/technical/creating-modules.md
+++ b/docs/technical/creating-modules.md
@@ -734,6 +734,42 @@ bus raises `RuntimeError` at publish time. Reference implementation:
 `payments` publishes `payment.allocated` / `payment.refunded` with `db`,
 `billing/events.py` consumes them transactionally.
 
+**Which one does your handler need?** (audit of every handler: issue #183)
+
+Ask: *does it read or write state that depends on what the publisher just
+wrote in this request?*
+
+- **Yes, and it must be atomic** — money, counters, cross-module links, a
+  status derived from the publisher's rows, or **any FK pointing at a row
+  the publisher just created**. Transactional. An own-session handler
+  cannot even insert that FK: the referenced row is invisible from a second
+  connection and Postgres rejects the write.
+- **Yes, but eventual is fine** — timeline entries, cache warmers. Either
+  read *only what the payload carries* (snapshot pattern — see
+  `patient_timeline/events.py`) or go transactional. Say which in the
+  docstring.
+- **No** — payload-only, sends an email, schedules a job. Own-session, with
+  a one-line docstring note saying so.
+
+Three more rules that fall out of the audit:
+
+- **A transactional handler that publishes forwards its session**:
+  `await event_bus.publish(type, payload, db=db)`. Otherwise the chain
+  silently drops back to own-session halfway through.
+- **Best-effort work goes in a savepoint.** A transactional handler's
+  exception rolls back the publisher's request — right for money, wrong for
+  a notification. Wrap the body in `async with db.begin_nested():` and log
+  the failure: the work still rolls back with the request, but a failure
+  can't take the request down. See `notifications/handlers.py`.
+- **Don't commit in a service another module's handler may call.** Flush and
+  let the session's owner commit (`get_db` in a request, the scheduler job
+  in a cron). A commit inside a transactional handler commits the
+  publisher's half-finished transaction.
+
+`backend/tests/test_event_bus_transactional.py` walks every registered
+handler and every `event_bus.publish` in `app/`, and fails CI when a
+publisher of a transactionally-consumed event forgets `db=`.
+
 ### FK cross-module
 
 Allowed **only** when the target module is in `depends`. A CI

--- a/docs/technical/media/events.md
+++ b/docs/technical/media/events.md
@@ -16,14 +16,16 @@ _This module does not publish any events._
 
 ## Subscribed
 
-| Event | Handler | Effect |
-|-------|---------|--------|
-| `patient.archived` | _Handler module path._ | _What it does in response._ |
+| Event | Handler | Mode | Effect |
+|-------|---------|------|--------|
+| `patient.archived` | `__init__.py::MediaModule._on_patient_archived` | transactional (ADR 0019) | Soft-archive the patient's documents, atomically with the archive itself. |
 
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, after the DB commit succeeds.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add the row to the table(s) above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.

--- a/docs/technical/notifications/events.md
+++ b/docs/technical/notifications/events.md
@@ -25,6 +25,10 @@ Published by the gateway (`gateway.py`) across the outbox lifecycle:
 
 ## Subscribed
 
+All six are **transactional** (ADR 0019): they queue a `CommunicationMessage`
+on the publisher's session inside a savepoint, and the outbox tick does the
+sending. A rolled-back request queues nothing (issue #183).
+
 | Event | Handler | Effect |
 |-------|---------|--------|
 | `appointment.scheduled` | `handlers.on_appointment_scheduled` | Enqueue `appointment_confirmation`. |
@@ -37,7 +41,9 @@ Published by the gateway (`gateway.py`) across the outbox lifecycle:
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, after the DB commit succeeds.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add the row to the table(s) above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.

--- a/docs/technical/odontogram/events.md
+++ b/docs/technical/odontogram/events.md
@@ -43,7 +43,9 @@ returns `{}`; plan→treatment propagation lives in
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, **after the DB commit succeeds**.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add the row to the table above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.

--- a/docs/technical/patient_timeline/events.md
+++ b/docs/technical/patient_timeline/events.md
@@ -16,6 +16,11 @@ _This module does not publish any events._
 
 ## Subscribed
 
+Every handler goes through `events.py::_record` and is deliberately
+**own-session and payload-only** (ADR 0019, issue #183): the timeline
+records what the payload carries, never re-reads the publisher's rows, and
+must never be able to fail the event it is logging.
+
 | Event | Handler | Effect |
 |-------|---------|--------|
 | `agenda.visit_note_updated` | _Handler module path._ | _What it does in response._ |
@@ -56,7 +61,9 @@ _This module does not publish any events._
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, after the DB commit succeeds.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add the row to the table(s) above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.

--- a/docs/technical/patients/events.md
+++ b/docs/technical/patients/events.md
@@ -25,7 +25,9 @@ This module does not subscribe to any events.
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, after the DB commit succeeds.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add a row to the table above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the global
    catalog.

--- a/docs/technical/patients_clinical/events.md
+++ b/docs/technical/patients_clinical/events.md
@@ -26,7 +26,9 @@ _This module does not subscribe to any events._
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, **after the DB commit succeeds**.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add the row to the table above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.

--- a/docs/technical/payments/events.md
+++ b/docs/technical/payments/events.md
@@ -22,6 +22,10 @@ payments never reads it (billing uses `context.prefer_invoice_id`).
 
 ## Subscribed
 
+Both are **transactional** (ADR 0019): revenue is booked in the same
+transaction as the treatment that earned it, so a failed request cannot
+leave an orphan entry behind (issue #183).
+
 | Event | Handler | Effect |
 |-------|---------|--------|
 | `odontogram.treatment.performed` | `payments/events.py::on_treatment_performed` | Upserts one `PatientEarnedEntry` with `source_session_id = NULL` for the event's `unit_price`. Skips when `unit_price` is `null` — that means the revenue was already attributed per-session (see below). |

--- a/docs/technical/periodontogram/events.md
+++ b/docs/technical/periodontogram/events.md
@@ -38,7 +38,9 @@ react to in-progress drafts.
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`)
    if a new event type is required.
-2. Publish from a service method, after the DB commit succeeds.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add a row to the table above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.

--- a/docs/technical/recalls/events.md
+++ b/docs/technical/recalls/events.md
@@ -16,18 +16,24 @@ _This module does not publish any events._
 
 ## Subscribed
 
-| Event | Handler | Effect |
-|-------|---------|--------|
-| `appointment.cancelled` | _Handler module path._ | _What it does in response._ |
-| `appointment.completed` | _Handler module path._ | _What it does in response._ |
-| `appointment.scheduled` | _Handler module path._ | _What it does in response._ |
-| `patient.archived` | _Handler module path._ | _What it does in response._ |
-| `treatment_plan.treatment_completed` | _Handler module path._ | _What it does in response._ |
+All four state-changing handlers are **transactional** (ADR 0019): a recall
+mirrors an appointment, and `linked_appointment_id` is an FK to a row that
+only exists in the publisher's transaction (issue #183).
+
+| Event | Handler | Mode | Effect |
+|-------|---------|------|--------|
+| `appointment.scheduled` | `events.on_appointment_scheduled` | transactional | Auto-link the single matching pending recall (bails out when ambiguous). |
+| `appointment.completed` | `events.on_appointment_completed` | transactional | Mark the linked recall done. |
+| `appointment.cancelled` | `events.on_appointment_cancelled` | transactional | Unlink and send the recall back to `pending`. |
+| `patient.archived` | `events.on_patient_archived` | transactional | Move active recalls to `needs_review`. |
+| `treatment_plan.treatment_completed` | `events.on_treatment_plan_completed` | own-session (payload-only) | Logs only — suggestions are pulled by the frontend. |
 
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, after the DB commit succeeds.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add the row to the table(s) above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.

--- a/docs/technical/treatment_plan/events.md
+++ b/docs/technical/treatment_plan/events.md
@@ -31,12 +31,16 @@ resulting `odontogram.treatment.performed` carries `unit_price: null`
 
 ## Subscribed
 
+Every handler is **transactional** (ADR 0019): it declares `db` and runs in
+the publisher's session, so plan and budget move together or not at all
+(issue #183).
+
 | Event | Handler | Effect |
 |-------|---------|--------|
 | `appointment.completed` | `events.py::on_appointment_completed` | Mark planned items as performed if linked. |
 | `budget.accepted` | `events.py::on_budget_accepted` | pending → active; also closed(`rejected_by_patient`) → active when the patient accepts a resent version (issue #162). On either transition the item's **pending** sessions are rescaled to the payload's `items[].net_amount` (matched by `treatment_id`) so the earned ledger books the discounted price the patient signed (issue #167). Idempotent (already-active plans are left untouched). |
 | `budget.rejected` | `events.py::on_budget_rejected` | pending → closed (`closure_reason=rejected_by_patient`). |
-| `budget.renegotiated` | `events.py::on_budget_renegotiated` | pending → draft via `reopen_from_budget` (never writes the budget row — the publisher's open transaction holds it locked). |
+| `budget.renegotiated` | `events.py::on_budget_renegotiated` | pending → draft via `reopen_from_budget` (never writes the budget row — the publisher is already cancelling it, and an echoed `budget.cancelled` would loop back here). |
 | `budget.cancelled` | `events.py::on_budget_cancelled` | pending → draft via `reopen_from_budget` (issue #162). No-op without `plan_id` (standalone budget). |
 | `budget.superseded` | `events.py::on_budget_superseded` | Repoint `plan.budget_id` to the resent version — only while the plan still points at the superseded budget (idempotent). Status untouched. |
 | `odontogram.treatment.performed` | `events.py::on_treatment_performed` | Mark the matching pending item completed **and cancel its pending sessions** (no session events) — the performed event already carried the full price to payments; a later session completion would book the same money twice. |
@@ -44,7 +48,9 @@ resulting `odontogram.treatment.performed` carries `unit_price: null`
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, after the DB commit succeeds.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add the row to the table(s) above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.

--- a/docs/technical/verifactu/events.md
+++ b/docs/technical/verifactu/events.md
@@ -23,7 +23,9 @@ _This module does not publish any events._
 ## Adding a new event
 
 1. Add the constant to `backend/app/core/events/types.py` (`EventType`).
-2. Publish from a service method, after the DB commit succeeds.
+2. Publish from a service method after `flush()` — the bus runs handlers
+   inline, *before* the request commits. Pass `db=db` so transactional
+   subscribers can join the transaction (ADR 0019, issue #183).
 3. Add the row to the table(s) above.
 4. Run `python backend/scripts/generate_catalogs.py` to refresh the
    global catalog.


### PR DESCRIPTION
Closes #183. Stacked on PR A (phases 1–3) — review that one first.

Phases 4–6 of the own-session handler audit: the last 16 handlers, and the documentation that had been teaching the mistake.

## The plan ↔ budget family (10 handlers)

`treatment_plan` (7) and `budget` (3) now run in the publisher's transaction. Three workarounds that existed *only* because they didn't could go:

- **`SKIP LOCKED`** in `on_treatment_performed`. The handler opened a second session and blocked on the row the publisher — which was awaiting it inline — already held. It had to skip past its own work to avoid deadlocking. Sharing the session shares the locks, and the publisher's flushed `status='completed'` filters the row out anyway.
- **The commit-first publish of `budget.superseded`**, documented in three places as "the sole deviation from the publish-before-commit pattern". `treatment_plans.budget_id` is an FK to a row that only exists inside the publisher's transaction; in-tx it is visible, so the deviation is gone and the event publishes like every other one.
- **The lock rationale on `cancel_budget(publish_event=False)`**. The flag stays — an echoed `budget.cancelled` would send the plan through a reopen it is already performing — but the comment no longer describes a deadlock that cannot happen.

`on_appointment_completed` was reading `completed_in_appointment` flags the publisher had only flushed, so from a second session it saw the pre-visit values and closed nothing.

Failures now reach the publisher instead of a log line: an accepted budget whose plan cannot activate rolls the acceptance back. The new test sees the request succeed with the two modules out of sync on `main`.

## notifications (6 handlers)

They fired `asyncio.create_task` at a worker that opened a fresh session and re-read the row the event was about — a race against the request's commit. `patient.created` lost it every time: the patient was invisible from the second connection, so the handler returned early and **the welcome message was never queued** (`CommunicationMessage.patient_id` is an FK to that same invisible row).

They never sent anything themselves — `enqueue` writes a row and the scheduler's `dispatch_outbox` tick owns the network I/O — so there was nothing to keep off the request. Twelve methods collapse to six.

Each body runs in a **savepoint** (`db.begin_nested()`, the pattern `migration_import` already uses): queueing must not be able to fail the appointment it announces, but an error still has to unwind cleanly or the publisher's transaction would be left unusable. A rolled-back request queues nothing, which is the point.

`enqueue` / `_skip` flush instead of committing — the session's owner decides when the message becomes real. The two scheduler jobs that own their session commit explicitly.

## Docs

Fourteen per-module `events.md` files told authors to "publish from a service method, **after the DB commit succeeds**". Publishers have always published after `flush`, before the request commits — that gap is the whole bug class. Fixed, along with:

- each module's Subscribed table now states the mode its handlers run in and why (transactional where the reaction must be atomic; own-session where it must not be able to fail what it reacts to — `patient_timeline` logs, `copilot` nudges, the four `clinic.created` seeders, which are the one event published *after* its publisher commits);
- `creating-modules.md` §6 gains the decision tree, the forward-your-`db` rule, the savepoint pattern, and "don't commit in a service another module's handler may call";
- ADR 0019 records the outcome;
- CHANGELOG entries for the 13 touched modules, catalogs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
