### PR TITLE
fix(odontogram): type-check clean under nuxt typecheck (#184)

### DIFF
--- a/backend/app/modules/odontogram/CHANGELOG.md
+++ b/backend/app/modules/odontogram/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): the layer type-checks clean under `nuxt typecheck`. Real bugs behind the errors: treatment colour dots read `TREATMENT_COLORS` (a `{light,dark}` config) as a hex string — they now go through `getTreatmentColor()`; the toast undo action used the v3 `click` key (v4: `onClick`), `UPopover :ui.width` is `content`; `TreatmentBar` emitted a possibly-undefined fallback status; touch drags on the timeline guard an empty `touches` list. Tooth-position lookups are typed by `ToothPosition` (1–8) instead of `|| MAP[1]` fallbacks.
 - fix(#183): `TreatmentService.perform` publishes with `db=` so the payments earned ledger and the plan-item completion run in its transaction (ADR 0019).
 - feat(events): `TreatmentService.perform` accepts `publish_price=False`
   to emit `odontogram.treatment.performed` with `unit_price: null` —

--- a/backend/app/modules/odontogram/frontend/components/clinical/DiagnosisCTA.vue
+++ b/backend/app/modules/odontogram/frontend/components/clinical/DiagnosisCTA.vue
@@ -23,6 +23,9 @@ const { t } = useI18n()
 
 const selectedDraftId = ref<string>('')
 
+/** The one draft to continue when exactly one exists (narrows for the template). */
+const soleDraft = computed(() => (props.draftPlans.length === 1 ? props.draftPlans[0] : undefined))
+
 // Options for dropdown when multiple drafts exist
 const draftOptions = computed(() =>
   props.draftPlans.map(plan => ({
@@ -61,12 +64,12 @@ function handleContinue() {
 
       <!-- 1 draft: Continue that plan -->
       <UButton
-        v-else-if="draftPlans.length === 1"
+        v-else-if="soleDraft"
         color="primary"
         icon="i-lucide-arrow-right"
-        @click="emit('continue', draftPlans[0].id)"
+        @click="emit('continue', soleDraft.id)"
       >
-        {{ t('clinical.diagnosis.continuePlan', { name: draftPlans[0].title || t('treatmentPlans.untitledPlan') }) }}
+        {{ t('clinical.diagnosis.continuePlan', { name: soleDraft.title || t('treatmentPlans.untitledPlan') }) }}
       </UButton>
 
       <!-- N drafts: Dropdown to select -->

--- a/backend/app/modules/odontogram/frontend/components/clinical/HistoryMode.vue
+++ b/backend/app/modules/odontogram/frontend/components/clinical/HistoryMode.vue
@@ -76,8 +76,8 @@ onMounted(async () => {
       fetchTreatments(props.patientId)
     ])
     // If there are dates, select the most recent one by default
-    if (timelineDates.value.length > 0) {
-      const mostRecent = timelineDates.value[timelineDates.value.length - 1]
+    const mostRecent = timelineDates.value.at(-1)
+    if (mostRecent) {
       await fetchOdontogramAtDate(props.patientId, mostRecent.date)
     }
   } finally {

--- a/backend/app/modules/odontogram/frontend/components/odontogram/ChangeHistorySection.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/ChangeHistorySection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { OdontogramHistoryEntry, ToothTreatmentView, Treatment } from '~~/app/types'
 import { viewForTooth } from '~~/app/utils/treatmentView'
-import { getToothNameKey, getToothPositionKeys, TREATMENT_COLORS } from '~~/app/config/odontogramConstants'
+import { getToothNameKey, getToothPositionKeys, getTreatmentColor } from '~~/app/config/odontogramConstants'
 
 const props = defineProps<{
   history: OdontogramHistoryEntry[]
@@ -101,7 +101,7 @@ function getConditionLabel(condition?: string): string {
 
 function getConditionColor(condition?: string): string {
   if (!condition) return '#E5E7EB'
-  return TREATMENT_COLORS[condition] || '#E5E7EB'
+  return getTreatmentColor(condition)
 }
 
 function getChangeTypeLabel(changeType: string): string {

--- a/backend/app/modules/odontogram/frontend/components/odontogram/ImplantSVG.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/ImplantSVG.vue
@@ -51,7 +51,7 @@ const implantTransform = computed(() => {
 })
 
 // Get status styling
-const statusStyle = computed(() => STATUS_STYLES[props.status] || STATUS_STYLES.existing)
+const statusStyle = computed(() => STATUS_STYLES[props.status])
 </script>
 
 <template>

--- a/backend/app/modules/odontogram/frontend/components/odontogram/OdontogramChart.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/OdontogramChart.vue
@@ -549,7 +549,7 @@ async function applyTreatment(toothNumber: number, surfaces?: Surface[]) {
     title: `${t(`odontogram.treatments.types.${treatment.clinical_type}`, treatment.clinical_type)} - ${t('odontogram.tooth')} ${toothNumber}`,
     description: t('odontogram.treatments.treatmentAdded'),
     color: 'success',
-    actions: [{ label: t('common.undo'), click: handleUndo }]
+    actions: [{ label: t('common.undo'), onClick: handleUndo }]
   })
 
   emit('treatmentAdd', treatment)

--- a/backend/app/modules/odontogram/frontend/components/odontogram/TimelineSlider.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/TimelineSlider.vue
@@ -35,9 +35,8 @@ const isDragging = ref(false)
 
 /** Whether last date in array is today (merges with"Now" position) */
 const lastDateIsToday = computed(() => {
-  if (props.dates.length === 0) return false
-  const lastDate = props.dates[props.dates.length - 1].date
-  const today = new Date().toISOString().split('T')[0]
+  const lastDate = props.dates.at(-1)?.date
+  const today = new Date().toISOString().slice(0, 10)
   return lastDate === today
 })
 
@@ -67,8 +66,8 @@ const thumbPosition = computed(() => {
 
 /** Label to display in the thumb badge */
 const thumbLabel = computed(() => {
-  if (currentIndex.value === null) return t('common.now')
-  return formatDate(props.dates[currentIndex.value].date)
+  const current = currentIndex.value === null ? undefined : props.dates[currentIndex.value]
+  return current ? formatDate(current.date) : t('common.now')
 })
 
 // ============================================================================
@@ -104,7 +103,8 @@ function getMarkerState(index: number): 'selected' | 'now' | 'past' | 'future' {
 /** Get label for a marker */
 function getMarkerLabel(index: number): string {
   const isLastAndToday = lastDateIsToday.value && index === props.dates.length - 1
-  return isLastAndToday ? t('common.now') : formatDate(props.dates[index].date)
+  const entry = props.dates[index]
+  return isLastAndToday || !entry ? t('common.now') : formatDate(entry.date)
 }
 
 // ============================================================================
@@ -127,7 +127,8 @@ function selectIndex(index: number | null) {
     return
   }
 
-  emit('update:currentDate', props.dates[index].date)
+  const entry = props.dates[index]
+  if (entry) emit('update:currentDate', entry.date)
 }
 
 /** Navigate to previous date */
@@ -203,7 +204,8 @@ function handleDragStart() {
 function handleDragMove(event: MouseEvent | TouchEvent) {
   if (!isDragging.value || !sliderRef.value) return
 
-  const clientX = 'touches' in event ? event.touches[0].clientX : event.clientX
+  const clientX = 'touches' in event ? event.touches[0]?.clientX : event.clientX
+  if (clientX === undefined) return // touchmove can fire with an empty touch list
   const rect = sliderRef.value.getBoundingClientRect()
   const percent = Math.max(0, Math.min(100, ((clientX - rect.left) / rect.width) * 100))
   const targetIndex = Math.round((percent / 100) * (totalPositions.value - 1))

--- a/backend/app/modules/odontogram/frontend/components/odontogram/ToothDualView.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/ToothDualView.vue
@@ -171,11 +171,11 @@ function hasTreatment(type: string, status?: TreatmentStatus): boolean {
   )
 }
 
-function getTreatmentOfType(type: string): Treatment | undefined {
+function getTreatmentOfType(type: string): ToothTreatmentView | undefined {
   return toothTreatments.value.find(t => t.treatment_type === type)
 }
 
-function getImplantFill(_treatment: Treatment): string {
+function getImplantFill(_treatment: ToothTreatmentView): string {
   return TREATMENT_COLORS.implant || '#10B981'
 }
 
@@ -193,7 +193,7 @@ const pulpFillTreatments = computed(() => {
 const hasPulpTreatment = computed(() => pulpFillTreatments.value.length > 0)
 
 // Get the primary pulp treatment (first one with pulp_fill rule)
-function getPulpTreatment(): Treatment | undefined {
+function getPulpTreatment(): ToothTreatmentView | undefined {
   return pulpFillTreatments.value[0]
 }
 
@@ -275,7 +275,7 @@ const occlusalSurfaceTreatments = computed(() => {
 })
 
 // Get occlusal visualization config for a treatment
-function getOcclusalConfig(treatment: Treatment) {
+function getOcclusalConfig(treatment: ToothTreatmentView) {
   const normalized = normalizeTreatmentType(treatment.treatment_type)
   return OCCLUSAL_VISUALIZATION[normalized]
 }
@@ -299,7 +299,7 @@ const patternFillTreatments = computed(() => {
 })
 
 // Get pattern config for a treatment (available for future use)
-function _getPatternConfig(treatment: Treatment) {
+function _getPatternConfig(treatment: ToothTreatmentView) {
   const normalized = normalizeTreatmentType(treatment.treatment_type)
   return PATTERN_CONFIG[normalized]
 }

--- a/backend/app/modules/odontogram/frontend/components/odontogram/ToothQuadrant.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/ToothQuadrant.vue
@@ -104,7 +104,7 @@ function isUpperTooth(toothNumber: number): boolean {
       <UPopover
         :open-delay="300"
         :close-delay="100"
-        :ui="{ width: 'min-w-48 max-w-72' }"
+        :ui="{ content: 'min-w-48 max-w-72' }"
       >
         <div
           class="tooth-cell"

--- a/backend/app/modules/odontogram/frontend/components/odontogram/ToothSVGPaths.ts
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/ToothSVGPaths.ts
@@ -10,6 +10,7 @@
  * Paths extracted from professional dental SVGs with anatomically accurate proportions.
  */
 
+import type { TreatmentStatus } from '~~/app/types'
 import {
   isDeciduousTooth as isDeciduousToothFn,
   isUpperTooth as isUpperToothFn,
@@ -44,14 +45,7 @@ export const TREATMENT_COLORS: Record<string, string> = Object.fromEntries(
 
 // Helper function to get icon anchors for a tooth
 export function getIconAnchors(toothNumber: number): IconAnchors | undefined {
-  const isDeciduous = isDeciduousToothFn(toothNumber)
-  let position = getToothPosition(toothNumber)
-
-  if (isDeciduous) {
-    position = DECIDUOUS_TO_PERMANENT_MAP[position] || 1
-  }
-
-  return LATERAL_PATHS_BY_POSITION[position]?.anchors
+  return getLateralPath(toothNumber).anchors
 }
 
 // Helper function to get partial pulp path
@@ -167,6 +161,24 @@ export function getToothPosition(toothNumber: number): number {
   return toothNumber % 10
 }
 
+/** Position within the quadrant (1 = central incisor … 8 = third molar). */
+export type ToothPosition = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8
+
+function isToothPosition(n: number): n is ToothPosition {
+  return Number.isInteger(n) && n >= 1 && n <= 8
+}
+
+/**
+ * Position whose SVG shape draws this tooth: deciduous teeth reuse the
+ * permanent shapes (see DECIDUOUS_TO_PERMANENT_MAP); anything outside the
+ * FDI range falls back to the central incisor.
+ */
+function getShapePosition(toothNumber: number): ToothPosition {
+  const position = getToothPosition(toothNumber)
+  const shape = isDeciduousTooth(toothNumber) ? DECIDUOUS_TO_PERMANENT_MAP[position] : position
+  return shape !== undefined && isToothPosition(shape) ? shape : 1
+}
+
 // ============================================================================
 // LATERAL VIEW PATHS
 // Extracted from professional dental SVGs
@@ -215,7 +227,7 @@ interface ToothDisplayConfig {
 // Upper teeth: roots point UP, crown at BOTTOM - crown line should be aligned
 // Lower teeth: roots point DOWN, crown at TOP - crown line should be aligned
 // Scales calibrated so all teeth have similar visual height (~100px)
-const TOOTH_DISPLAY_CONFIG: Record<number, ToothDisplayConfig> = {
+const TOOTH_DISPLAY_CONFIG: Record<ToothPosition, ToothDisplayConfig> = {
   // Incisors - narrower teeth, need smaller scale to achieve similar height
   1: { scale: 0.65, offsetY: 0, displayHeight: 100 },
   2: { scale: 0.62, offsetY: 0, displayHeight: 100 },
@@ -231,18 +243,11 @@ const TOOTH_DISPLAY_CONFIG: Record<number, ToothDisplayConfig> = {
 }
 
 export function getToothDisplayConfig(toothNumber: number): ToothDisplayConfig {
-  const isDeciduous = isDeciduousTooth(toothNumber)
-  let position = getToothPosition(toothNumber)
-
-  if (isDeciduous) {
-    position = DECIDUOUS_TO_PERMANENT_MAP[position] || 1
-  }
-
-  return TOOTH_DISPLAY_CONFIG[position] || TOOTH_DISPLAY_CONFIG[1]
+  return TOOTH_DISPLAY_CONFIG[getShapePosition(toothNumber)]
 }
 
 // Paths indexed by position (1-8) - using actual SVG paths from reference
-const LATERAL_PATHS_BY_POSITION: Record<number, LateralPaths> = {
+const LATERAL_PATHS_BY_POSITION: Record<ToothPosition, LateralPaths> = {
   // Position 1: Central Incisor (tooth 11) - viewBox 46x134
   1: {
     viewBox: '0 0 46 134',
@@ -455,7 +460,7 @@ const CIRCULAR_DIVIDERS = [
 
 // All teeth use the same circular occlusal view
 // Quadrant symmetry is handled by CSS transform (napkin unfolding)
-const OCCLUSAL_PATHS_BY_POSITION: Record<number, OcclusalPaths> = {
+const OCCLUSAL_PATHS_BY_POSITION: Record<ToothPosition, OcclusalPaths> = {
   1: { outline: CIRCULAR_OUTLINE, highlight: CIRCULAR_DIVIDERS, surfaces: CIRCULAR_SURFACES },
   2: { outline: CIRCULAR_OUTLINE, highlight: CIRCULAR_DIVIDERS, surfaces: CIRCULAR_SURFACES },
   3: { outline: CIRCULAR_OUTLINE, highlight: CIRCULAR_DIVIDERS, surfaces: CIRCULAR_SURFACES },
@@ -471,7 +476,7 @@ const OCCLUSAL_PATHS_BY_POSITION: Record<number, OcclusalPaths> = {
 // ============================================================================
 
 // Map deciduous positions to permanent tooth shapes
-const DECIDUOUS_TO_PERMANENT_MAP: Record<number, number> = {
+const DECIDUOUS_TO_PERMANENT_MAP: Record<number, ToothPosition> = {
   1: 1, // Deciduous central incisor → Central incisor
   2: 2, // Deciduous lateral incisor → Lateral incisor
   3: 3, // Deciduous canine → Canine
@@ -484,27 +489,11 @@ const DECIDUOUS_TO_PERMANENT_MAP: Record<number, number> = {
 // ============================================================================
 
 export function getLateralPath(toothNumber: number): LateralPaths {
-  const isDeciduous = isDeciduousTooth(toothNumber)
-  let position = getToothPosition(toothNumber)
-
-  // Map deciduous positions to permanent shapes
-  if (isDeciduous) {
-    position = DECIDUOUS_TO_PERMANENT_MAP[position] || 1
-  }
-
-  return LATERAL_PATHS_BY_POSITION[position] || LATERAL_PATHS_BY_POSITION[1]
+  return LATERAL_PATHS_BY_POSITION[getShapePosition(toothNumber)]
 }
 
 export function getOcclusalPath(toothNumber: number): OcclusalPaths {
-  const isDeciduous = isDeciduousTooth(toothNumber)
-  let position = getToothPosition(toothNumber)
-
-  // Map deciduous positions to permanent shapes
-  if (isDeciduous) {
-    position = DECIDUOUS_TO_PERMANENT_MAP[position] || 1
-  }
-
-  return OCCLUSAL_PATHS_BY_POSITION[position] || OCCLUSAL_PATHS_BY_POSITION[1]
+  return OCCLUSAL_PATHS_BY_POSITION[getShapePosition(toothNumber)]
 }
 
 // ============================================================================
@@ -557,14 +546,23 @@ export const TREATMENT_OVERLAYS = {
 // ============================================================================
 
 // Convert from odontogramConstants format to local format
-export const STATUS_STYLES: Record<string, { opacity: number, border: string, borderWidth: number, borderDash?: string }> = Object.fromEntries(
-  Object.entries(STATUS_STYLES_CONFIG).map(([key, value]) => [
-    key,
-    {
-      opacity: value.opacity,
-      border: value.border || 'none',
-      borderWidth: value.borderWidth,
-      ...(value.borderDash ? { borderDash: value.borderDash } : {})
-    }
-  ])
-)
+interface StatusStyle {
+  opacity: number
+  border: string
+  borderWidth: number
+  borderDash?: string
+}
+
+function toStatusStyle(value: typeof STATUS_STYLES_CONFIG[TreatmentStatus]): StatusStyle {
+  return {
+    opacity: value.opacity,
+    border: value.border || 'none',
+    borderWidth: value.borderWidth,
+    ...(value.borderDash ? { borderDash: value.borderDash } : {})
+  }
+}
+
+export const STATUS_STYLES: Record<TreatmentStatus, StatusStyle> = {
+  existing: toStatusStyle(STATUS_STYLES_CONFIG.existing),
+  planned: toStatusStyle(STATUS_STYLES_CONFIG.planned)
+}

--- a/backend/app/modules/odontogram/frontend/components/odontogram/ToothTooltip.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/ToothTooltip.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ToothTreatmentView, TreatmentStatus } from '~~/app/types'
-import { TREATMENT_COLORS } from '~~/app/config/odontogramConstants'
+import { getTreatmentColor } from '~~/app/config/odontogramConstants'
 import { getTreatmentDisplayName } from '~~/app/utils/treatmentView'
 
 const props = defineProps<{
@@ -42,7 +42,7 @@ function getToothName(toothNumber: number): string {
 
 // Group treatments by status
 const groupedTreatments = computed(() => {
-  const groups: Record<TreatmentStatus, Treatment[]> = {
+  const groups: Record<TreatmentStatus, ToothTreatmentView[]> = {
     planned: [],
     existing: []
   }
@@ -70,7 +70,7 @@ function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleDateString()
 }
 
-function handleEditClick(event: Event, treatment: Treatment) {
+function handleEditClick(event: Event, treatment: ToothTreatmentView) {
   event.stopPropagation()
   event.preventDefault()
   emit('editTreatment', treatment)
@@ -113,7 +113,7 @@ function handleEditClick(event: Event, treatment: Treatment) {
           <div class="treatment-main">
             <span
               class="treatment-dot"
-              :style="{ backgroundColor: TREATMENT_COLORS[treatment.treatment_type] || '#9CA3AF' }"
+              :style="{ backgroundColor: getTreatmentColor(treatment.treatment_type) }"
             />
             <span class="treatment-name">{{ getTreatmentLabel(treatment) }}</span>
             <UBadge
@@ -149,7 +149,7 @@ function handleEditClick(event: Event, treatment: Treatment) {
           <div class="treatment-main">
             <span
               class="treatment-dot"
-              :style="{ backgroundColor: TREATMENT_COLORS[treatment.treatment_type] || '#9CA3AF' }"
+              :style="{ backgroundColor: getTreatmentColor(treatment.treatment_type) }"
             />
             <span class="treatment-name">{{ getTreatmentLabel(treatment) }}</span>
             <UBadge

--- a/backend/app/modules/odontogram/frontend/components/odontogram/TreatmentBar.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/TreatmentBar.vue
@@ -367,10 +367,9 @@ function selectTreatment(item: TreatmentBarItem) {
 function selectTreatmentRegular(item: TreatmentBarItem) {
   // Check allowed statuses and auto-set if restricted
   const allowedStatuses = getEffectiveAllowedStatuses(item.odontogramType)
-  if (allowedStatuses.length === 1 && !allowedStatuses.includes(props.selectedStatus)) {
-    emit('update:selectedStatus', allowedStatuses[0])
-  } else if (!allowedStatuses.includes(props.selectedStatus)) {
-    emit('update:selectedStatus', allowedStatuses[0])
+  const [fallbackStatus] = allowedStatuses
+  if (fallbackStatus && !allowedStatuses.includes(props.selectedStatus)) {
+    emit('update:selectedStatus', fallbackStatus)
   }
 
   // Atomic multi-tooth (bridge, splint) and regular treatments share the same flow:

--- a/backend/app/modules/odontogram/frontend/components/odontogram/TreatmentEditModal.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/TreatmentEditModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Surface, ToothTreatmentView, TreatmentStatus } from '~~/app/types'
-import { TREATMENT_COLORS, isSurfaceTreatment, getAllowedStatusesForTreatment } from '~~/app/config/odontogramConstants'
+import { getTreatmentColor, isSurfaceTreatment, getAllowedStatusesForTreatment } from '~~/app/config/odontogramConstants'
+import type { UiColor } from '~~/app/config/severity'
 import { getTreatmentDisplayName } from '~~/app/utils/treatmentView'
 
 const props = defineProps<{
@@ -50,13 +51,13 @@ const treatmentLabel = computed(() => {
 // Treatment color
 const treatmentColor = computed(() => {
   if (!props.treatment) return '#9CA3AF'
-  return TREATMENT_COLORS[props.treatment.treatment_type] || '#9CA3AF'
+  return getTreatmentColor(props.treatment.treatment_type)
 })
 
 // All status options
-const allStatusOptions = [
-  { value: 'existing' as TreatmentStatus, label: () => t('odontogram.status.existing'), color: 'neutral' },
-  { value: 'planned' as TreatmentStatus, label: () => t('odontogram.status.planned'), color: 'warning' }
+const allStatusOptions: { value: TreatmentStatus, label: () => string, color: UiColor }[] = [
+  { value: 'existing', label: () => t('odontogram.status.existing'), color: 'neutral' },
+  { value: 'planned', label: () => t('odontogram.status.planned'), color: 'warning' }
 ]
 
 // Status options filtered by treatment type
@@ -163,7 +164,7 @@ function handleClose() {
                 :color="status === option.value ? option.color : 'neutral'"
                 :variant="status === option.value ? 'solid' : 'outline'"
                 size="sm"
-                @click="status = option.value as TreatmentStatus"
+                @click="status = option.value"
               >
                 {{ option.label }}
               </UButton>

--- a/backend/app/modules/odontogram/frontend/components/odontogram/TreatmentIcons.ts
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/TreatmentIcons.ts
@@ -12,6 +12,15 @@ import {
 // Re-export from central config
 export { SURFACE_TREATMENTS, TREATMENT_CATEGORIES }
 
+// Filling (legacy) - tooth with filled surface. Also the fallback icon for
+// unknown treatment types (see getTreatmentIcon).
+const FILLING_ICON = `
+    <path d="M7 3C7 1.5 9.5 0 12 0C14.5 0 17 1.5 17 3V12C17 14 15.5 16 12 16C8.5 16 7 14 7 12V3Z" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <rect x="9" y="5" width="6" height="5" rx="1" fill="currentColor"/>
+    <path d="M10 18V22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+    <path d="M14 18V22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  `
+
 export const TREATMENT_ICONS: Record<string, string> = {
   // ============================================================================
   // DIAGNÓSTICO
@@ -161,13 +170,7 @@ export const TREATMENT_ICONS: Record<string, string> = {
     <path d="M14 18V22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
   `,
 
-  // Filling (legacy) - tooth with filled surface
-  filling: `
-    <path d="M7 3C7 1.5 9.5 0 12 0C14.5 0 17 1.5 17 3V12C17 14 15.5 16 12 16C8.5 16 7 14 7 12V3Z" fill="none" stroke="currentColor" stroke-width="1.5"/>
-    <rect x="9" y="5" width="6" height="5" rx="1" fill="currentColor"/>
-    <path d="M10 18V22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-    <path d="M14 18V22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-  `,
+  filling: FILLING_ICON,
 
   // Sealant - tooth with protective layer
   sealant: `
@@ -508,7 +511,7 @@ export function resolveTreatmentIconKey(
 
 // Get icon SVG for a treatment type
 export function getTreatmentIcon(treatmentType: string): string {
-  return TREATMENT_ICONS[treatmentType] || TREATMENT_ICONS.filling
+  return TREATMENT_ICONS[treatmentType] || FILLING_ICON
 }
 
 // Check if treatment requires surface selection (re-export with same name for compatibility)

--- a/backend/app/modules/odontogram/frontend/components/odontogram/TreatmentListSection.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/TreatmentListSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Treatment } from '~~/app/types'
-import { getToothNameKey, getToothPositionKeys, TREATMENT_COLORS } from '~~/app/config/odontogramConstants'
+import { getToothNameKey, getToothPositionKeys, getTreatmentColor } from '~~/app/config/odontogramConstants'
 import { getTreatmentDisplayName, viewForTooth } from '~~/app/utils/treatmentView'
 
 const props = defineProps<{
@@ -41,10 +41,6 @@ function formatDate(dateStr: string): string {
   const month = (date.getMonth() + 1).toString().padStart(2, '0')
   const year = date.getFullYear()
   return `${day}/${month}/${year}`
-}
-
-function getTreatmentColor(treatmentType: string): string {
-  return TREATMENT_COLORS[treatmentType] || '#9CA3AF'
 }
 
 function getStatusBadgeColor(status: string): 'success' | 'warning' | 'neutral' {

--- a/backend/app/modules/odontogram/frontend/components/odontogram/TreatmentSummary.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/TreatmentSummary.vue
@@ -36,14 +36,16 @@ const treatmentsByType = computed(() => {
   > = {}
 
   for (const treatment of perToothTreatments.value) {
-    if (!grouped[treatment.treatment_type]) {
-      grouped[treatment.treatment_type] = { count: 0, teeth: [], treatments: [] }
+    let entry = grouped[treatment.treatment_type]
+    if (!entry) {
+      entry = { count: 0, teeth: [], treatments: [] }
+      grouped[treatment.treatment_type] = entry
     }
-    grouped[treatment.treatment_type].count++
-    if (!grouped[treatment.treatment_type].teeth.includes(treatment.tooth_number)) {
-      grouped[treatment.treatment_type].teeth.push(treatment.tooth_number)
+    entry.count++
+    if (!entry.teeth.includes(treatment.tooth_number)) {
+      entry.teeth.push(treatment.tooth_number)
     }
-    grouped[treatment.treatment_type].treatments.push(treatment)
+    entry.treatments.push(treatment)
   }
 
   return Object.entries(grouped)

--- a/backend/app/modules/odontogram/frontend/composables/useOdontogramUI.ts
+++ b/backend/app/modules/odontogram/frontend/composables/useOdontogramUI.ts
@@ -3,7 +3,7 @@
  * Handles view mode, dentition selection, and panel visibility
  */
 
-import { PERMANENT_TEETH, DECIDUOUS_TEETH } from '~/composables/useOdontogram'
+import { PERMANENT_TEETH, DECIDUOUS_TEETH } from './useOdontogram'
 
 export type DentitionMode = 'permanent' | 'deciduous'
 

--- a/backend/app/modules/patient_timeline/CHANGELOG.md
+++ b/backend/app/modules/patient_timeline/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — guard the IntersectionObserver entry before reading `isIntersecting`.
 - docs(#183): handlers documented as own-session/payload-only — the timeline records what the payload carries and must never be able to fail the event it logs.
 - i18n: add `pt` fallback to treatment name resolution in the demo
   timeline seed.

--- a/backend/app/modules/patient_timeline/frontend/components/patient/PatientTimeline.vue
+++ b/backend/app/modules/patient_timeline/frontend/components/patient/PatientTimeline.vue
@@ -251,7 +251,7 @@ onMounted(() => {
 
   const observer = new IntersectionObserver(
     (entries) => {
-      if (entries[0].isIntersecting && hasMore.value && !isLoadingMore.value) {
+      if (entries[0]?.isIntersecting && hasMore.value && !isLoadingMore.value) {
         loadMore()
       }
     },

--- a/backend/app/modules/patients_clinical/CHANGELOG.md
+++ b/backend/app/modules/patients_clinical/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — `UAccordion :ui.item` is a class string in Nuxt UI v4 (the border/margin classes were not applied), `getSeverityColor()` returns `UiColor`, allergy rows key by index (entries have no `id`).
 - refactor(types): drop the ``as unknown as Record<string, unknown>`` cast in ``useMedicalHistory`` now that ``useApi`` accepts ``object`` payloads.
 - Added per-module `CLAUDE.md` for AI-agent context (2026-04-27).
 

--- a/backend/app/modules/patients_clinical/frontend/components/patient/MedicalHistoryForm.vue
+++ b/backend/app/modules/patients_clinical/frontend/components/patient/MedicalHistoryForm.vue
@@ -143,7 +143,7 @@ function handleSave() {
     <!-- Allergies Section -->
     <UAccordion
       :items="[{ label: t('patients.medicalHistory.allergies'), icon: 'i-lucide-alert-triangle', defaultOpen: true, slot: 'allergies' }]"
-      :ui="{ item: { base: 'border rounded-lg mb-2' } }"
+      :ui="{ item: 'border rounded-lg mb-2' }"
     >
       <template #allergies>
         <div class="p-4 space-y-4">
@@ -210,7 +210,7 @@ function handleSave() {
     <!-- Current Medications Section -->
     <UAccordion
       :items="[{ label: t('patients.medicalHistory.medications'), icon: 'i-lucide-pill', defaultOpen: false, slot: 'medications' }]"
-      :ui="{ item: { base: 'border rounded-lg mb-2' } }"
+      :ui="{ item: 'border rounded-lg mb-2' }"
     >
       <template #medications>
         <div class="p-4 space-y-4">
@@ -268,7 +268,7 @@ function handleSave() {
     <!-- Systemic Diseases Section -->
     <UAccordion
       :items="[{ label: t('patients.medicalHistory.systemicDiseases'), icon: 'i-lucide-activity', defaultOpen: false, slot: 'diseases' }]"
-      :ui="{ item: { base: 'border rounded-lg mb-2' } }"
+      :ui="{ item: 'border rounded-lg mb-2' }"
     >
       <template #diseases>
         <div class="p-4 space-y-4">
@@ -336,7 +336,7 @@ function handleSave() {
     <!-- Special Conditions Section -->
     <UAccordion
       :items="[{ label: t('patients.medicalHistory.specialConditions'), icon: 'i-lucide-heart-pulse', defaultOpen: true, slot: 'conditions' }]"
-      :ui="{ item: { base: 'border rounded-lg mb-2' } }"
+      :ui="{ item: 'border rounded-lg mb-2' }"
     >
       <template #conditions>
         <div class="p-4 space-y-4">
@@ -426,7 +426,7 @@ function handleSave() {
     <!-- Lifestyle Section -->
     <UAccordion
       :items="[{ label: t('patients.medicalHistory.lifestyle'), icon: 'i-lucide-cigarette', defaultOpen: false, slot: 'lifestyle' }]"
-      :ui="{ item: { base: 'border rounded-lg mb-2' } }"
+      :ui="{ item: 'border rounded-lg mb-2' }"
     >
       <template #lifestyle>
         <div class="p-4 space-y-4">
@@ -463,7 +463,7 @@ function handleSave() {
     <!-- Surgical History Section -->
     <UAccordion
       :items="[{ label: t('patients.medicalHistory.surgicalHistory'), icon: 'i-lucide-scissors', defaultOpen: false, slot: 'surgery' }]"
-      :ui="{ item: { base: 'border rounded-lg mb-2' } }"
+      :ui="{ item: 'border rounded-lg mb-2' }"
     >
       <template #surgery>
         <div class="p-4 space-y-4">

--- a/backend/app/modules/patients_clinical/frontend/components/summary/MedicalHistoryCard.vue
+++ b/backend/app/modules/patients_clinical/frontend/components/summary/MedicalHistoryCard.vue
@@ -88,8 +88,8 @@ const isEmpty = computed(() =>
         </div>
         <ul class="pl-5 text-muted">
           <li
-            v-for="a in topAllergies"
-            :key="a.id"
+            v-for="(a, i) in topAllergies"
+            :key="`allergy-${i}`"
             class="truncate"
           >
             · {{ a.name }}

--- a/backend/app/modules/patients_clinical/frontend/composables/usePatientAlerts.ts
+++ b/backend/app/modules/patients_clinical/frontend/composables/usePatientAlerts.ts
@@ -1,4 +1,5 @@
 import type { ApiResponse, PatientAlert } from '~~/app/types'
+import type { UiColor } from '~~/app/config/severity'
 
 export function usePatientAlerts(patientId: Ref<string | undefined>) {
   const api = useApi()
@@ -70,14 +71,14 @@ export function usePatientAlerts(patientId: Ref<string | undefined>) {
   }
 
   // Get color for severity
-  function getSeverityColor(severity: PatientAlert['severity']): string {
-    const colors: Record<PatientAlert['severity'], string> = {
+  function getSeverityColor(severity: PatientAlert['severity']): UiColor {
+    const colors: Record<PatientAlert['severity'], UiColor> = {
       critical: 'error',
       high: 'warning',
       medium: 'info',
       low: 'neutral'
     }
-    return colors[severity] || 'neutral'
+    return colors[severity]
   }
 
   // Watch patientId and fetch when it changes

--- a/backend/app/modules/periodontogram/CHANGELOG.md
+++ b/backend/app/modules/periodontogram/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — non-empty tuple cycles for the mobility/prognosis/furcation toggles, explicit central-incisor defaults for the per-position viewBox maps, `?? null` on optional site markers.
 - docs(#183): both event handlers documented as own-session/payload-only, with a note that PR-3's real cleanup should be transactional (ADR 0019).
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 

--- a/backend/app/modules/periodontogram/frontend/components/PerioArchBlock.vue
+++ b/backend/app/modules/periodontogram/frontend/components/PerioArchBlock.vue
@@ -85,14 +85,15 @@ function siteValue(tooth: PerioTooth, code: SiteCode): PerioSite | null {
 // keyboard friendliness (a value clears via the same button).
 // ---------------------------------------------------------------------------
 
-const MOBILITY_CYCLE: Array<number | null> = [null, 0, 1, 2, 3]
-const PROGNOSIS_CYCLE: Array<Prognosis | null> = [null, 'good', 'fair', 'poor', 'hopeless']
-const FURCA_CYCLE: Array<Furcation | null> = [null, '0', 'I', 'II', 'III']
+// Cycles are non-empty tuples so `cycle[0]` is provably defined; the first
+// entry (null) is what a click on an unknown value falls back to.
+const MOBILITY_CYCLE: readonly [null, ...Array<number | null>] = [null, 0, 1, 2, 3]
+const PROGNOSIS_CYCLE: readonly [null, ...Array<Prognosis | null>] = [null, 'good', 'fair', 'poor', 'hopeless']
+const FURCA_CYCLE: readonly [null, ...Array<Furcation | null>] = [null, '0', 'I', 'II', 'III']
 
-function nextInCycle<T>(cycle: T[], current: T): T {
+function nextInCycle<T>(cycle: readonly [T, ...T[]], current: T): T {
   const idx = cycle.findIndex(v => v === current)
-  if (idx === -1) return cycle[1] ?? cycle[0]
-  return cycle[(idx + 1) % cycle.length]
+  return cycle[(idx + 1) % cycle.length] ?? cycle[0]
 }
 
 function prognosisGlyph(v: Prognosis | null | undefined): string {

--- a/backend/app/modules/periodontogram/frontend/components/PerioProfileStrip.vue
+++ b/backend/app/modules/periodontogram/frontend/components/PerioProfileStrip.vue
@@ -59,8 +59,8 @@ function depthToY(mm: number): number {
 function siteX(toothIdx: number, siteIdx: number): number {
   // Three sites per tooth, evenly spaced across the column at 20/50/80%.
   // The middle site sits over the centre of the tooth silhouette.
-  const offsets = [0.2, 0.5, 0.8]
-  return toothIdx * COL_W + COL_W * offsets[siteIdx]
+  const offsets = [0.2, 0.5, 0.8] as const
+  return toothIdx * COL_W + COL_W * (offsets[siteIdx] ?? 0.5)
 }
 
 interface PathPoint { x: number, y: number }
@@ -81,8 +81,7 @@ function buildPath(
 }
 
 function siteAt(ti: number, si: number) {
-  const tooth = props.teeth[ti]
-  return tooth.sites.find(s => s.site_code === sites.value[si])
+  return props.teeth[ti]?.sites.find(s => s.site_code === sites.value[si])
 }
 
 const gmPath = computed(() =>

--- a/backend/app/modules/periodontogram/frontend/components/PerioToothLateral.vue
+++ b/backend/app/modules/periodontogram/frontend/components/PerioToothLateral.vue
@@ -53,10 +53,12 @@ const baseTransform = computed(() => getToothTransform(props.tooth.tooth_number)
 const GUM_LINE_Y_BY_POSITION: Record<number, number> = {
   1: 95, 2: 85, 3: 103, 4: 62.5, 5: 80, 6: 85, 7: 78, 8: 63
 }
+const DEFAULT_GUM_LINE_Y = 95 // central incisor
 
 const VIEWBOX_W_BY_POSITION: Record<number, number> = {
   1: 46, 2: 40, 3: 47, 4: 40, 5: 40, 6: 64, 7: 66, 8: 67
 }
+const DEFAULT_VIEWBOX_W = 46 // central incisor
 
 // Common 70 × 150 view window. 70 wide covers the widest molar
 // (vbW=67); 150 tall fits every tooth's crown bottom without cropping
@@ -70,8 +72,8 @@ const TARGET_GUM_VB_Y = 97.5
 
 const alignedViewBox = computed(() => {
   const position = getToothPosition(props.tooth.tooth_number)
-  const vbW = VIEWBOX_W_BY_POSITION[position] ?? VIEWBOX_W_BY_POSITION[1]
-  const gly = GUM_LINE_Y_BY_POSITION[position] ?? GUM_LINE_Y_BY_POSITION[1]
+  const vbW = VIEWBOX_W_BY_POSITION[position] ?? DEFAULT_VIEWBOX_W
+  const gly = GUM_LINE_Y_BY_POSITION[position] ?? DEFAULT_GUM_LINE_Y
   // Centre the tooth horizontally inside the common view window, then
   // shift the view vertically so its CEJ row lands on TARGET_GUM_VB_Y.
   const xV = vbW / 2 - VIEW_W / 2
@@ -114,7 +116,7 @@ const visualOpacity = computed(() => (props.tooth.is_present ? 1 : 0.35))
       <PerioSiteMarker
         v-for="code in visibleSites"
         :key="`above-${code}`"
-        :site="siteByCode[code]"
+        :site="siteByCode[code] ?? null"
         size="sm"
         readonly
       />
@@ -203,7 +205,7 @@ const visualOpacity = computed(() => (props.tooth.is_present ? 1 : 0.35))
       <PerioSiteMarker
         v-for="code in visibleSites"
         :key="`below-${code}`"
-        :site="siteByCode[code]"
+        :site="siteByCode[code] ?? null"
         size="sm"
         readonly
       />

--- a/backend/app/modules/periodontogram/frontend/components/PeriodontogramView.vue
+++ b/backend/app/modules/periodontogram/frontend/components/PeriodontogramView.vue
@@ -37,11 +37,11 @@ const viewingDate = ref<string | null>(null)
 const isViewingHistory = computed(() => viewingDate.value !== null)
 
 async function loadCurrentView() {
+  const latest = timeline.value?.dates.at(-1)
   if (hasDraft.value && timeline.value?.draft) {
     await fetchSnapshot(timeline.value.draft.id)
-  } else if (timeline.value && timeline.value.dates.length > 0) {
-    const last = timeline.value.dates[timeline.value.dates.length - 1]
-    await fetchSnapshot(last.snapshot_id)
+  } else if (latest) {
+    await fetchSnapshot(latest.snapshot_id)
   } else {
     currentSnapshot.value = null
   }


### PR DESCRIPTION
Part 3/7 of #184 — odontogram (39), periodontogram (9), patients_clinical (9), patient_timeline (1) → 0. Stacked on #193.

- Treatment colour dots read `TREATMENT_COLORS` (a `{light,dark}` config) as a hex string → they now use the existing `getTreatmentColor()`. Toast undo action used the v3 `click` key (v4: `onClick`); `UPopover`/`UAccordion` `ui` slots renamed (the accordion border classes were not being applied).
- `ToothSVGPaths`: position lookups typed by `ToothPosition` (1–8) with one `getShapePosition()` helper instead of three copies of the deciduous mapping + `|| MAP[1]`; `STATUS_STYLES` re-export typed by `TreatmentStatus` (was `Record<string,…>` via `Object.fromEntries`). `ToothDualView`/`ToothTooltip` referenced a `Treatment` type they never imported — the values are `ToothTreatmentView`.
- `noUncheckedIndexedAccess` sites restructured (guards, `.at(-1)`, non-empty tuple cycles in the perio toggles, `?? null` on optional site markers) — no `!`, no casts. `TreatmentBar` emitted a possibly-undefined fallback status; touch drags guard an empty `touches` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)