### PR TITLE
ci(frontend): make module layers type-checkable (infra for #184)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,25 +321,7 @@ jobs:
         # the host-run Nuxt dev server we regenerate it with absolute
         # host paths pointing at `backend/app/modules/<name>/frontend`.
         working-directory: frontend
-        run: |
-          python3 - <<'PY'
-          import json, os
-          from pathlib import Path
-          root = Path(os.environ["GITHUB_WORKSPACE"])
-          modules_dir = root / "backend/app/modules"
-          entries = []
-          for m in sorted(modules_dir.iterdir()):
-              layer = m / "frontend"
-              if layer.is_dir():
-                  entries.append({"name": m.name, "path": str(layer.resolve())})
-          Path("modules.json").write_text(
-              json.dumps(
-                  {"layers": [e["path"] for e in entries], "modules": entries, "version": 1},
-                  indent=2,
-              )
-          )
-          PY
-          cat modules.json
+        run: node scripts/modules-json.mjs "$GITHUB_WORKSPACE/backend/app/modules"
 
       - name: Start Nuxt dev in background
         working-directory: frontend

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ docker-compose up
 docker-compose exec backend python -m pytest -v
 cd backend && ruff check . && ruff format --check .
 cd frontend && npm run lint
+cd frontend && npm run typecheck:layers && git checkout modules.json   # vue-tsc over host + all module layers (stop the frontend container first)
 
 # Reset DB + reseed demo data (use after tests wipe tables)
 ./scripts/reset-db.sh        # drop, alembic upgrade heads

--- a/docs/technical/creating-modules.md
+++ b/docs/technical/creating-modules.md
@@ -579,13 +579,29 @@ and namespace every top-level key under your module name
 (e.g. `"inventory": { "nav": { "items": "Items" } }`) to avoid
 collisions with the host and with other modules.
 
-TypeScript aliases inside layer files: `~` resolves per-layer, so use
-`~~` (rootDir, = host frontend root) to reach shared types:
+TypeScript aliases inside layer files: `~~` (rootDir, = host frontend
+root) reaches shared host code. `~` is a trap: Vite rewrites it to the
+layer at build time (`nuxt:layer-aliasing`), but `vue-tsc` maps it to
+the host `frontend/app`, so `~/composables/useFoo` type-checks against
+a file that does not exist. Use **relative imports** for sibling files
+inside your layer and `~~/app/...` for the host:
 
 ```ts
 import type { Patient } from '~~/app/types'
 import { PERMISSIONS } from '~~/app/config/permissions'
+import { useInventory } from '../composables/useInventory'   // sibling in the layer
 ```
+
+Type-check the host plus every layer before opening a PR — CI runs the
+same command (`frontend-typecheck`):
+
+```bash
+cd frontend && npm run typecheck:layers && git checkout modules.json
+```
+
+It rewrites `modules.json` to list every `module_layers/*/frontend`
+(the symlink ESLint uses), so stop the dev frontend container first —
+it watches that file and restarts on change.
 
 ### Backend-driven navigation
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -16,11 +16,7 @@ COPY frontend/ ./
 # dev checkout's installed set; a prod image can't rebuild when a module
 # is installed later, so ship all layers and let the backend's
 # `/modules/-/active` decide what is visible at runtime.
-RUN node -e 'const fs=require("fs");\
-  const names=fs.readdirSync("/module_layers").filter(n=>fs.existsSync(`/module_layers/${n}/frontend/nuxt.config.ts`)).sort();\
-  const modules=names.map(name=>({name,path:`/module_layers/${name}/frontend`}));\
-  fs.writeFileSync("modules.json",JSON.stringify({layers:modules.map(m=>m.path),modules,version:1},null,2));\
-  console.log("modules.json:",names.join(", "))'
+RUN node scripts/modules-json.mjs /module_layers
 
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,6 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { isAbsolute, join, resolve } from 'node:path'
 
 /**
  * Load Nuxt Layer paths from `modules.json`.
@@ -29,6 +29,13 @@ function loadModuleLayers(): { layers: string[], names: string[] } {
 
 const { layers: moduleLayers, names: moduleLayerNames } = loadModuleLayers()
 const modulesJsonPath = resolve(__dirname, 'modules.json')
+// Layers referenced by a path inside this directory (`./module_layers/...`,
+// the symlink CI and ESLint use). Nuxt only auto-includes layers that live
+// outside rootDir or under `layers/*/app` in the generated tsconfig, so
+// without an explicit include `nuxt typecheck` silently skips every layer
+// page. Absolute paths (the Docker mount) are outside rootDir and already
+// included by Nuxt itself.
+const localLayers = moduleLayers.filter(layer => !isAbsolute(layer))
 
 export default defineNuxtConfig({
 
@@ -107,6 +114,14 @@ export default defineNuxtConfig({
         '@vue/devtools-core',
         '@vue/devtools-kit'
       ]
+    }
+  },
+
+  typescript: {
+    tsConfig: {
+      include: localLayers.map(layer => join('..', layer, '**/*')),
+      // Layer nuxt.config files belong to the node tsconfig, not the app one.
+      exclude: localLayers.map(layer => join('..', layer, 'nuxt.config.*'))
     }
   },
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint . module_layers",
     "lint:fix": "eslint . module_layers --fix",
     "typecheck": "nuxt typecheck",
+    "typecheck:layers": "node scripts/modules-json.mjs ./module_layers && nuxt typecheck",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",

--- a/frontend/scripts/modules-json.mjs
+++ b/frontend/scripts/modules-json.mjs
@@ -1,0 +1,25 @@
+// Write `modules.json` listing every module layer under <layers-root>.
+//
+//   node scripts/modules-json.mjs <layers-root>
+//
+// The backend regenerates this file at runtime as modules are installed;
+// build/CI contexts have no backend, so they bake every layer instead:
+//   Dockerfile.prod  → /module_layers            (COPY of backend/app/modules)
+//   CI e2e           → $GITHUB_WORKSPACE/backend/app/modules
+//   CI typecheck     → ./module_layers           (symlink, same trick as ESLint)
+import { existsSync, readdirSync, writeFileSync } from 'node:fs'
+
+const root = process.argv[2]
+if (!root) {
+  console.error('usage: node scripts/modules-json.mjs <layers-root>')
+  process.exit(1)
+}
+const names = readdirSync(root)
+  .filter(name => existsSync(`${root}/${name}/frontend/nuxt.config.ts`))
+  .sort()
+const modules = names.map(name => ({ name, path: `${root}/${name}/frontend` }))
+writeFileSync(
+  'modules.json',
+  JSON.stringify({ layers: modules.map(m => m.path), modules, version: 1 }, null, 2) + '\n'
+)
+console.log('modules.json:', names.join(', '))


### PR DESCRIPTION
Part 1/7 of #184. Infra only — the CI gate flips in the last PR of the series once the layer fixes land.

## Why
`nuxt typecheck` never covered module layers: `@nuxt/kit` only auto-includes layers living outside `rootDir` or under `layers/*/app`, so with the `./module_layers/*/frontend` symlink every layer **page** was silently outside the TS program (only files reached through `components.d.ts`/`imports.d.ts` were checked). Absolute out-of-root paths (what the e2e job uses) include pages but then bare imports inside layers (`marked`, `@nuxt/ui`…) can't resolve — no `node_modules` above `backend/app/modules`. Reproduced: the issue's 163 errors are 272 once pages are in.

## What
- `nuxt.config.ts`: `typescript.tsConfig.include/exclude` for in-root layers (nuxt.config.* of each layer excluded — they belong to the node tsconfig).
- `scripts/modules-json.mjs`: one generator for the three places that inlined it (`Dockerfile.prod`, e2e job, and the typecheck job).
- `npm run typecheck:layers` (rewrites `modules.json`, so stop the dev frontend container first — it watches that file).
- `docs/technical/creating-modules.md`: `~` is per-layer only in Vite (`nuxt:layer-aliasing`); vue-tsc maps it to the host → sibling imports must be relative. `CLAUDE.md` quick start line.

## Verified
- Scratchpad copy of `frontend/` + this config + all 22 layers: pages included, bare imports resolve, layer `nuxt.config.ts` not pulled in → 272 errors (definitive list, fixed in PRs 2–6).
- `frontend/scripts/` survives the root `.dockerignore` (`scripts/` only matches the root dir) — checked with a throwaway image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)