### PR TITLE
fix(verifactu,catalog): type-check clean under nuxt typecheck (#184)

### DIFF
--- a/backend/app/modules/catalog/CHANGELOG.md
+++ b/backend/app/modules/catalog/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — VAT-type toasts use semantic colours; `useCatalog` passes typed payloads to `useApi` without `Record` casts; `CatalogItemModal` builds a typed payload (create narrows the required fields instead of casting), option lists are typed to the form's unions, `UTextarea :rows` is a number; VAT badge colours are `UiColor`.
 - feat(onboarding): the `catalog-empty` getting-started step resolves inline — `CatalogSeedQuickModal` calls `POST /catalog/seed` from the dashboard card, or hands off to `/settings/catalog`.
 
 - feat: `POST /catalog/seed` (`catalog.admin`) loads the stock VAT types, categories and treatments for the clinic — idempotent repair path for installs created before `clinic.created` seeding existed (≤ v2.2.2) or where that seed failed silently. Surfaced as "Load default catalog" in the empty state of `/settings/catalog`.

--- a/backend/app/modules/catalog/frontend/components/catalog/CatalogItemModal.vue
+++ b/backend/app/modules/catalog/frontend/components/catalog/CatalogItemModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type {
   CatalogItemSessionInput,
+  PricingStrategy,
   TreatmentCatalogCategory,
   TreatmentCatalogItem,
   TreatmentCatalogItemUpdate,
@@ -195,7 +196,7 @@ watch(sessionsEnabled, (enabled) => {
 })
 
 // Scope options with icons
-const scopeOptionsVisual = computed(() => [
+const scopeOptionsVisual = computed<{ value: NonNullable<TreatmentCatalogItemCreate['treatment_scope']>, label: string, icon: string }[]>(() => [
   { value: 'tooth', label: t('catalog.scopeTypes.tooth'), icon: 'i-lucide-circle-dot' },
   { value: 'multi_tooth', label: t('catalog.scopeTypes.multi_tooth'), icon: 'i-lucide-grip' },
   { value: 'global_arch', label: t('catalog.scopeTypes.global_arch'), icon: 'i-lucide-rectangle-horizontal' },
@@ -203,7 +204,7 @@ const scopeOptionsVisual = computed(() => [
 ])
 
 // Pricing strategy with icons
-const strategyOptionsVisual = computed(() => [
+const strategyOptionsVisual = computed<{ value: PricingStrategy, label: string, icon: string }[]>(() => [
   { value: 'flat', label: t('catalog.pricingStrategy.flat'), icon: 'i-lucide-equal' },
   { value: 'per_tooth', label: t('catalog.pricingStrategy.per_tooth'), icon: 'i-lucide-x' },
   { value: 'per_surface', label: t('catalog.pricingStrategy.per_surface'), icon: 'i-lucide-layers' },
@@ -252,7 +253,7 @@ const categoryOptions = computed(() =>
   }))
 )
 
-const odontogramTypeOptions = computed(() => [
+const odontogramTypeOptions = computed<{ value: string | undefined, label: string }[]>(() => [
   { value: undefined, label: t('catalog.noOdontogramMapping') },
   ...ALL_TREATMENT_TYPES.map(type => ({
     value: type,
@@ -260,7 +261,7 @@ const odontogramTypeOptions = computed(() => [
   }))
 ])
 
-const clinicalCategoryOptions = computed(() =>
+const clinicalCategoryOptions = computed<{ value: string, label: string }[]>(() =>
   TREATMENT_CATEGORIES.map(c => ({
     value: c.key,
     label: t(c.labelKey, c.key)
@@ -314,15 +315,14 @@ const pricingHasError = computed(() =>
 function handleSubmit() {
   if (!isValid.value) return
 
-  const cleanData: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(formData.value)) {
-    if (value !== undefined) {
-      cleanData[key] = value
-    }
+  // `undefined` fields are dropped by JSON serialisation, so the form
+  // state is the payload as-is.
+  const payload: TreatmentCatalogItemUpdate = {
+    ...formData.value,
+    sessions: sessionsEnabled.value ? sessionsToPayload() : []
   }
-
   if (odontogramType.value && clinicalCategory.value) {
-    cleanData.odontogram_mapping = {
+    payload.odontogram_mapping = {
       odontogram_treatment_type: odontogramType.value,
       visualization_rules: getVisualizationRules(odontogramType.value),
       visualization_config: {},
@@ -330,12 +330,13 @@ function handleSubmit() {
     }
   }
 
-  cleanData.sessions = sessionsEnabled.value ? sessionsToPayload() : []
-
   if (isCreateMode.value) {
-    emit('create', cleanData as TreatmentCatalogItemCreate)
+    // isValid guarantees these; narrowing keeps the create payload honest.
+    const { internal_code, category_id, names } = payload
+    if (!internal_code || !category_id || !names) return
+    emit('create', { ...payload, internal_code, category_id, names })
   } else {
-    emit('save', cleanData as TreatmentCatalogItemUpdate)
+    emit('save', payload)
   }
 }
 
@@ -487,7 +488,7 @@ function handleClose() {
               <UFormField :label="t('catalog.materialNotes')">
                 <UTextarea
                   v-model="formData.material_notes"
-                  rows="2"
+                  :rows="2"
                   :placeholder="t('catalog.materialNotesPlaceholder')"
                 />
               </UFormField>

--- a/backend/app/modules/catalog/frontend/composables/useCatalog.ts
+++ b/backend/app/modules/catalog/frontend/composables/useCatalog.ts
@@ -88,7 +88,7 @@ export function useCatalog() {
     try {
       const response = await api.post<ApiResponse<TreatmentCatalogCategory>>(
         '/api/v1/catalog/categories',
-        data as Record<string, unknown>
+        data
       )
 
       toast.add({
@@ -127,7 +127,7 @@ export function useCatalog() {
     try {
       const response = await api.put<ApiResponse<TreatmentCatalogCategory>>(
         `/api/v1/catalog/categories/${categoryId}`,
-        data as Record<string, unknown>
+        data
       )
 
       toast.add({
@@ -255,7 +255,7 @@ export function useCatalog() {
     try {
       const response = await api.post<ApiResponse<TreatmentCatalogItem>>(
         '/api/v1/catalog/items',
-        data as Record<string, unknown>
+        data
       )
 
       toast.add({
@@ -300,7 +300,7 @@ export function useCatalog() {
     try {
       const response = await api.put<ApiResponse<TreatmentCatalogItem>>(
         `/api/v1/catalog/items/${itemId}`,
-        data as Record<string, unknown>
+        data
       )
 
       toast.add({

--- a/backend/app/modules/catalog/frontend/composables/useTreatmentCatalog.ts
+++ b/backend/app/modules/catalog/frontend/composables/useTreatmentCatalog.ts
@@ -282,9 +282,9 @@ export function useTreatmentCatalog() {
   function getCategoryLabel(categoryKey: string, overrideLocale?: string): string {
     const loc = overrideLocale || locale.value
     if (useCatalog.value) {
-      const treatments = treatmentsByCategory.value[categoryKey]
-      if (treatments && treatments.length > 0) {
-        return treatments[0].category_names[loc] || treatments[0].category_names.es || treatments[0].category_names.en || categoryKey
+      const first = treatmentsByCategory.value[categoryKey]?.[0]
+      if (first) {
+        return first.category_names[loc] || first.category_names.es || first.category_names.en || categoryKey
       }
     }
 

--- a/backend/app/modules/catalog/frontend/composables/useVatTypes.ts
+++ b/backend/app/modules/catalog/frontend/composables/useVatTypes.ts
@@ -54,7 +54,7 @@ export function useVatTypes() {
       toast.add({
         title: t('common.error'),
         description: errorMessage(e, t('vatTypes.loadError')),
-        color: 'red'
+        color: 'error'
       })
     } finally {
       isLoading.value = false
@@ -73,14 +73,14 @@ export function useVatTypes() {
       toast.add({
         title: t('common.success'),
         description: t('vatTypes.created'),
-        color: 'green'
+        color: 'success'
       })
       return response.data
     } catch (e) {
       toast.add({
         title: t('common.error'),
         description: errorMessage(e, t('vatTypes.createError')),
-        color: 'red'
+        color: 'error'
       })
       return null
     }
@@ -105,14 +105,14 @@ export function useVatTypes() {
       toast.add({
         title: t('common.success'),
         description: t('vatTypes.updated'),
-        color: 'green'
+        color: 'success'
       })
       return response.data
     } catch (e) {
       toast.add({
         title: t('common.error'),
         description: errorMessage(e, t('vatTypes.updateError')),
-        color: 'red'
+        color: 'error'
       })
       return null
     }
@@ -123,21 +123,19 @@ export function useVatTypes() {
     try {
       await api.del(`/api/v1/catalog/vat-types/${id}`)
       // Mark as inactive in local state
-      const index = vatTypes.value.findIndex(vt => vt.id === id)
-      if (index !== -1) {
-        vatTypes.value[index] = { ...vatTypes.value[index], is_active: false }
-      }
+      const deleted = vatTypes.value.find(vt => vt.id === id)
+      if (deleted) deleted.is_active = false
       toast.add({
         title: t('common.success'),
         description: t('vatTypes.deleted'),
-        color: 'green'
+        color: 'success'
       })
       return true
     } catch (e) {
       toast.add({
         title: t('common.error'),
         description: errorMessage(e, t('vatTypes.deleteError')),
-        color: 'red'
+        color: 'error'
       })
       return false
     }

--- a/backend/app/modules/catalog/frontend/pages/settings/catalog/index.vue
+++ b/backend/app/modules/catalog/frontend/pages/settings/catalog/index.vue
@@ -2,6 +2,7 @@
 import type { TreatmentCatalogItem, TreatmentCatalogItemUpdate, TreatmentCatalogItemCreate, TreatmentCatalogCategory, VatTypeBrief } from '~~/app/types'
 
 import { PERMISSIONS } from '~~/app/config/permissions'
+import type { UiColor } from '~~/app/config/severity'
 
 const { t, locale } = useI18n()
 const { isAdmin, can } = usePermissions()
@@ -195,12 +196,12 @@ function getVatTypeLabel(vatType: VatTypeBrief | undefined): string {
   return vatType.names[locale.value] || vatType.names.es || vatType.names.en || '-'
 }
 
-function getVatTypeBadgeColor(vatType: VatTypeBrief | undefined): string {
+function getVatTypeBadgeColor(vatType: VatTypeBrief | undefined): UiColor {
   if (!vatType) return 'neutral'
-  // Color based on rate: 0% = green, < 10% = yellow, >= 10% = red
-  if (vatType.rate === 0) return 'green'
-  if (vatType.rate < 10) return 'yellow'
-  return 'red'
+  // Color based on rate: 0% = success, < 10% = warning, >= 10% = error
+  if (vatType.rate === 0) return 'success'
+  if (vatType.rate < 10) return 'warning'
+  return 'error'
 }
 
 // Category options for filter

--- a/backend/app/modules/clinical_notes/CHANGELOG.md
+++ b/backend/app/modules/clinical_notes/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — `sourceBadgeColor()` returns `UiColor` (plan notes use `neutral`, the design-system role, instead of `secondary`).
 - i18n: add Tamil locale (`ta.json`); add Tamil translations to seed
   data; add `body_i18n_key` to template responses so template bodies
   resolve in the active locale. Labels now resolve via

--- a/backend/app/modules/clinical_notes/frontend/components/PatientClinicalNotesByPlan.vue
+++ b/backend/app/modules/clinical_notes/frontend/components/PatientClinicalNotesByPlan.vue
@@ -10,6 +10,7 @@
  */
 
 import type { PlanNotesGroup } from '~~/app/types'
+import type { UiColor } from '~~/app/config/severity'
 
 const props = defineProps<{
   ctx: { patientId: string }
@@ -41,10 +42,10 @@ function formatDate(iso: string): string {
   }
 }
 
-function sourceBadgeColor(source: 'plan' | 'treatment' | 'visit'): string {
+function sourceBadgeColor(source: 'plan' | 'treatment' | 'visit'): UiColor {
   if (source === 'visit') return 'primary'
   if (source === 'treatment') return 'success'
-  return 'secondary'
+  return 'neutral'
 }
 
 const hasAny = computed(() =>

--- a/backend/app/modules/migration_import/CHANGELOG.md
+++ b/backend/app/modules/migration_import/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — semantic badge/toast colours; `scoreBadgeColor()` returns `UiColor`.
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 
 - style(lint): first ESLint pass over this module's frontend layer —

--- a/backend/app/modules/migration_import/frontend/components/settings/DataMigrationPage.vue
+++ b/backend/app/modules/migration_import/frontend/components/settings/DataMigrationPage.vue
@@ -6,6 +6,7 @@
 import { computed, onUnmounted, ref } from 'vue'
 import { PERMISSIONS } from '~~/app/config/permissions'
 import { errorMessage } from '~~/app/utils/error'
+import type { UiColor } from '~~/app/config/severity'
 
 const { t } = useI18n()
 const api = useApi()
@@ -219,11 +220,11 @@ async function patchProposal(proposal: MappingProposal, operatorAction: string) 
   await loadProposals()
 }
 
-function scoreBadgeColor(score: number | null): string {
-  if (score === null) return 'gray'
-  if (score >= 0.9) return 'green'
-  if (score >= 0.8) return 'blue'
-  return 'amber'
+function scoreBadgeColor(score: number | null): UiColor {
+  if (score === null) return 'neutral'
+  if (score >= 0.9) return 'success'
+  if (score >= 0.8) return 'info'
+  return 'warning'
 }
 
 function operatorStatusKey(action: string): string {
@@ -293,7 +294,7 @@ onUnmounted(() => {
         </UFormField>
         <UAlert
           v-if="uploadError"
-          color="red"
+          color="error"
           :title="t('migrationImport.upload.error')"
           :description="uploadError"
         />
@@ -320,13 +321,13 @@ onUnmounted(() => {
               {{ (job.file_size / 1024 / 1024).toFixed(1) }} MB
             </p>
           </div>
-          <UBadge :color="job.status === 'failed' ? 'red' : job.status === 'completed' ? 'green' : 'blue'">
+          <UBadge :color="job.status === 'failed' ? 'error' : job.status === 'completed' ? 'success' : 'info'">
             {{ t(`migrationImport.status.${job.status}`) }}
           </UBadge>
         </div>
         <UAlert
           v-if="job.error"
-          color="red"
+          color="error"
           :description="job.error"
         />
       </div>
@@ -406,7 +407,7 @@ onUnmounted(() => {
           </div>
           <UAlert
             v-if="proposalsError"
-            color="red"
+            color="error"
             :description="proposalsError"
             class="mt-2"
           />
@@ -494,7 +495,7 @@ onUnmounted(() => {
                   <td class="px-2 py-1">
                     <UBadge
                       size="xs"
-                      :color="p.operator_action === 'pending' ? 'gray' : 'green'"
+                      :color="p.operator_action === 'pending' ? 'neutral' : 'success'"
                     >
                       {{ t(operatorStatusKey(p.operator_action)) }}
                     </UBadge>
@@ -511,7 +512,7 @@ onUnmounted(() => {
                       </UButton>
                       <UButton
                         size="xs"
-                        color="red"
+                        color="error"
                         variant="ghost"
                         :disabled="!canExecute || p.operator_action === 'ignored'"
                         @click="patchProposal(p, 'ignored')"
@@ -602,7 +603,7 @@ onUnmounted(() => {
         </div>
 
         <UAlert
-          color="amber"
+          color="warning"
           :description="t('migrationImport.preview.warning')"
         />
 

--- a/backend/app/modules/recalls/CHANGELOG.md
+++ b/backend/app/modules/recalls/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — the new-category reason ref is typed to the `reasons` union.
 - fix(#183): the four event handlers are transactional (ADR 0019). `on_appointment_scheduled` writes `linked_appointment_id`, an FK to the appointment the publisher has only flushed — from its own session that write was rejected and swallowed, so **auto-link never worked** through the API.
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 

--- a/backend/app/modules/recalls/frontend/components/RecallSettingsPanel.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallSettingsPanel.vue
@@ -73,7 +73,7 @@ const categoryRows = computed(() => {
 })
 
 const newCategoryKey = ref('')
-const newCategoryReason = ref<string>('hygiene')
+const newCategoryReason = ref<(typeof reasons)[number]>('hygiene')
 
 function addCategory() {
   if (!settings.value || !newCategoryKey.value) return

--- a/backend/app/modules/verifactu/CHANGELOG.md
+++ b/backend/app/modules/verifactu/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — toasts/badges/alerts use Nuxt UI v4 semantic colours (`red/green/amber/blue/gray` were rendering uncoloured), `VatClassification` codes are typed once in `useVerifactu` and shared with the VAT-mapping page, the invoice slot's local `errorMessage` computed no longer shadows the `errorMessage()` util it calls, sibling composable imports are relative.
 - docs(#183): `on_invoice_paid` documented as own-session/payload-only (ADR 0019).
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 

--- a/backend/app/modules/verifactu/frontend/components/verifactu/InvoiceVerifactuPanel.vue
+++ b/backend/app/modules/verifactu/frontend/components/verifactu/InvoiceVerifactuPanel.vue
@@ -2,6 +2,8 @@
 // Inline panel rendered in the invoice detail page when the invoice
 // has Verifactu compliance metadata (clinic.country=ES + verifactu
 // installed and enabled).
+import type { UiColor } from '~~/app/config/severity'
+
 const props = defineProps<{
   complianceData?: Record<string, unknown> | null
 }>()
@@ -13,12 +15,12 @@ const data = computed(() => {
   return (cd.ES ?? null) as Record<string, string> | null
 })
 
-const stateColor = computed(() => {
-  if (!data.value) return 'gray'
-  if (data.value.state === 'accepted') return 'green'
-  if (data.value.state === 'rejected') return 'red'
-  if (data.value.state === 'accepted_with_errors') return 'amber'
-  return 'gray'
+const stateColor = computed<UiColor>(() => {
+  if (!data.value) return 'neutral'
+  if (data.value.state === 'accepted') return 'success'
+  if (data.value.state === 'rejected') return 'error'
+  if (data.value.state === 'accepted_with_errors') return 'warning'
+  return 'neutral'
 })
 </script>
 

--- a/backend/app/modules/verifactu/frontend/components/verifactu/InvoiceVerifactuSlot.vue
+++ b/backend/app/modules/verifactu/frontend/components/verifactu/InvoiceVerifactuSlot.vue
@@ -71,7 +71,7 @@ watch(() => invoice.value?.id, fetchLiveRecord)
 const state = computed(
   () => liveRecord.value?.state ?? (es.value?.state as string | undefined) ?? null
 )
-const errorMessage = computed(
+const aeatErrorMessage = computed(
   () =>
     liveRecord.value?.aeat_descripcion_error
     ?? (es.value?.error_message as string | undefined)
@@ -133,7 +133,7 @@ async function save() {
       billing_address: editAddress.value,
       expected_updated_at: invoice.value.updated_at ?? null
     })
-    toast?.add({ title: t('verifactu.billingParty.saved'), color: 'green' })
+    toast?.add({ title: t('verifactu.billingParty.saved'), color: 'success' })
     editOpen.value = false
     await fetchInvoice(invoice.value.id)
     await fetchLiveRecord()
@@ -141,7 +141,7 @@ async function save() {
     const msg = errorStatus(e) === 409
       ? t('verifactu.billingParty.concurrentEdit')
       : errorMessage(e, t('verifactu.billingParty.saveFailed'))
-    toast?.add({ title: msg, color: 'red' })
+    toast?.add({ title: msg, color: 'error' })
   } finally {
     saving.value = false
   }
@@ -154,11 +154,11 @@ async function regenerate() {
   regenerating.value = true
   try {
     await retryRecord(recordId)
-    toast?.add({ title: t('verifactu.queue.regeneratedToast'), color: 'green' })
+    toast?.add({ title: t('verifactu.queue.regeneratedToast'), color: 'success' })
     if (invoice.value?.id) await fetchInvoice(invoice.value.id)
     await fetchLiveRecord()
   } catch (e: unknown) {
-    toast?.add({ title: errorMessage(e, t('verifactu.billingParty.saveFailed')), color: 'red' })
+    toast?.add({ title: errorMessage(e, t('verifactu.billingParty.saveFailed')), color: 'error' })
   } finally {
     regenerating.value = false
   }
@@ -173,14 +173,14 @@ function goToClinic() {
   <div class="space-y-3">
     <UAlert
       v-if="isRejected"
-      color="red"
+      color="error"
       variant="soft"
       icon="i-lucide-alert-triangle"
       :title="t('verifactu.invoiceBanner.rejectedTitle')"
     >
       <template #description>
         <p class="mb-2">
-          {{ errorMessage || t('verifactu.invoiceBanner.rejectedBody') }}
+          {{ aeatErrorMessage || t('verifactu.invoiceBanner.rejectedBody') }}
         </p>
         <div class="flex flex-wrap gap-2">
           <UButton
@@ -214,7 +214,7 @@ function goToClinic() {
 
     <UAlert
       v-if="isAccepted && invoice?.pdf_stale"
-      color="amber"
+      color="warning"
       variant="soft"
       icon="i-lucide-file-warning"
       :title="t('verifactu.invoiceBanner.pdfStaleTitle')"

--- a/backend/app/modules/verifactu/frontend/components/verifactu/RejectedGlobalBanner.vue
+++ b/backend/app/modules/verifactu/frontend/components/verifactu/RejectedGlobalBanner.vue
@@ -37,7 +37,7 @@ onBeforeUnmount(() => {
 <template>
   <UAlert
     v-if="showing"
-    color="red"
+    color="error"
     variant="soft"
     icon="i-lucide-alert-octagon"
     :title="t('verifactu.globalBanner.title', { n: rejectedCount })"

--- a/backend/app/modules/verifactu/frontend/composables/useVerifactu.ts
+++ b/backend/app/modules/verifactu/frontend/composables/useVerifactu.ts
@@ -264,14 +264,18 @@ export const useVerifactu = () => {
   }
 }
 
+/** AEAT VAT classification codes (mirrors the backend `pattern`). */
+export const VAT_CLASSIFICATION_CODES = ['S1', 'S2', 'E1', 'E2', 'E3', 'E4', 'E5', 'E6', 'N1', 'N2'] as const
+export type VatClassification = (typeof VAT_CLASSIFICATION_CODES)[number]
+
 export interface VatClassificationItem {
   vat_type_id: string
   label: string
   rate: string
   is_default: boolean
-  inferred_classification: string
+  inferred_classification: VatClassification
   inferred_exemption_cause: string | null
-  override_classification: string | null
+  override_classification: VatClassification | null
   override_exemption_cause: string | null
   override_notes: string | null
 }

--- a/backend/app/modules/verifactu/frontend/pages/settings/verifactu/certificate.vue
+++ b/backend/app/modules/verifactu/frontend/pages/settings/verifactu/certificate.vue
@@ -85,7 +85,7 @@ async function submit() {
     await uploadCertificate(file.value, password.value)
     file.value = null
     password.value = ''
-    toast?.add({ title: t('verifactu.certificate.uploaded'), color: 'green' })
+    toast?.add({ title: t('verifactu.certificate.uploaded'), color: 'success' })
     await refresh()
   } catch (e: unknown) {
     error.value = errorMessage(e, t('verifactu.certificate.uploadFailed'))
@@ -328,7 +328,7 @@ onMounted(refresh)
 
         <UAlert
           v-if="error"
-          color="red"
+          color="error"
           variant="soft"
           icon="i-lucide-alert-triangle"
           :title="error"
@@ -403,7 +403,7 @@ onMounted(refresh)
           class="py-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm"
         >
           <UBadge
-            :color="c.is_active ? 'green' : 'gray'"
+            :color="c.is_active ? 'success' : 'neutral'"
             variant="subtle"
             size="sm"
           >

--- a/backend/app/modules/verifactu/frontend/pages/settings/verifactu/index.vue
+++ b/backend/app/modules/verifactu/frontend/pages/settings/verifactu/index.vue
@@ -6,6 +6,7 @@
 // summaries that link to their dedicated pages. The environment switch
 // lives only in the hero so there is no conflicting control elsewhere.
 import { PERMISSIONS } from '~~/app/config/permissions'
+import type { UiColor } from '~~/app/config/severity'
 import { errorMessage as resolveErrorMessage } from '~~/app/utils/error'
 
 const { t } = useI18n()
@@ -159,12 +160,12 @@ async function confirmProd() {
   }
 }
 
-const certWarning = computed(() => {
+const certWarning = computed<{ color: UiColor, message: string } | null>(() => {
   if (!summary.value || !summary.value.has_certificate || !summary.value.certificate_valid_until) return null
   const until = new Date(summary.value.certificate_valid_until)
   const days = Math.floor((until.getTime() - Date.now()) / (1000 * 60 * 60 * 24))
-  if (days < 0) return { color: 'red', message: t('verifactu.status.certificateExpired') }
-  if (days < 60) return { color: days < 15 ? 'red' : 'amber', message: t('verifactu.status.certificateExpiringSoon', { days }) }
+  if (days < 0) return { color: 'error', message: t('verifactu.status.certificateExpired') }
+  if (days < 60) return { color: days < 15 ? 'error' : 'warning', message: t('verifactu.status.certificateExpiringSoon', { days }) }
   return null
 })
 
@@ -257,7 +258,7 @@ onMounted(refresh)
           >
             <UButton
               :loading="saving"
-              :color="settings?.enabled ? 'gray' : 'primary'"
+              :color="settings?.enabled ? 'neutral' : 'primary'"
               :icon="settings?.enabled ? 'i-lucide-power-off' : 'i-lucide-power'"
               @click="toggleEnabled"
             >
@@ -269,7 +270,7 @@ onMounted(refresh)
             <div class="flex items-center gap-2 text-sm">
               <span class="text-gray-500">{{ t('verifactu.environment.label') }}:</span>
               <UBadge
-                :color="settings?.environment === 'prod' ? 'red' : 'gray'"
+                :color="settings?.environment === 'prod' ? 'error' : 'neutral'"
                 variant="subtle"
               >
                 {{ t(`verifactu.environment.${settings?.environment}`) }}
@@ -278,7 +279,7 @@ onMounted(refresh)
                 v-if="settings?.environment === 'test' && canPromoteToProd"
                 :loading="switchingEnv"
                 variant="ghost"
-                color="red"
+                color="error"
                 size="xs"
                 trailing-icon="i-lucide-arrow-right"
                 @click="switchEnvironment('prod')"
@@ -299,7 +300,7 @@ onMounted(refresh)
 
           <UAlert
             v-if="errorMessage"
-            color="red"
+            color="error"
             variant="soft"
             :title="errorMessage"
             class="mt-4"
@@ -569,7 +570,7 @@ onMounted(refresh)
                 {{ t('common.cancel') }}
               </UButton>
               <UButton
-                color="red"
+                color="error"
                 :loading="switchingEnv"
                 @click="confirmProd"
               >

--- a/backend/app/modules/verifactu/frontend/pages/settings/verifactu/producer.vue
+++ b/backend/app/modules/verifactu/frontend/pages/settings/verifactu/producer.vue
@@ -6,7 +6,7 @@
 //    El servidor sella timestamp + user_id como evidencia para una
 //    inspección AEAT (RD 1007/2023 art. 13).
 // 3. Descarga el PDF firmado para archivo / distribución a clínicas.
-import type { ProducerInfoUpdate, VerifactuSettings, ProducerDefaults } from '~/composables/useVerifactu'
+import type { ProducerInfoUpdate, VerifactuSettings, ProducerDefaults } from '../../../composables/useVerifactu'
 import { PERMISSIONS } from '~~/app/config/permissions'
 import { errorMessage } from '~~/app/utils/error'
 
@@ -80,7 +80,7 @@ async function saveDraft() {
   error.value = null
   try {
     settings.value = await updateProducer({ ...form.value, sign_declaracion: false })
-    toast?.add({ title: t('verifactu.producer.draftSaved'), color: 'green' })
+    toast?.add({ title: t('verifactu.producer.draftSaved'), color: 'success' })
   } catch (e: unknown) {
     error.value = errorMessage(e, t('verifactu.producer.saveFailed'))
   } finally {
@@ -96,7 +96,7 @@ async function revokeNow() {
     settings.value = await revokeDeclaration()
     showRevokeConfirm.value = false
     acceptedDeclaration.value = false
-    toast?.add({ title: t('verifactu.producer.revokedToast'), color: 'amber' })
+    toast?.add({ title: t('verifactu.producer.revokedToast'), color: 'warning' })
   } catch (e: unknown) {
     error.value = errorMessage(e, t('verifactu.producer.saveFailed'))
   } finally {
@@ -111,7 +111,7 @@ async function signNow() {
   try {
     settings.value = await updateProducer({ ...form.value, sign_declaracion: true })
     acceptedDeclaration.value = false
-    toast?.add({ title: t('verifactu.producer.signedToast'), color: 'green' })
+    toast?.add({ title: t('verifactu.producer.signedToast'), color: 'success' })
   } catch (e: unknown) {
     error.value = errorMessage(e, t('verifactu.producer.saveFailed'))
   } finally {
@@ -206,7 +206,7 @@ onMounted(refresh)
     <!-- 3-step process explainer. Always visible so the user has the
          mental model of what's required before scrolling. -->
     <UAlert
-      color="blue"
+      color="info"
       variant="soft"
       :title="t('verifactu.producer.process.title')"
     >
@@ -245,7 +245,7 @@ onMounted(refresh)
 
         <UAlert
           v-if="alreadySigned"
-          color="amber"
+          color="warning"
           variant="soft"
           icon="i-lucide-lock"
           :title="t('verifactu.producer.step1.lockedTitle')"
@@ -255,7 +255,7 @@ onMounted(refresh)
           <template #actions>
             <UButton
               v-if="canManage"
-              color="amber"
+              color="warning"
               variant="solid"
               size="xs"
               icon="i-lucide-unlock"
@@ -335,7 +335,7 @@ onMounted(refresh)
               </h2>
             </div>
             <UBadge
-              :color="alreadySigned ? 'green' : 'amber'"
+              :color="alreadySigned ? 'success' : 'warning'"
               variant="subtle"
               :icon="alreadySigned ? 'i-lucide-check-circle' : 'i-lucide-clock'"
             >
@@ -392,7 +392,7 @@ onMounted(refresh)
 
           <UAlert
             v-if="error"
-            color="red"
+            color="error"
             variant="soft"
             :title="error"
           />
@@ -499,7 +499,7 @@ onMounted(refresh)
                 {{ t('common.cancel') }}
               </UButton>
               <UButton
-                color="amber"
+                color="warning"
                 :loading="revoking"
                 icon="i-lucide-unlock"
                 @click="revokeNow"

--- a/backend/app/modules/verifactu/frontend/pages/settings/verifactu/queue.vue
+++ b/backend/app/modules/verifactu/frontend/pages/settings/verifactu/queue.vue
@@ -40,13 +40,13 @@ async function retry(item: VerifactuQueueItem) {
     await retryRecord(item.id)
     toast?.add({
       title: t('verifactu.queue.regeneratedToast'),
-      color: 'green'
+      color: 'success'
     })
     await refresh()
   } catch (e: unknown) {
     toast?.add({
       title: errorMessage(e, 'Error'),
-      color: 'red'
+      color: 'error'
     })
   } finally {
     retryingId.value = null
@@ -63,7 +63,7 @@ async function retryAll() {
         n: r.regenerated,
         failed: r.failed.length
       }),
-      color: r.failed.length === 0 ? 'green' : 'amber'
+      color: r.failed.length === 0 ? 'success' : 'warning'
     })
     await refresh()
   } finally {
@@ -81,7 +81,7 @@ async function process() {
   processing.value = true
   try {
     const r = await processNow()
-    toast?.add({ title: t('verifactu.queue.processed', { n: r.processed }), color: 'green' })
+    toast?.add({ title: t('verifactu.queue.processed', { n: r.processed }), color: 'success' })
     await refresh()
   } finally {
     processing.value = false

--- a/backend/app/modules/verifactu/frontend/pages/settings/verifactu/records.vue
+++ b/backend/app/modules/verifactu/frontend/pages/settings/verifactu/records.vue
@@ -126,7 +126,7 @@ onMounted(refresh)
             </td>
             <td class="py-2 px-2">
               <UBadge
-                :color="r.state === 'accepted' ? 'green' : r.state === 'rejected' ? 'red' : 'gray'"
+                :color="r.state === 'accepted' ? 'success' : r.state === 'rejected' ? 'error' : 'neutral'"
                 variant="subtle"
               >
                 {{ t(`verifactu.recordState.${r.state}`) }}

--- a/backend/app/modules/verifactu/frontend/pages/settings/verifactu/vat-mapping.vue
+++ b/backend/app/modules/verifactu/frontend/pages/settings/verifactu/vat-mapping.vue
@@ -5,7 +5,8 @@
 // admin pin its AEAT ``CalificacionOperacion`` / ``OperacionExenta``
 // override. When no override is set, the verifactu hook falls back to
 // the rate-based heuristic.
-import type { VatClassificationItem } from '~/composables/useVerifactu'
+import type { VatClassification, VatClassificationItem } from '../../../composables/useVerifactu'
+import type { UiColor } from '~~/app/config/severity'
 import { PERMISSIONS } from '~~/app/config/permissions'
 import { errorMessage } from '~~/app/utils/error'
 
@@ -20,7 +21,7 @@ const items = ref<VatClassificationItem[]>([])
 const loading = ref(true)
 const saving = ref<string | null>(null)
 
-const CLASSIFICATIONS = [
+const CLASSIFICATIONS: { value: VatClassification, label: string }[] = [
   { value: 'S1', label: 'S1 — Sujeto, no exento (régimen general)' },
   { value: 'S2', label: 'S2 — Sujeto, no exento (inversión sujeto pasivo)' },
   { value: 'E1', label: 'E1 — Exento (art. 20 LIVA — sanitario, financiero…)' },
@@ -31,13 +32,13 @@ const CLASSIFICATIONS = [
   { value: 'E6', label: 'E6 — Exento (otros)' },
   { value: 'N1', label: 'N1 — No sujeta (art. 7, 14, otros — por reglas localización)' },
   { value: 'N2', label: 'N2 — No sujeta (por reglas de localización)' }
-] as const
+]
 
 const AUTO_VALUE = '__auto__'
 
 interface Row {
   data: VatClassificationItem
-  selected: string // override classification or AUTO_VALUE
+  selected: VatClassification | typeof AUTO_VALUE // override classification or AUTO_VALUE
   notes: string
   dirty: boolean
 }
@@ -73,10 +74,10 @@ function effectiveSource(row: Row): 'auto' | 'override' {
   return row.selected === AUTO_VALUE ? 'auto' : 'override'
 }
 
-function classificationColor(code: string): 'green' | 'amber' | 'gray' {
-  if (code.startsWith('S')) return 'green'
-  if (code.startsWith('E')) return 'amber'
-  return 'gray'
+function classificationColor(code: string): UiColor {
+  if (code.startsWith('S')) return 'success'
+  if (code.startsWith('E')) return 'warning'
+  return 'neutral'
 }
 
 async function save(row: Row) {
@@ -99,9 +100,9 @@ async function save(row: Row) {
       row.data = updated
     }
     row.dirty = false
-    toast?.add({ title: t('verifactu.vatMapping.saved'), color: 'green' })
+    toast?.add({ title: t('verifactu.vatMapping.saved'), color: 'success' })
   } catch (e: unknown) {
-    toast?.add({ title: errorMessage(e, t('verifactu.vatMapping.saveFailed')), color: 'red' })
+    toast?.add({ title: errorMessage(e, t('verifactu.vatMapping.saveFailed')), color: 'error' })
   } finally {
     saving.value = null
   }
@@ -130,7 +131,7 @@ onMounted(refresh)
     </header>
 
     <UAlert
-      color="blue"
+      color="info"
       variant="soft"
       icon="i-lucide-info"
       :title="t('verifactu.vatMapping.legalIntroTitle')"


### PR DESCRIPTION
Part 4/7 of #184 — verifactu (41), catalog (21), migration_import (8), clinical_notes (2), recalls (1) → 0. Stacked on #194.

- Mostly Nuxt UI v3 colour names (`red/green/amber/blue/gray`) that v4 ignores in toasts/badges/alerts → semantic `error/success/warning/info/neutral`; colour helpers return `UiColor` (`~~/app/config/severity`, the established pattern).
- verifactu: VAT classification codes typed once in `useVerifactu` (`VatClassification`, mirrors the backend pattern) and shared with the mapping page; the invoice slot's local `errorMessage` computed shadowed the `errorMessage()` util it calls (renamed `aeatErrorMessage`); sibling imports relative.
- catalog: `useCatalog` passes typed payloads to `useApi` without `Record` casts; `CatalogItemModal` builds a typed payload and narrows the create-required fields instead of casting; option lists typed to the form's unions; `UTextarea :rows` is a number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)