### PR TITLE
fix(treatment_plan): type-check clean under nuxt typecheck (#184)

### DIFF
--- a/backend/app/modules/treatment_plan/CHANGELOG.md
+++ b/backend/app/modules/treatment_plan/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- fix(#184): the layer type-checks clean under `nuxt typecheck`. Real
+  bugs behind the type errors: `TreatmentPlanStatus` now matches the API
+  (`pending`/`closed` instead of the phantom `cancelled`), toasts use
+  Nuxt UI v4 semantic colours (`error`/`success` — they rendered
+  uncoloured), `TreatmentPlanResponse` exposes `closure_reason` /
+  `closure_note` / `closed_at` (the reactivate dialog read `undefined`),
+  `TreatmentBrief` exposes `notes` (migrated treatments' legacy label was
+  never shown), and `PlansMode` "activate" no longer calls an
+  out-of-scope helper.
 - fix(#183): the seven event handlers are transactional (ADR 0019). `on_appointment_completed` was reading `completed_in_appointment` flags the publisher had only flushed, so it closed nothing. The `SKIP LOCKED` in `on_treatment_performed` is gone — it only existed to dodge a deadlock between the handler's own session and the publisher awaiting it.
 - fix(sessions): accepting a quote now reprices the plan's pending
   sessions to the accepted line amounts (line + global discount, ex-tax),

--- a/backend/app/modules/treatment_plan/frontend/components/clinical/PlanDetailView.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/clinical/PlanDetailView.vue
@@ -17,7 +17,7 @@ import ReopenPlanModal from './modals/ReopenPlanModal.vue'
 import ClosePlanModal from './modals/ClosePlanModal.vue'
 import ReactivatePlanModal from './modals/ReactivatePlanModal.vue'
 import ContactLogModal from './modals/ContactLogModal.vue'
-import { itemEffectivePrice } from '~/composables/useTreatmentPlans'
+import { itemEffectivePrice } from '../../composables/useTreatmentPlans'
 
 const props = withDefaults(defineProps<{
   plan: TreatmentPlanDetail

--- a/backend/app/modules/treatment_plan/frontend/components/clinical/PlanTreatmentList.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/clinical/PlanTreatmentList.vue
@@ -14,7 +14,7 @@ import { VueDraggable } from 'vue-draggable-plus'
 import CompletionNudgeModal from './notes/CompletionNudgeModal.vue'
 import PlanItemDoctorChip from './PlanItemDoctorChip.vue'
 import PlanItemSessionRow from '../treatment-plans/PlanItemSessionRow.vue'
-import { itemCatalogPrice, itemEffectivePrice } from '~/composables/useTreatmentPlans'
+import { itemCatalogPrice, itemEffectivePrice } from '../../composables/useTreatmentPlans'
 
 const props = defineProps<{
   items: PlannedTreatmentItem[]

--- a/backend/app/modules/treatment_plan/frontend/components/clinical/PlansMode.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/clinical/PlansMode.vue
@@ -186,7 +186,7 @@ watch(() => props.initialPlanId, (newId) => {
       :patient-id="patientId"
       :readonly="readonly"
       @updated="handlePlanUpdated"
-      @activate="fetchPatientPlans(patientId)"
+      @activate="loadPatientPlans()"
       @generate-budget="handleDetailGenerateBudget"
       @schedule="router.push(`/appointments?patient_id=${patientId}`)"
       @cancelled="handlePlanCancelled"

--- a/backend/app/modules/treatment_plan/frontend/components/clinical/modals/ClosePlanModal.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/clinical/modals/ClosePlanModal.vue
@@ -24,7 +24,7 @@ const REASONS = [
   'other'
 ] as const
 
-const reason = ref<string>('cancelled_by_clinic')
+const reason = ref<typeof REASONS[number]>('cancelled_by_clinic')
 const note = ref('')
 
 const reasonOptions = computed(() =>

--- a/backend/app/modules/treatment_plan/frontend/components/clinical/modals/ContactLogModal.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/clinical/modals/ContactLogModal.vue
@@ -19,7 +19,7 @@ const { t } = useI18n()
 
 const CHANNELS = ['call', 'whatsapp', 'email', 'in_person', 'other'] as const
 
-const channel = ref<string>('call')
+const channel = ref<typeof CHANNELS[number]>('call')
 const note = ref('')
 
 const channelLabels: Record<string, string> = {

--- a/backend/app/modules/treatment_plan/frontend/components/treatment-plans/PipelineTabPanel.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/treatment-plans/PipelineTabPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import type { PipelineRow, PipelineTab } from '~/composables/usePipeline'
+import type { PipelineRow, PipelineTab } from '../../composables/usePipeline'
+import type { UiColor } from '~~/app/config/severity'
 
 const props = defineProps<{
   tab: PipelineTab
@@ -62,7 +63,7 @@ function formatDate(iso: string | null): string {
   }
 }
 
-function statusBadgeColor(status: string): string {
+function statusBadgeColor(status: string): UiColor {
   switch (status) {
     case 'draft':
       return 'neutral'

--- a/backend/app/modules/treatment_plan/frontend/components/treatment-plans/PlansListPanel.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/treatment-plans/PlansListPanel.vue
@@ -23,13 +23,13 @@ const selectedStatuses = ref<TreatmentPlanStatus[]>([])
 const currentPage = ref(1)
 const pageSize = 20
 
-const statusOptions = computed(() => [
-  { label: t('treatmentPlans.status.draft'), value: 'draft' as TreatmentPlanStatus },
-  { label: t('treatmentPlans.status.pending'), value: 'pending' as TreatmentPlanStatus },
-  { label: t('treatmentPlans.status.active'), value: 'active' as TreatmentPlanStatus },
-  { label: t('treatmentPlans.status.completed'), value: 'completed' as TreatmentPlanStatus },
-  { label: t('treatmentPlans.status.closed'), value: 'closed' as TreatmentPlanStatus },
-  { label: t('treatmentPlans.status.archived'), value: 'archived' as TreatmentPlanStatus }
+const statusOptions = computed<{ label: string, value: TreatmentPlanStatus }[]>(() => [
+  { label: t('treatmentPlans.status.draft'), value: 'draft' },
+  { label: t('treatmentPlans.status.pending'), value: 'pending' },
+  { label: t('treatmentPlans.status.active'), value: 'active' },
+  { label: t('treatmentPlans.status.completed'), value: 'completed' },
+  { label: t('treatmentPlans.status.closed'), value: 'closed' },
+  { label: t('treatmentPlans.status.archived'), value: 'archived' }
 ])
 
 async function loadPlans() {

--- a/backend/app/modules/treatment_plan/frontend/components/treatment-plans/TreatmentPlanMiniCard.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/treatment-plans/TreatmentPlanMiniCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { TreatmentPlan, TreatmentPlanStatus } from '~~/app/types'
+import type { UiColor } from '~~/app/config/severity'
 
 const props = defineProps<{
   plan: TreatmentPlan
@@ -24,16 +25,17 @@ const progress = computed(() => {
 })
 
 // Status badge color mapping
-const statusColors: Record<TreatmentPlanStatus, 'success' | 'warning' | 'neutral' | 'info' | 'error'> = {
-  active: 'success',
+const statusColors: Record<TreatmentPlanStatus, UiColor> = {
   draft: 'warning',
+  pending: 'warning',
+  active: 'success',
   completed: 'info',
-  cancelled: 'error',
+  closed: 'error',
   archived: 'neutral'
 }
 
 function getStatusColor(status: TreatmentPlanStatus) {
-  return statusColors[status] || 'neutral'
+  return statusColors[status]
 }
 
 // Format currency — clinic-wide via useCurrency.

--- a/backend/app/modules/treatment_plan/frontend/components/treatment-plans/TreatmentPlanModal.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/treatment-plans/TreatmentPlanModal.vue
@@ -158,7 +158,7 @@ function closeModal() {
 <template>
   <UModal
     v-model:open="isOpen"
-    :ui="{ width: 'sm:max-w-lg' }"
+    :ui="{ content: 'sm:max-w-lg' }"
   >
     <template #content>
       <UCard>

--- a/backend/app/modules/treatment_plan/frontend/components/treatment-plans/TreatmentPlanStatusBadge.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/treatment-plans/TreatmentPlanStatusBadge.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { TreatmentPlanStatus } from '~~/app/types'
+import type { UiColor } from '~~/app/config/severity'
 
 const props = defineProps<{
   status: TreatmentPlanStatus
@@ -8,15 +9,16 @@ const props = defineProps<{
 
 const { t } = useI18n()
 
-const colorMap: Record<TreatmentPlanStatus, string> = {
-  draft: 'gray',
-  active: 'blue',
-  completed: 'green',
-  archived: 'neutral',
-  cancelled: 'red'
+const colorMap: Record<TreatmentPlanStatus, UiColor> = {
+  draft: 'neutral',
+  pending: 'warning',
+  active: 'info',
+  completed: 'success',
+  closed: 'error',
+  archived: 'neutral'
 }
 
-const color = computed(() => colorMap[props.status] || 'gray')
+const color = computed(() => colorMap[props.status])
 const label = computed(() => t(`treatmentPlans.status.${props.status}`))
 </script>
 

--- a/backend/app/modules/treatment_plan/frontend/composables/useTreatmentPlans.ts
+++ b/backend/app/modules/treatment_plan/frontend/composables/useTreatmentPlans.ts
@@ -80,7 +80,7 @@ export function useTreatmentPlans() {
       console.error('Error fetching treatment plans:', error)
       toast.add({
         title: t('errors.loadFailed'),
-        color: 'red'
+        color: 'error'
       })
     } finally {
       loading.value = false
@@ -105,7 +105,7 @@ export function useTreatmentPlans() {
       console.error('Error fetching treatment plan:', error)
       toast.add({
         title: t('errors.loadFailed'),
-        color: 'red'
+        color: 'error'
       })
       return null
     } finally {
@@ -123,14 +123,14 @@ export function useTreatmentPlans() {
       )
       toast.add({
         title: t('treatmentPlans.created'),
-        color: 'green'
+        color: 'success'
       })
       return response.data
     } catch (error) {
       console.error('Error creating treatment plan:', error)
       toast.add({
         title: t('errors.createFailed'),
-        color: 'red'
+        color: 'error'
       })
       return null
     } finally {
@@ -151,14 +151,14 @@ export function useTreatmentPlans() {
       }
       toast.add({
         title: t('treatmentPlans.updated'),
-        color: 'green'
+        color: 'success'
       })
       return response.data
     } catch (error) {
       console.error('Error updating treatment plan:', error)
       toast.add({
         title: t('errors.updateFailed'),
-        color: 'red'
+        color: 'error'
       })
       return null
     } finally {
@@ -179,14 +179,14 @@ export function useTreatmentPlans() {
       }
       toast.add({
         title: t('treatmentPlans.statusUpdated'),
-        color: 'green'
+        color: 'success'
       })
       return response.data
     } catch (error) {
       console.error('Error updating plan status:', error)
       toast.add({
         title: t('errors.updateFailed'),
-        color: 'red'
+        color: 'error'
       })
       return null
     } finally {
@@ -205,14 +205,14 @@ export function useTreatmentPlans() {
       }
       toast.add({
         title: t('treatmentPlans.deleted'),
-        color: 'green'
+        color: 'success'
       })
       return true
     } catch (error) {
       console.error('Error deleting treatment plan:', error)
       toast.add({
         title: t('errors.deleteFailed'),
-        color: 'red'
+        color: 'error'
       })
       return false
     } finally {
@@ -236,7 +236,7 @@ export function useTreatmentPlans() {
       console.error('Error adding treatment item:', error)
       toast.add({
         title: t('errors.createFailed'),
-        color: 'red'
+        color: 'error'
       })
       return null
     } finally {
@@ -267,7 +267,7 @@ export function useTreatmentPlans() {
       console.error('Error updating treatment item:', error)
       toast.add({
         title: t('errors.updateFailed'),
-        color: 'red'
+        color: 'error'
       })
       return null
     } finally {
@@ -304,7 +304,7 @@ export function useTreatmentPlans() {
       console.error('Error removing treatment item:', error)
       toast.add({
         title: t('errors.deleteFailed'),
-        color: 'red'
+        color: 'error'
       })
       return false
     } finally {
@@ -343,7 +343,7 @@ export function useTreatmentPlans() {
       }
       toast.add({
         title: t('errors.updateFailed'),
-        color: 'red'
+        color: 'error'
       })
       return null
     }
@@ -369,14 +369,14 @@ export function useTreatmentPlans() {
       }
       toast.add({
         title: t('treatmentPlans.itemCompleted'),
-        color: 'green'
+        color: 'success'
       })
       return response.data
     } catch (error) {
       console.error('Error completing treatment item:', error)
       toast.add({
         title: t('errors.updateFailed'),
-        color: 'red'
+        color: 'error'
       })
       return null
     } finally {
@@ -402,11 +402,11 @@ export function useTreatmentPlans() {
           currentPlan.value.items[idx] = response.data
         }
       }
-      toast.add({ title: t('clinical.plans.sessions.markedDone'), color: 'green' })
+      toast.add({ title: t('clinical.plans.sessions.markedDone'), color: 'success' })
       return response.data
     } catch (error) {
       console.error('Error completing session:', error)
-      toast.add({ title: t('errors.updateFailed'), color: 'red' })
+      toast.add({ title: t('errors.updateFailed'), color: 'error' })
       return null
     } finally {
       loading.value = false
@@ -431,11 +431,11 @@ export function useTreatmentPlans() {
           currentPlan.value.items[idx] = response.data
         }
       }
-      toast.add({ title: t('clinical.plans.sessions.cancelled'), color: 'orange' })
+      toast.add({ title: t('clinical.plans.sessions.cancelled'), color: 'warning' })
       return response.data
     } catch (error) {
       console.error('Error cancelling session:', error)
-      toast.add({ title: t('errors.updateFailed'), color: 'red' })
+      toast.add({ title: t('errors.updateFailed'), color: 'error' })
       return null
     } finally {
       loading.value = false
@@ -455,14 +455,14 @@ export function useTreatmentPlans() {
       }
       toast.add({
         title: t('treatmentPlans.budgetLinked'),
-        color: 'green'
+        color: 'success'
       })
       return response.data
     } catch (error) {
       console.error('Error linking budget:', error)
       toast.add({
         title: t('errors.updateFailed'),
-        color: 'red'
+        color: 'error'
       })
       return null
     } finally {
@@ -479,14 +479,14 @@ export function useTreatmentPlans() {
       )
       toast.add({
         title: t('treatmentPlans.budgetSynced'),
-        color: 'green'
+        color: 'success'
       })
       return true
     } catch (error) {
       console.error('Error syncing budget:', error)
       toast.add({
         title: t('errors.updateFailed'),
-        color: 'red'
+        color: 'error'
       })
       return false
     } finally {
@@ -506,14 +506,14 @@ export function useTreatmentPlans() {
       }
       toast.add({
         title: t('treatmentPlans.budgetGenerated'),
-        color: 'green'
+        color: 'success'
       })
       return response.data
     } catch (error) {
       console.error('Error generating budget:', error)
       toast.add({
         title: t('errors.createFailed'),
-        color: 'red'
+        color: 'error'
       })
       return null
     } finally {
@@ -538,11 +538,11 @@ export function useTreatmentPlans() {
       const response = await api.post<ApiResponse<TreatmentPlan>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}/confirm`
       )
-      toast.add({ title: t('treatmentPlans.confirmed'), color: 'green' })
+      toast.add({ title: t('treatmentPlans.confirmed'), color: 'success' })
       return response.data
     } catch (error) {
       console.error('Error confirming plan:', error)
-      toast.add({ title: t('errors.updateFailed'), color: 'red' })
+      toast.add({ title: t('errors.updateFailed'), color: 'error' })
       return null
     } finally {
       loading.value = false
@@ -555,11 +555,11 @@ export function useTreatmentPlans() {
       const response = await api.post<ApiResponse<TreatmentPlan>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}/reopen`
       )
-      toast.add({ title: t('treatmentPlans.reopened'), color: 'green' })
+      toast.add({ title: t('treatmentPlans.reopened'), color: 'success' })
       return response.data
     } catch (error) {
       console.error('Error reopening plan:', error)
-      toast.add({ title: t('errors.updateFailed'), color: 'red' })
+      toast.add({ title: t('errors.updateFailed'), color: 'error' })
       return null
     } finally {
       loading.value = false
@@ -576,11 +576,11 @@ export function useTreatmentPlans() {
         `/api/v1/treatment_plan/treatment-plans/${planId}/close`,
         payload
       )
-      toast.add({ title: t('treatmentPlans.closed'), color: 'green' })
+      toast.add({ title: t('treatmentPlans.closed'), color: 'success' })
       return response.data
     } catch (error) {
       console.error('Error closing plan:', error)
-      toast.add({ title: t('errors.updateFailed'), color: 'red' })
+      toast.add({ title: t('errors.updateFailed'), color: 'error' })
       return null
     } finally {
       loading.value = false
@@ -593,11 +593,11 @@ export function useTreatmentPlans() {
       const response = await api.post<ApiResponse<TreatmentPlan>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}/reactivate`
       )
-      toast.add({ title: t('treatmentPlans.reactivated'), color: 'green' })
+      toast.add({ title: t('treatmentPlans.reactivated'), color: 'success' })
       return response.data
     } catch (error) {
       console.error('Error reactivating plan:', error)
-      toast.add({ title: t('errors.updateFailed'), color: 'red' })
+      toast.add({ title: t('errors.updateFailed'), color: 'error' })
       return null
     } finally {
       loading.value = false
@@ -613,11 +613,11 @@ export function useTreatmentPlans() {
         `/api/v1/treatment_plan/treatment-plans/${planId}/contact-log`,
         payload
       )
-      toast.add({ title: t('treatmentPlans.contactLogged'), color: 'green' })
+      toast.add({ title: t('treatmentPlans.contactLogged'), color: 'success' })
       return true
     } catch (error) {
       console.error('Error logging contact:', error)
-      toast.add({ title: t('errors.updateFailed'), color: 'red' })
+      toast.add({ title: t('errors.updateFailed'), color: 'error' })
       return false
     }
   }

--- a/backend/app/modules/treatment_plan/frontend/pages/treatment-plans/index.vue
+++ b/backend/app/modules/treatment_plan/frontend/pages/treatment-plans/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { PipelineTab } from '~/composables/usePipeline'
+import type { PipelineTab } from '../../composables/usePipeline'
 import { PERMISSIONS } from '~~/app/config/permissions'
 
 type ActiveTab = PipelineTab | 'listado'

--- a/backend/app/modules/treatment_plan/schemas.py
+++ b/backend/app/modules/treatment_plan/schemas.py
@@ -66,6 +66,7 @@ class TreatmentBrief(BaseModel):
     catalog_item_id: UUID | None = None
     catalog_item: CatalogItemBrief | None = None
     price_snapshot: Decimal | None = None
+    notes: str | None = None
     teeth: list[TreatmentToothBrief] = Field(default_factory=list)
 
 
@@ -182,6 +183,11 @@ class TreatmentPlanResponse(BaseModel):
     item_count: int = 0
     completed_count: int = 0
     total: float = 0.0
+    # Closure metadata — set while ``status == "closed"``; the reactivate
+    # dialog shows the previous reason.
+    closure_reason: str | None = None
+    closure_note: str | None = None
+    closed_at: datetime | None = None
     patient: PatientBrief | None = None
     budget: BudgetBrief | None = None
 

--- a/backend/tests/test_treatment_plan.py
+++ b/backend/tests/test_treatment_plan.py
@@ -527,7 +527,11 @@ async def test_cancel_plan_removes_planned_treatments(
         f"/api/v1/treatment_plan/treatment-plans/{plan_id}",
         headers=auth_headers,
     )
-    treatment_id = plan_resp.json()["data"]["items"][0]["treatment"]["id"]
+    treatment_brief = plan_resp.json()["data"]["items"][0]["treatment"]
+    treatment_id = treatment_brief["id"]
+    # The nested brief carries the treatment notes (migrated treatments keep
+    # their legacy label there — issue #184).
+    assert "notes" in treatment_brief
 
     # draft → pending (auto-creates draft budget)
     r = await client.post(
@@ -549,9 +553,16 @@ async def test_cancel_plan_removes_planned_treatments(
     r = await client.post(
         f"/api/v1/treatment_plan/treatment-plans/{plan_id}/close",
         headers=auth_headers,
-        json={"closure_reason": "cancelled_by_clinic"},
+        json={"closure_reason": "cancelled_by_clinic", "closure_note": "moved abroad"},
     )
     assert r.status_code == 200, r.text
+    # Closure metadata is part of the response so the reactivate dialog can
+    # show the previous reason (issue #184).
+    closed = r.json()["data"]
+    assert closed["status"] == "closed"
+    assert closed["closure_reason"] == "cancelled_by_clinic"
+    assert closed["closure_note"] == "moved abroad"
+    assert closed["closed_at"] is not None
 
     assert await _treatment_is_deleted(client, auth_headers, setup["patient_id"], treatment_id)
 

--- a/docs/user-manual/en/treatment_plan/screens/treatment-plans_id.md
+++ b/docs/user-manual/en/treatment_plan/screens/treatment-plans_id.md
@@ -33,7 +33,7 @@ related_permissions:
 related_paths:
   - backend/app/modules/treatment_plan/frontend/pages/treatment-plans/[id].vue
   - backend/app/modules/treatment_plan/router.py
-last_verified_commit: 6c91240
+last_verified_commit: e1d6873
 ---
 
 # Treatment plan detail

--- a/docs/user-manual/es/treatment_plan/screens/treatment-plans_id.md
+++ b/docs/user-manual/es/treatment_plan/screens/treatment-plans_id.md
@@ -33,7 +33,7 @@ related_permissions:
 related_paths:
   - backend/app/modules/treatment_plan/frontend/pages/treatment-plans/[id].vue
   - backend/app/modules/treatment_plan/router.py
-last_verified_commit: 6c91240
+last_verified_commit: e1d6873
 ---
 
 # Detalle del plan de tratamiento

--- a/frontend/app/config/severity.ts
+++ b/frontend/app/config/severity.ts
@@ -87,25 +87,6 @@ export const TREATMENT_STATUS_ROLE: Record<TreatmentStatus, SemanticRole> = {
 }
 
 // ---------------------------------------------------------------------------
-// Treatment plan status
-// ---------------------------------------------------------------------------
-
-export type TreatmentPlanStatus
-  = | 'draft'
-    | 'active'
-    | 'completed'
-    | 'cancelled'
-    | 'on_hold'
-
-export const TREATMENT_PLAN_STATUS_ROLE: Record<TreatmentPlanStatus, SemanticRole> = {
-  draft: 'neutral',
-  active: 'primary',
-  completed: 'success',
-  cancelled: 'neutral',
-  on_hold: 'warning'
-}
-
-// ---------------------------------------------------------------------------
 // Budget status
 // ---------------------------------------------------------------------------
 

--- a/frontend/app/types/index.ts
+++ b/frontend/app/types/index.ts
@@ -435,6 +435,10 @@ export type ClinicalType
     | 'band'
     | 'attachment'
     | 'retainer'
+  // Catch-all written by the migration importer for treatments whose
+  // legacy type has no mapping (see migration_import/mappers). Not creatable
+  // through the API; the original label lives in `Treatment.notes`.
+    | 'migrated'
 
 /** @deprecated — kept for gradual migration; prefer ClinicalType. */
 export type TreatmentType = ClinicalType
@@ -2062,7 +2066,7 @@ export interface AttachmentCreate {
 // Treatment Plan Types
 // ============================================================================
 
-export type TreatmentPlanStatus = 'draft' | 'active' | 'completed' | 'archived' | 'cancelled'
+export type TreatmentPlanStatus = 'draft' | 'pending' | 'active' | 'completed' | 'closed' | 'archived'
 
 export type PlannedItemStatus = 'pending' | 'completed' | 'cancelled'
 
@@ -2076,6 +2080,7 @@ export interface TreatmentBrief {
   catalog_item_id?: string | null
   catalog_item?: TreatmentCatalogItemBrief | null
   price_snapshot?: string | null
+  notes?: string | null
   teeth: Array<{
     tooth_number: number
     role?: 'pillar' | 'pontic' | null
@@ -2323,6 +2328,10 @@ export interface TreatmentPlan {
   item_count: number
   completed_count: number
   total: number
+  // Set while status === 'closed' (see treatment_plan/models.py).
+  closure_reason?: string | null
+  closure_note?: string | null
+  closed_at?: string | null
   patient?: PatientBrief
   budget?: BudgetBrief
 }


### PR DESCRIPTION
Part 2/7 of #184 — treatment_plan (58 vue-tsc errors → 0). Verify locally with #192's `npm run typecheck:layers` (this branch is off `main`; the series is stacked from here: #194 → #195 → #196 → #197 → gate).

Most errors were real bugs, not type noise:
- `TreatmentPlanStatus` now mirrors the API (`draft|pending|active|completed|closed|archived`) — `cancelled` never existed on the backend, `pending`/`closed` did. Drops the dead duplicate type + `TREATMENT_PLAN_STATUS_ROLE` in `severity.ts`; status badge/mini-card maps typed `UiColor` and updated.
- Toasts used Nuxt UI v3 colours (`red`/`green`/`orange`) that v4 ignores → `error`/`success`/`warning`.
- **Backend**: `TreatmentPlanResponse` exposes `closure_reason`/`closure_note`/`closed_at` (the reactivate dialog read `undefined`); `TreatmentBrief` exposes `notes` (migrated treatments' legacy label was never rendered). `ClinicalType` gains the `'migrated'` catch-all the importer writes. Test extended in `test_treatment_plan.py`.
- Sibling composable imports relative (`~` maps to the host for vue-tsc), `UModal :ui.width` → `content`, USelect refs typed to their `as const` unions, `PlansMode` "activate" calls the in-scope `loadPatientPlans()`.

Docs: module CHANGELOG, plan detail screen MD bumped (en/es).

🤖 Generated with [Claude Code](https://claude.com/claude-code)