### PR TITLE
fix(patients,agenda): type-check clean under nuxt typecheck (#184)

### DIFF
--- a/backend/app/modules/agenda/CHANGELOG.md
+++ b/backend/app/modules/agenda/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean. `useAppointments`/`useHomeAgenda` expose their lists with `shallowReadonly` (the deep `readonly()` view forced `DeepReadonly<Appointment>` through every child prop); the mobile day summary/timeline called `t()` with a 3-arg (key, fallback, params) form vue-i18n does not have — the keys exist in every locale, so params only; `getCabinetColor` accepts the nullable cabinet; the modal no longer sends a `media` field `PlannedTreatmentItem` does not have.
 - fix(#183): appointment events are published with `db=` so recalls, treatment_plan and notifications react inside the request's transaction (ADR 0019).
 - feat(onboarding): subscribe to `clinic.created` — create one default cabinet for a new clinic.
 

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentCalendar.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentCalendar.vue
@@ -235,7 +235,7 @@ function getAppointmentDayIndex(appointment: Appointment): number {
 }
 
 // Get cabinet color
-function getCabinetColor(cabinetName: string): string {
+function getCabinetColor(cabinetName: string | null): string {
   const cabinet = props.cabinets?.find(c => c.name === cabinetName)
   return cabinet?.color || '#6B7280' // Default gray
 }

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentMobileDaySummary.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentMobileDaySummary.vue
@@ -170,7 +170,7 @@ function minDurationLabel(value: number): string {
           class="w-3.5 h-3.5"
         />
         <span class="tnum">
-          {{ t('appointments.freeSlots.nextFreeAt', 'Próximo {time}', {
+          {{ t('appointments.freeSlots.nextFreeAt', {
             time: formatNextFreeTime(summary.nextFreeStart)
           }) }}
           <span class="text-subtle">
@@ -186,7 +186,7 @@ function minDurationLabel(value: number): string {
           class="w-3.5 h-3.5"
         />
         <span class="tnum">
-          {{ t('appointments.freeSlots.gapsAtLeast', '{count} huecos ≥ {min} min', {
+          {{ t('appointments.freeSlots.gapsAtLeast', {
             count: summary.qualifyingGapsCount,
             min: minDurationMin
           }) }}

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentMobileTimeline.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentMobileTimeline.vue
@@ -88,11 +88,10 @@ function blockedLabel(e: BlockedEntry): string {
 }
 
 function freeAriaLabel(e: FreeSlotEntry): string {
-  return t(
-    'appointments.freeSlots.tapToBookAria',
-    'Hueco libre de {duration} a las {time}',
-    { duration: formatDuration(e.durationMin), time: formatTime(e.start) }
-  )
+  return t('appointments.freeSlots.tapToBookAria', {
+    duration: formatDuration(e.durationMin),
+    time: formatTime(e.start)
+  })
 }
 
 function entryKey(e: TimelineEntry, i: number): string {

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentModal.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentModal.vue
@@ -346,8 +346,7 @@ watch(() => props.open, async (isOpen) => {
               names: t.names,
               default_price: t.default_price != null ? String(t.default_price) : null
             }
-          : undefined,
-        media: []
+          : undefined
       }))
     } else {
       selectedTreatments.value = []

--- a/backend/app/modules/agenda/frontend/composables/useAppointments.ts
+++ b/backend/app/modules/agenda/frontend/composables/useAppointments.ts
@@ -179,7 +179,10 @@ export function useAppointments() {
   }
 
   return {
-    appointments: readonly(appointments),
+    // shallowReadonly: consumers cannot swap the list, while elements keep
+    // their `Appointment` type — the deep `readonly()` view forces
+    // DeepReadonly<Appointment> through every child prop and emit.
+    appointments: shallowReadonly(appointments),
     isLoading: readonly(isLoading),
     error: readonly(error),
     fetchAppointments,

--- a/backend/app/modules/agenda/frontend/composables/useHomeAgenda.ts
+++ b/backend/app/modules/agenda/frontend/composables/useHomeAgenda.ts
@@ -62,8 +62,10 @@ export function useHomeAgenda() {
   }
 
   return {
-    todayAppointments: readonly(todayAppointments),
-    tomorrowUnconfirmed: readonly(tomorrowUnconfirmed),
+    // shallowReadonly (see useAppointments): the list cannot be swapped,
+    // elements keep their `Appointment` type for child props.
+    todayAppointments: shallowReadonly(todayAppointments),
+    tomorrowUnconfirmed: shallowReadonly(tomorrowUnconfirmed),
     todayLoaded: readonly(todayLoaded),
     tomorrowLoaded: readonly(tomorrowLoaded),
     fetchToday,

--- a/backend/app/modules/budget/CHANGELOG.md
+++ b/backend/app/modules/budget/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat(#184): `BudgetListResponse` exposes `plan_number_snapshot` so patient-side lists can show the plan link without importing treatment_plan.
 - fix(#183): the three plan-sync handlers are transactional (ADR 0019); a failed mirror now fails the request instead of leaving the quote out of sync with the plan.
 - fix(#183): `budget.superseded` is published before commit like every other event — the treatment_plan handler shares the session, so the FK to the new budget row resolves. Removes the documented "sole deviation from the publish-before-commit pattern".
 - chore: drop `BudgetService.on_treatment_performed`, a no-op placeholder subscribed to `odontogram.treatment.performed`.

--- a/backend/app/modules/budget/schemas.py
+++ b/backend/app/modules/budget/schemas.py
@@ -424,6 +424,9 @@ class BudgetListResponse(BaseModel):
     valid_until: date | None
     total: Decimal
     created_at: datetime
+    # Denormalized plan number when the budget was generated from a
+    # treatment plan (ADR 0003) — lets patient-side lists show the link.
+    plan_number_snapshot: str | None = None
 
     # Related (brief)
     patient: PatientBrief | None = None

--- a/backend/app/modules/catalog/CHANGELOG.md
+++ b/backend/app/modules/catalog/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — VAT-type toasts use semantic colours; `useCatalog` passes typed payloads to `useApi` without `Record` casts; `CatalogItemModal` builds a typed payload (create narrows the required fields instead of casting), option lists are typed to the form's unions, `UTextarea :rows` is a number; VAT badge colours are `UiColor`.
 - feat(onboarding): the `catalog-empty` getting-started step resolves inline — `CatalogSeedQuickModal` calls `POST /catalog/seed` from the dashboard card, or hands off to `/settings/catalog`.
 
 - feat: `POST /catalog/seed` (`catalog.admin`) loads the stock VAT types, categories and treatments for the clinic — idempotent repair path for installs created before `clinic.created` seeding existed (≤ v2.2.2) or where that seed failed silently. Surfaced as "Load default catalog" in the empty state of `/settings/catalog`.

--- a/backend/app/modules/catalog/frontend/components/catalog/CatalogItemModal.vue
+++ b/backend/app/modules/catalog/frontend/components/catalog/CatalogItemModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type {
   CatalogItemSessionInput,
+  PricingStrategy,
   TreatmentCatalogCategory,
   TreatmentCatalogItem,
   TreatmentCatalogItemUpdate,
@@ -195,7 +196,7 @@ watch(sessionsEnabled, (enabled) => {
 })
 
 // Scope options with icons
-const scopeOptionsVisual = computed(() => [
+const scopeOptionsVisual = computed<{ value: NonNullable<TreatmentCatalogItemCreate['treatment_scope']>, label: string, icon: string }[]>(() => [
   { value: 'tooth', label: t('catalog.scopeTypes.tooth'), icon: 'i-lucide-circle-dot' },
   { value: 'multi_tooth', label: t('catalog.scopeTypes.multi_tooth'), icon: 'i-lucide-grip' },
   { value: 'global_arch', label: t('catalog.scopeTypes.global_arch'), icon: 'i-lucide-rectangle-horizontal' },
@@ -203,7 +204,7 @@ const scopeOptionsVisual = computed(() => [
 ])
 
 // Pricing strategy with icons
-const strategyOptionsVisual = computed(() => [
+const strategyOptionsVisual = computed<{ value: PricingStrategy, label: string, icon: string }[]>(() => [
   { value: 'flat', label: t('catalog.pricingStrategy.flat'), icon: 'i-lucide-equal' },
   { value: 'per_tooth', label: t('catalog.pricingStrategy.per_tooth'), icon: 'i-lucide-x' },
   { value: 'per_surface', label: t('catalog.pricingStrategy.per_surface'), icon: 'i-lucide-layers' },
@@ -252,7 +253,7 @@ const categoryOptions = computed(() =>
   }))
 )
 
-const odontogramTypeOptions = computed(() => [
+const odontogramTypeOptions = computed<{ value: string | undefined, label: string }[]>(() => [
   { value: undefined, label: t('catalog.noOdontogramMapping') },
   ...ALL_TREATMENT_TYPES.map(type => ({
     value: type,
@@ -260,7 +261,7 @@ const odontogramTypeOptions = computed(() => [
   }))
 ])
 
-const clinicalCategoryOptions = computed(() =>
+const clinicalCategoryOptions = computed<{ value: string, label: string }[]>(() =>
   TREATMENT_CATEGORIES.map(c => ({
     value: c.key,
     label: t(c.labelKey, c.key)
@@ -314,15 +315,14 @@ const pricingHasError = computed(() =>
 function handleSubmit() {
   if (!isValid.value) return
 
-  const cleanData: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(formData.value)) {
-    if (value !== undefined) {
-      cleanData[key] = value
-    }
+  // `undefined` fields are dropped by JSON serialisation, so the form
+  // state is the payload as-is.
+  const payload: TreatmentCatalogItemUpdate = {
+    ...formData.value,
+    sessions: sessionsEnabled.value ? sessionsToPayload() : []
   }
-
   if (odontogramType.value && clinicalCategory.value) {
-    cleanData.odontogram_mapping = {
+    payload.odontogram_mapping = {
       odontogram_treatment_type: odontogramType.value,
       visualization_rules: getVisualizationRules(odontogramType.value),
       visualization_config: {},
@@ -330,12 +330,13 @@ function handleSubmit() {
     }
   }
 
-  cleanData.sessions = sessionsEnabled.value ? sessionsToPayload() : []
-
   if (isCreateMode.value) {
-    emit('create', cleanData as TreatmentCatalogItemCreate)
+    // isValid guarantees these; narrowing keeps the create payload honest.
+    const { internal_code, category_id, names } = payload
+    if (!internal_code || !category_id || !names) return
+    emit('create', { ...payload, internal_code, category_id, names })
   } else {
-    emit('save', cleanData as TreatmentCatalogItemUpdate)
+    emit('save', payload)
   }
 }
 
@@ -487,7 +488,7 @@ function handleClose() {
               <UFormField :label="t('catalog.materialNotes')">
                 <UTextarea
                   v-model="formData.material_notes"
-                  rows="2"
+                  :rows="2"
                   :placeholder="t('catalog.materialNotesPlaceholder')"
                 />
               </UFormField>

--- a/backend/app/modules/catalog/frontend/composables/useCatalog.ts
+++ b/backend/app/modules/catalog/frontend/composables/useCatalog.ts
@@ -88,7 +88,7 @@ export function useCatalog() {
     try {
       const response = await api.post<ApiResponse<TreatmentCatalogCategory>>(
         '/api/v1/catalog/categories',
-        data as Record<string, unknown>
+        data
       )
 
       toast.add({
@@ -127,7 +127,7 @@ export function useCatalog() {
     try {
       const response = await api.put<ApiResponse<TreatmentCatalogCategory>>(
         `/api/v1/catalog/categories/${categoryId}`,
-        data as Record<string, unknown>
+        data
       )
 
       toast.add({
@@ -255,7 +255,7 @@ export function useCatalog() {
     try {
       const response = await api.post<ApiResponse<TreatmentCatalogItem>>(
         '/api/v1/catalog/items',
-        data as Record<string, unknown>
+        data
       )
 
       toast.add({
@@ -300,7 +300,7 @@ export function useCatalog() {
     try {
       const response = await api.put<ApiResponse<TreatmentCatalogItem>>(
         `/api/v1/catalog/items/${itemId}`,
-        data as Record<string, unknown>
+        data
       )
 
       toast.add({

--- a/backend/app/modules/catalog/frontend/composables/useTreatmentCatalog.ts
+++ b/backend/app/modules/catalog/frontend/composables/useTreatmentCatalog.ts
@@ -282,9 +282,9 @@ export function useTreatmentCatalog() {
   function getCategoryLabel(categoryKey: string, overrideLocale?: string): string {
     const loc = overrideLocale || locale.value
     if (useCatalog.value) {
-      const treatments = treatmentsByCategory.value[categoryKey]
-      if (treatments && treatments.length > 0) {
-        return treatments[0].category_names[loc] || treatments[0].category_names.es || treatments[0].category_names.en || categoryKey
+      const first = treatmentsByCategory.value[categoryKey]?.[0]
+      if (first) {
+        return first.category_names[loc] || first.category_names.es || first.category_names.en || categoryKey
       }
     }
 

--- a/backend/app/modules/catalog/frontend/composables/useVatTypes.ts
+++ b/backend/app/modules/catalog/frontend/composables/useVatTypes.ts
@@ -54,7 +54,7 @@ export function useVatTypes() {
       toast.add({
         title: t('common.error'),
         description: errorMessage(e, t('vatTypes.loadError')),
-        color: 'red'
+        color: 'error'
       })
     } finally {
       isLoading.value = false
@@ -73,14 +73,14 @@ export function useVatTypes() {
       toast.add({
         title: t('common.success'),
         description: t('vatTypes.created'),
-        color: 'green'
+        color: 'success'
       })
       return response.data
     } catch (e) {
       toast.add({
         title: t('common.error'),
         description: errorMessage(e, t('vatTypes.createError')),
-        color: 'red'
+        color: 'error'
       })
       return null
     }
@@ -105,14 +105,14 @@ export function useVatTypes() {
       toast.add({
         title: t('common.success'),
         description: t('vatTypes.updated'),
-        color: 'green'
+        color: 'success'
       })
       return response.data
     } catch (e) {
       toast.add({
         title: t('common.error'),
         description: errorMessage(e, t('vatTypes.updateError')),
-        color: 'red'
+        color: 'error'
       })
       return null
     }
@@ -123,21 +123,19 @@ export function useVatTypes() {
     try {
       await api.del(`/api/v1/catalog/vat-types/${id}`)
       // Mark as inactive in local state
-      const index = vatTypes.value.findIndex(vt => vt.id === id)
-      if (index !== -1) {
-        vatTypes.value[index] = { ...vatTypes.value[index], is_active: false }
-      }
+      const deleted = vatTypes.value.find(vt => vt.id === id)
+      if (deleted) deleted.is_active = false
       toast.add({
         title: t('common.success'),
         description: t('vatTypes.deleted'),
-        color: 'green'
+        color: 'success'
       })
       return true
     } catch (e) {
       toast.add({
         title: t('common.error'),
         description: errorMessage(e, t('vatTypes.deleteError')),
-        color: 'red'
+        color: 'error'
       })
       return false
     }

--- a/backend/app/modules/catalog/frontend/pages/settings/catalog/index.vue
+++ b/backend/app/modules/catalog/frontend/pages/settings/catalog/index.vue
@@ -2,6 +2,7 @@
 import type { TreatmentCatalogItem, TreatmentCatalogItemUpdate, TreatmentCatalogItemCreate, TreatmentCatalogCategory, VatTypeBrief } from '~~/app/types'
 
 import { PERMISSIONS } from '~~/app/config/permissions'
+import type { UiColor } from '~~/app/config/severity'
 
 const { t, locale } = useI18n()
 const { isAdmin, can } = usePermissions()
@@ -195,12 +196,12 @@ function getVatTypeLabel(vatType: VatTypeBrief | undefined): string {
   return vatType.names[locale.value] || vatType.names.es || vatType.names.en || '-'
 }
 
-function getVatTypeBadgeColor(vatType: VatTypeBrief | undefined): string {
+function getVatTypeBadgeColor(vatType: VatTypeBrief | undefined): UiColor {
   if (!vatType) return 'neutral'
-  // Color based on rate: 0% = green, < 10% = yellow, >= 10% = red
-  if (vatType.rate === 0) return 'green'
-  if (vatType.rate < 10) return 'yellow'
-  return 'red'
+  // Color based on rate: 0% = success, < 10% = warning, >= 10% = error
+  if (vatType.rate === 0) return 'success'
+  if (vatType.rate < 10) return 'warning'
+  return 'error'
 }
 
 // Category options for filter

--- a/backend/app/modules/clinical_notes/CHANGELOG.md
+++ b/backend/app/modules/clinical_notes/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — `sourceBadgeColor()` returns `UiColor` (plan notes use `neutral`, the design-system role, instead of `secondary`).
 - i18n: add Tamil locale (`ta.json`); add Tamil translations to seed
   data; add `body_i18n_key` to template responses so template bodies
   resolve in the active locale. Labels now resolve via

--- a/backend/app/modules/clinical_notes/frontend/components/PatientClinicalNotesByPlan.vue
+++ b/backend/app/modules/clinical_notes/frontend/components/PatientClinicalNotesByPlan.vue
@@ -10,6 +10,7 @@
  */
 
 import type { PlanNotesGroup } from '~~/app/types'
+import type { UiColor } from '~~/app/config/severity'
 
 const props = defineProps<{
   ctx: { patientId: string }
@@ -41,10 +42,10 @@ function formatDate(iso: string): string {
   }
 }
 
-function sourceBadgeColor(source: 'plan' | 'treatment' | 'visit'): string {
+function sourceBadgeColor(source: 'plan' | 'treatment' | 'visit'): UiColor {
   if (source === 'visit') return 'primary'
   if (source === 'treatment') return 'success'
-  return 'secondary'
+  return 'neutral'
 }
 
 const hasAny = computed(() =>

--- a/backend/app/modules/media/CHANGELOG.md
+++ b/backend/app/modules/media/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — drop the `onRequest` hook that cast ofetch's `Headers` to delete `Content-Type` (ofetch already leaves it unset for `FormData`).
 - fix(#183): `patient.archived` cascade is transactional (ADR 0019) — the documents are archived with the patient, and no longer stay archived when the request rolls back. Covered end-to-end now that it shares the publisher's session.
 - fix(events): repair the `patient.archived` cascade, which had never
   run (audit event-bus #1, #95). The handler signature took

--- a/backend/app/modules/media/frontend/composables/useDocuments.ts
+++ b/backend/app/modules/media/frontend/composables/useDocuments.ts
@@ -88,13 +88,8 @@ export function useDocuments() {
           headers: {
             Authorization: `Bearer ${auth.accessToken.value}`
           },
-          // Note: browser handles Content-Type for FormData automatically
-          onRequest({ options }) {
-            // Remove content-type to let browser set it with boundary
-            if (options.headers) {
-              delete (options.headers as Record<string, string>)['Content-Type']
-            }
-          },
+          // No Content-Type: ofetch leaves it unset for FormData bodies so
+          // the browser adds the multipart boundary.
           onRequestError() {
             uploadProgress.value = null
           },

--- a/backend/app/modules/migration_import/CHANGELOG.md
+++ b/backend/app/modules/migration_import/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — semantic badge/toast colours; `scoreBadgeColor()` returns `UiColor`.
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 
 - style(lint): first ESLint pass over this module's frontend layer —

--- a/backend/app/modules/migration_import/frontend/components/settings/DataMigrationPage.vue
+++ b/backend/app/modules/migration_import/frontend/components/settings/DataMigrationPage.vue
@@ -6,6 +6,7 @@
 import { computed, onUnmounted, ref } from 'vue'
 import { PERMISSIONS } from '~~/app/config/permissions'
 import { errorMessage } from '~~/app/utils/error'
+import type { UiColor } from '~~/app/config/severity'
 
 const { t } = useI18n()
 const api = useApi()
@@ -219,11 +220,11 @@ async function patchProposal(proposal: MappingProposal, operatorAction: string) 
   await loadProposals()
 }
 
-function scoreBadgeColor(score: number | null): string {
-  if (score === null) return 'gray'
-  if (score >= 0.9) return 'green'
-  if (score >= 0.8) return 'blue'
-  return 'amber'
+function scoreBadgeColor(score: number | null): UiColor {
+  if (score === null) return 'neutral'
+  if (score >= 0.9) return 'success'
+  if (score >= 0.8) return 'info'
+  return 'warning'
 }
 
 function operatorStatusKey(action: string): string {
@@ -293,7 +294,7 @@ onUnmounted(() => {
         </UFormField>
         <UAlert
           v-if="uploadError"
-          color="red"
+          color="error"
           :title="t('migrationImport.upload.error')"
           :description="uploadError"
         />
@@ -320,13 +321,13 @@ onUnmounted(() => {
               {{ (job.file_size / 1024 / 1024).toFixed(1) }} MB
             </p>
           </div>
-          <UBadge :color="job.status === 'failed' ? 'red' : job.status === 'completed' ? 'green' : 'blue'">
+          <UBadge :color="job.status === 'failed' ? 'error' : job.status === 'completed' ? 'success' : 'info'">
             {{ t(`migrationImport.status.${job.status}`) }}
           </UBadge>
         </div>
         <UAlert
           v-if="job.error"
-          color="red"
+          color="error"
           :description="job.error"
         />
       </div>
@@ -406,7 +407,7 @@ onUnmounted(() => {
           </div>
           <UAlert
             v-if="proposalsError"
-            color="red"
+            color="error"
             :description="proposalsError"
             class="mt-2"
           />
@@ -494,7 +495,7 @@ onUnmounted(() => {
                   <td class="px-2 py-1">
                     <UBadge
                       size="xs"
-                      :color="p.operator_action === 'pending' ? 'gray' : 'green'"
+                      :color="p.operator_action === 'pending' ? 'neutral' : 'success'"
                     >
                       {{ t(operatorStatusKey(p.operator_action)) }}
                     </UBadge>
@@ -511,7 +512,7 @@ onUnmounted(() => {
                       </UButton>
                       <UButton
                         size="xs"
-                        color="red"
+                        color="error"
                         variant="ghost"
                         :disabled="!canExecute || p.operator_action === 'ignored'"
                         @click="patchProposal(p, 'ignored')"
@@ -602,7 +603,7 @@ onUnmounted(() => {
         </div>
 
         <UAlert
-          color="amber"
+          color="warning"
           :description="t('migrationImport.preview.warning')"
         />
 

--- a/backend/app/modules/odontogram/frontend/components/clinical/ClinicalModeToggle.vue
+++ b/backend/app/modules/odontogram/frontend/components/clinical/ClinicalModeToggle.vue
@@ -5,7 +5,7 @@
  * Optional badges surface contextual counts (e.g. "Planes 2") so the
  * user sees workload before clicking in.
  */
-export type ClinicalMode = 'history' | 'diagnosis' | 'plans' | 'appointments'
+import type { ClinicalMode } from '~~/app/types'
 
 interface ModeBadges {
   diagnosis?: string | number

--- a/backend/app/modules/patients/CHANGELOG.md
+++ b/backend/app/modules/patients/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean. `PatientUpdate`/`PatientExtendedUpdate` are declared explicitly with `| null` (an explicit `null` clears the field — the section edit modal already relied on it); `ClinicalMode` moves to the shared types (the tab imported it from another module's `.vue`); the visit summary renders the treatment's localized `names` (`.name` never existed); the Administration → Budgets tab shows the linked plan number via `plan_number_snapshot` (the old `treatment_plan_id` check never rendered); `UAvatar :ui.text` is `fallback` in Nuxt UI v4.
 - fix(#183): `patient.created` / `patient.archived` are published with `db=` so the notifications, recalls and media handlers see the row and roll back with it (ADR 0019).
 - feat(onboarding): optional getting-started rule `first-patient` — suggests creating the first patient.
 

--- a/backend/app/modules/patients/frontend/components/patient/AdministrationTab.vue
+++ b/backend/app/modules/patients/frontend/components/patient/AdministrationTab.vue
@@ -231,14 +231,14 @@ const { format: formatCurrency } = useCurrency()
                     {{ formatDate(budget.created_at) }}
                   </span>
                   <span
-                    v-if="budget.treatment_plan_id"
+                    v-if="budget.plan_number_snapshot"
                     class="text-caption text-subtle flex items-center gap-1"
                   >
                     <UIcon
                       name="i-lucide-link"
                       class="w-3 h-3"
                     />
-                    {{ t('budget.linkedToPlan') }}
+                    {{ t('budget.linkedToPlan') }} {{ budget.plan_number_snapshot }}
                   </span>
                 </div>
               </div>

--- a/backend/app/modules/patients/frontend/components/patient/ClinicalTab.vue
+++ b/backend/app/modules/patients/frontend/components/patient/ClinicalTab.vue
@@ -9,8 +9,7 @@
  * - appointments: View and manage patient appointments
  */
 
-import type { ClinicalMode } from '../clinical/ClinicalModeToggle.vue'
-import type { TreatmentPlan } from '~~/app/types'
+import type { ClinicalMode, TreatmentPlan } from '~~/app/types'
 import { PERMISSIONS } from '~~/app/config/permissions'
 
 const props = defineProps<{
@@ -57,10 +56,9 @@ watch(currentMode, (mode) => {
 
 // Initialize from URL on mount
 onMounted(() => {
-  const queryMode = route.query.clinicalMode as ClinicalMode
-  if (queryMode && ['history', 'diagnosis', 'plans', 'appointments'].includes(queryMode)) {
-    currentMode.value = queryMode
-  }
+  const modes: readonly ClinicalMode[] = ['history', 'diagnosis', 'plans', 'appointments']
+  const queryMode = modes.find(m => m === route.query.clinicalMode)
+  if (queryMode) currentMode.value = queryMode
 
   // Check for planId in URL
   const planId = route.query.planId as string

--- a/backend/app/modules/patients/frontend/components/patient/PatientStickyHeader.vue
+++ b/backend/app/modules/patients/frontend/components/patient/PatientStickyHeader.vue
@@ -124,7 +124,7 @@ const actionItems = computed(() => [
         :text="initials"
         size="lg"
         class="shrink-0 ring-2 ring-[var(--color-border-subtle)]"
-        :ui="{ text: 'font-semibold' }"
+        :ui="{ fallback: 'font-semibold' }"
       />
 
       <!-- Identity column -->

--- a/backend/app/modules/patients/frontend/components/patient/info/VisitSummaryCard.vue
+++ b/backend/app/modules/patients/frontend/components/patient/info/VisitSummaryCard.vue
@@ -30,7 +30,8 @@ function appointmentTime(a: Appointment): string | null {
 }
 
 function appointmentTreatment(a: Appointment): string | null {
-  if (a.treatments?.length) return a.treatments[0]?.name ?? null
+  const first = a.treatments?.[0]
+  if (first) return first.names[locale.value] || first.names.es || first.names.en || first.internal_code
   return a.treatment_type ?? null
 }
 

--- a/backend/app/modules/recalls/CHANGELOG.md
+++ b/backend/app/modules/recalls/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — the new-category reason ref is typed to the `reasons` union.
 - fix(#183): the four event handlers are transactional (ADR 0019). `on_appointment_scheduled` writes `linked_appointment_id`, an FK to the appointment the publisher has only flushed — from its own session that write was rejected and swallowed, so **auto-link never worked** through the API.
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 

--- a/backend/app/modules/recalls/frontend/components/RecallSettingsPanel.vue
+++ b/backend/app/modules/recalls/frontend/components/RecallSettingsPanel.vue
@@ -73,7 +73,7 @@ const categoryRows = computed(() => {
 })
 
 const newCategoryKey = ref('')
-const newCategoryReason = ref<string>('hygiene')
+const newCategoryReason = ref<(typeof reasons)[number]>('hygiene')
 
 function addCategory() {
   if (!settings.value || !newCategoryKey.value) return

--- a/backend/app/modules/schedules/CHANGELOG.md
+++ b/backend/app/modules/schedules/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — `useProfessionalHours` re-exports `Shift`/`WeekdayShifts`, override forms keep `reason` as a string and normalise to `null` on submit, shift edits guard the indexed row.
 - docs(#183): `on_clinic_created` documented as own-session (published after setup commits); the appointment handlers are payload-only logging.
 - feat(onboarding): `ClinicHoursQuickModal` — inline weekly-hours editor with two presets, used as the getting-started mini-modal.
 

--- a/backend/app/modules/schedules/frontend/components/WeeklyShiftGrid.vue
+++ b/backend/app/modules/schedules/frontend/components/WeeklyShiftGrid.vue
@@ -43,7 +43,9 @@ function removeShift(weekday: number, index: number) {
 function updateShift(weekday: number, index: number, field: 'start_time' | 'end_time', value: string) {
   const current = shiftsForDay(weekday)
   const padded = value.length === 5 ? `${value}:00` : value
-  current[index] = { ...current[index], [field]: padded }
+  const existing = current[index]
+  if (!existing) return
+  current[index] = { ...existing, [field]: padded }
   updateDay(weekday, current)
 }
 

--- a/backend/app/modules/schedules/frontend/components/settings/ClinicHoursPage.vue
+++ b/backend/app/modules/schedules/frontend/components/settings/ClinicHoursPage.vue
@@ -25,7 +25,10 @@ const isSaving = ref(false)
 
 const showOverrideModal = ref(false)
 const editingOverride = ref<ClinicOverride | null>(null)
-const overrideForm = ref<ClinicOverridePayload>({
+// The form keeps `reason` as a string for the input; it is normalised to
+// `null` when building the payload.
+type OverrideForm = Omit<ClinicOverridePayload, 'reason'> & { reason: string }
+const overrideForm = ref<OverrideForm>({
   start_date: new Date().toISOString().slice(0, 10),
   end_date: new Date().toISOString().slice(0, 10),
   kind: 'closed',

--- a/backend/app/modules/schedules/frontend/components/settings/ProfessionalSchedulesPage.vue
+++ b/backend/app/modules/schedules/frontend/components/settings/ProfessionalSchedulesPage.vue
@@ -17,7 +17,7 @@ const {
   deleteOverride
 } = useProfessionalHours()
 
-const selectedProfessional = ref<string | null>(null)
+const selectedProfessional = ref<string | undefined>(undefined)
 
 const isAdmin = computed(() => can(PERMISSIONS.schedules.professionalRead) || can(PERMISSIONS.schedules.professionalWrite))
 const canWrite = computed(() => {
@@ -39,7 +39,10 @@ const professionalOptions = computed(() =>
 
 const showOverrideModal = ref(false)
 const editingOverride = ref<ProfessionalOverride | null>(null)
-const overrideForm = ref<ProfessionalOverridePayload>({
+// The form keeps `reason` as a string for the input; it is normalised to
+// `null` when building the payload.
+type OverrideForm = Omit<ProfessionalOverridePayload, 'reason'> & { reason: string }
+const overrideForm = ref<OverrideForm>({
   start_date: new Date().toISOString().slice(0, 10),
   end_date: new Date().toISOString().slice(0, 10),
   kind: 'unavailable',

--- a/backend/app/modules/schedules/frontend/composables/useProfessionalHours.ts
+++ b/backend/app/modules/schedules/frontend/composables/useProfessionalHours.ts
@@ -1,6 +1,8 @@
 import type { ApiResponse } from '~~/app/types'
 import type { Shift, WeekdayShifts } from './useClinicHours'
 
+export type { Shift, WeekdayShifts } from './useClinicHours'
+
 export interface ProfessionalHours {
   id: string
   clinic_id: string

--- a/backend/app/modules/verifactu/CHANGELOG.md
+++ b/backend/app/modules/verifactu/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — toasts/badges/alerts use Nuxt UI v4 semantic colours (`red/green/amber/blue/gray` were rendering uncoloured), `VatClassification` codes are typed once in `useVerifactu` and shared with the VAT-mapping page, the invoice slot's local `errorMessage` computed no longer shadows the `errorMessage()` util it calls, sibling composable imports are relative.
 - docs(#183): `on_invoice_paid` documented as own-session/payload-only (ADR 0019).
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 

--- a/backend/app/modules/verifactu/frontend/components/verifactu/InvoiceVerifactuPanel.vue
+++ b/backend/app/modules/verifactu/frontend/components/verifactu/InvoiceVerifactuPanel.vue
@@ -2,6 +2,8 @@
 // Inline panel rendered in the invoice detail page when the invoice
 // has Verifactu compliance metadata (clinic.country=ES + verifactu
 // installed and enabled).
+import type { UiColor } from '~~/app/config/severity'
+
 const props = defineProps<{
   complianceData?: Record<string, unknown> | null
 }>()
@@ -13,12 +15,12 @@ const data = computed(() => {
   return (cd.ES ?? null) as Record<string, string> | null
 })
 
-const stateColor = computed(() => {
-  if (!data.value) return 'gray'
-  if (data.value.state === 'accepted') return 'green'
-  if (data.value.state === 'rejected') return 'red'
-  if (data.value.state === 'accepted_with_errors') return 'amber'
-  return 'gray'
+const stateColor = computed<UiColor>(() => {
+  if (!data.value) return 'neutral'
+  if (data.value.state === 'accepted') return 'success'
+  if (data.value.state === 'rejected') return 'error'
+  if (data.value.state === 'accepted_with_errors') return 'warning'
+  return 'neutral'
 })
 </script>
 

--- a/backend/app/modules/verifactu/frontend/components/verifactu/InvoiceVerifactuSlot.vue
+++ b/backend/app/modules/verifactu/frontend/components/verifactu/InvoiceVerifactuSlot.vue
@@ -71,7 +71,7 @@ watch(() => invoice.value?.id, fetchLiveRecord)
 const state = computed(
   () => liveRecord.value?.state ?? (es.value?.state as string | undefined) ?? null
 )
-const errorMessage = computed(
+const aeatErrorMessage = computed(
   () =>
     liveRecord.value?.aeat_descripcion_error
     ?? (es.value?.error_message as string | undefined)
@@ -133,7 +133,7 @@ async function save() {
       billing_address: editAddress.value,
       expected_updated_at: invoice.value.updated_at ?? null
     })
-    toast?.add({ title: t('verifactu.billingParty.saved'), color: 'green' })
+    toast?.add({ title: t('verifactu.billingParty.saved'), color: 'success' })
     editOpen.value = false
     await fetchInvoice(invoice.value.id)
     await fetchLiveRecord()
@@ -141,7 +141,7 @@ async function save() {
     const msg = errorStatus(e) === 409
       ? t('verifactu.billingParty.concurrentEdit')
       : errorMessage(e, t('verifactu.billingParty.saveFailed'))
-    toast?.add({ title: msg, color: 'red' })
+    toast?.add({ title: msg, color: 'error' })
   } finally {
     saving.value = false
   }
@@ -154,11 +154,11 @@ async function regenerate() {
   regenerating.value = true
   try {
     await retryRecord(recordId)
-    toast?.add({ title: t('verifactu.queue.regeneratedToast'), color: 'green' })
+    toast?.add({ title: t('verifactu.queue.regeneratedToast'), color: 'success' })
     if (invoice.value?.id) await fetchInvoice(invoice.value.id)
     await fetchLiveRecord()
   } catch (e: unknown) {
-    toast?.add({ title: errorMessage(e, t('verifactu.billingParty.saveFailed')), color: 'red' })
+    toast?.add({ title: errorMessage(e, t('verifactu.billingParty.saveFailed')), color: 'error' })
   } finally {
     regenerating.value = false
   }
@@ -173,14 +173,14 @@ function goToClinic() {
   <div class="space-y-3">
     <UAlert
       v-if="isRejected"
-      color="red"
+      color="error"
       variant="soft"
       icon="i-lucide-alert-triangle"
       :title="t('verifactu.invoiceBanner.rejectedTitle')"
     >
       <template #description>
         <p class="mb-2">
-          {{ errorMessage || t('verifactu.invoiceBanner.rejectedBody') }}
+          {{ aeatErrorMessage || t('verifactu.invoiceBanner.rejectedBody') }}
         </p>
         <div class="flex flex-wrap gap-2">
           <UButton
@@ -214,7 +214,7 @@ function goToClinic() {
 
     <UAlert
       v-if="isAccepted && invoice?.pdf_stale"
-      color="amber"
+      color="warning"
       variant="soft"
       icon="i-lucide-file-warning"
       :title="t('verifactu.invoiceBanner.pdfStaleTitle')"

--- a/backend/app/modules/verifactu/frontend/components/verifactu/RejectedGlobalBanner.vue
+++ b/backend/app/modules/verifactu/frontend/components/verifactu/RejectedGlobalBanner.vue
@@ -37,7 +37,7 @@ onBeforeUnmount(() => {
 <template>
   <UAlert
     v-if="showing"
-    color="red"
+    color="error"
     variant="soft"
     icon="i-lucide-alert-octagon"
     :title="t('verifactu.globalBanner.title', { n: rejectedCount })"

--- a/backend/app/modules/verifactu/frontend/composables/useVerifactu.ts
+++ b/backend/app/modules/verifactu/frontend/composables/useVerifactu.ts
@@ -264,14 +264,18 @@ export const useVerifactu = () => {
   }
 }
 
+/** AEAT VAT classification codes (mirrors the backend `pattern`). */
+export const VAT_CLASSIFICATION_CODES = ['S1', 'S2', 'E1', 'E2', 'E3', 'E4', 'E5', 'E6', 'N1', 'N2'] as const
+export type VatClassification = (typeof VAT_CLASSIFICATION_CODES)[number]
+
 export interface VatClassificationItem {
   vat_type_id: string
   label: string
   rate: string
   is_default: boolean
-  inferred_classification: string
+  inferred_classification: VatClassification
   inferred_exemption_cause: string | null
-  override_classification: string | null
+  override_classification: VatClassification | null
   override_exemption_cause: string | null
   override_notes: string | null
 }

--- a/backend/app/modules/verifactu/frontend/pages/settings/verifactu/certificate.vue
+++ b/backend/app/modules/verifactu/frontend/pages/settings/verifactu/certificate.vue
@@ -85,7 +85,7 @@ async function submit() {
     await uploadCertificate(file.value, password.value)
     file.value = null
     password.value = ''
-    toast?.add({ title: t('verifactu.certificate.uploaded'), color: 'green' })
+    toast?.add({ title: t('verifactu.certificate.uploaded'), color: 'success' })
     await refresh()
   } catch (e: unknown) {
     error.value = errorMessage(e, t('verifactu.certificate.uploadFailed'))
@@ -328,7 +328,7 @@ onMounted(refresh)
 
         <UAlert
           v-if="error"
-          color="red"
+          color="error"
           variant="soft"
           icon="i-lucide-alert-triangle"
           :title="error"
@@ -403,7 +403,7 @@ onMounted(refresh)
           class="py-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm"
         >
           <UBadge
-            :color="c.is_active ? 'green' : 'gray'"
+            :color="c.is_active ? 'success' : 'neutral'"
             variant="subtle"
             size="sm"
           >

--- a/backend/app/modules/verifactu/frontend/pages/settings/verifactu/index.vue
+++ b/backend/app/modules/verifactu/frontend/pages/settings/verifactu/index.vue
@@ -6,6 +6,7 @@
 // summaries that link to their dedicated pages. The environment switch
 // lives only in the hero so there is no conflicting control elsewhere.
 import { PERMISSIONS } from '~~/app/config/permissions'
+import type { UiColor } from '~~/app/config/severity'
 import { errorMessage as resolveErrorMessage } from '~~/app/utils/error'
 
 const { t } = useI18n()
@@ -159,12 +160,12 @@ async function confirmProd() {
   }
 }
 
-const certWarning = computed(() => {
+const certWarning = computed<{ color: UiColor, message: string } | null>(() => {
   if (!summary.value || !summary.value.has_certificate || !summary.value.certificate_valid_until) return null
   const until = new Date(summary.value.certificate_valid_until)
   const days = Math.floor((until.getTime() - Date.now()) / (1000 * 60 * 60 * 24))
-  if (days < 0) return { color: 'red', message: t('verifactu.status.certificateExpired') }
-  if (days < 60) return { color: days < 15 ? 'red' : 'amber', message: t('verifactu.status.certificateExpiringSoon', { days }) }
+  if (days < 0) return { color: 'error', message: t('verifactu.status.certificateExpired') }
+  if (days < 60) return { color: days < 15 ? 'error' : 'warning', message: t('verifactu.status.certificateExpiringSoon', { days }) }
   return null
 })
 
@@ -257,7 +258,7 @@ onMounted(refresh)
           >
             <UButton
               :loading="saving"
-              :color="settings?.enabled ? 'gray' : 'primary'"
+              :color="settings?.enabled ? 'neutral' : 'primary'"
               :icon="settings?.enabled ? 'i-lucide-power-off' : 'i-lucide-power'"
               @click="toggleEnabled"
             >
@@ -269,7 +270,7 @@ onMounted(refresh)
             <div class="flex items-center gap-2 text-sm">
               <span class="text-gray-500">{{ t('verifactu.environment.label') }}:</span>
               <UBadge
-                :color="settings?.environment === 'prod' ? 'red' : 'gray'"
+                :color="settings?.environment === 'prod' ? 'error' : 'neutral'"
                 variant="subtle"
               >
                 {{ t(`verifactu.environment.${settings?.environment}`) }}
@@ -278,7 +279,7 @@ onMounted(refresh)
                 v-if="settings?.environment === 'test' && canPromoteToProd"
                 :loading="switchingEnv"
                 variant="ghost"
-                color="red"
+                color="error"
                 size="xs"
                 trailing-icon="i-lucide-arrow-right"
                 @click="switchEnvironment('prod')"
@@ -299,7 +300,7 @@ onMounted(refresh)
 
           <UAlert
             v-if="errorMessage"
-            color="red"
+            color="error"
             variant="soft"
             :title="errorMessage"
             class="mt-4"
@@ -569,7 +570,7 @@ onMounted(refresh)
                 {{ t('common.cancel') }}
               </UButton>
               <UButton
-                color="red"
+                color="error"
                 :loading="switchingEnv"
                 @click="confirmProd"
               >

--- a/backend/app/modules/verifactu/frontend/pages/settings/verifactu/producer.vue
+++ b/backend/app/modules/verifactu/frontend/pages/settings/verifactu/producer.vue
@@ -6,7 +6,7 @@
 //    El servidor sella timestamp + user_id como evidencia para una
 //    inspección AEAT (RD 1007/2023 art. 13).
 // 3. Descarga el PDF firmado para archivo / distribución a clínicas.
-import type { ProducerInfoUpdate, VerifactuSettings, ProducerDefaults } from '~/composables/useVerifactu'
+import type { ProducerInfoUpdate, VerifactuSettings, ProducerDefaults } from '../../../composables/useVerifactu'
 import { PERMISSIONS } from '~~/app/config/permissions'
 import { errorMessage } from '~~/app/utils/error'
 
@@ -80,7 +80,7 @@ async function saveDraft() {
   error.value = null
   try {
     settings.value = await updateProducer({ ...form.value, sign_declaracion: false })
-    toast?.add({ title: t('verifactu.producer.draftSaved'), color: 'green' })
+    toast?.add({ title: t('verifactu.producer.draftSaved'), color: 'success' })
   } catch (e: unknown) {
     error.value = errorMessage(e, t('verifactu.producer.saveFailed'))
   } finally {
@@ -96,7 +96,7 @@ async function revokeNow() {
     settings.value = await revokeDeclaration()
     showRevokeConfirm.value = false
     acceptedDeclaration.value = false
-    toast?.add({ title: t('verifactu.producer.revokedToast'), color: 'amber' })
+    toast?.add({ title: t('verifactu.producer.revokedToast'), color: 'warning' })
   } catch (e: unknown) {
     error.value = errorMessage(e, t('verifactu.producer.saveFailed'))
   } finally {
@@ -111,7 +111,7 @@ async function signNow() {
   try {
     settings.value = await updateProducer({ ...form.value, sign_declaracion: true })
     acceptedDeclaration.value = false
-    toast?.add({ title: t('verifactu.producer.signedToast'), color: 'green' })
+    toast?.add({ title: t('verifactu.producer.signedToast'), color: 'success' })
   } catch (e: unknown) {
     error.value = errorMessage(e, t('verifactu.producer.saveFailed'))
   } finally {
@@ -206,7 +206,7 @@ onMounted(refresh)
     <!-- 3-step process explainer. Always visible so the user has the
          mental model of what's required before scrolling. -->
     <UAlert
-      color="blue"
+      color="info"
       variant="soft"
       :title="t('verifactu.producer.process.title')"
     >
@@ -245,7 +245,7 @@ onMounted(refresh)
 
         <UAlert
           v-if="alreadySigned"
-          color="amber"
+          color="warning"
           variant="soft"
           icon="i-lucide-lock"
           :title="t('verifactu.producer.step1.lockedTitle')"
@@ -255,7 +255,7 @@ onMounted(refresh)
           <template #actions>
             <UButton
               v-if="canManage"
-              color="amber"
+              color="warning"
               variant="solid"
               size="xs"
               icon="i-lucide-unlock"
@@ -335,7 +335,7 @@ onMounted(refresh)
               </h2>
             </div>
             <UBadge
-              :color="alreadySigned ? 'green' : 'amber'"
+              :color="alreadySigned ? 'success' : 'warning'"
               variant="subtle"
               :icon="alreadySigned ? 'i-lucide-check-circle' : 'i-lucide-clock'"
             >
@@ -392,7 +392,7 @@ onMounted(refresh)
 
           <UAlert
             v-if="error"
-            color="red"
+            color="error"
             variant="soft"
             :title="error"
           />
@@ -499,7 +499,7 @@ onMounted(refresh)
                 {{ t('common.cancel') }}
               </UButton>
               <UButton
-                color="amber"
+                color="warning"
                 :loading="revoking"
                 icon="i-lucide-unlock"
                 @click="revokeNow"

--- a/backend/app/modules/verifactu/frontend/pages/settings/verifactu/queue.vue
+++ b/backend/app/modules/verifactu/frontend/pages/settings/verifactu/queue.vue
@@ -40,13 +40,13 @@ async function retry(item: VerifactuQueueItem) {
     await retryRecord(item.id)
     toast?.add({
       title: t('verifactu.queue.regeneratedToast'),
-      color: 'green'
+      color: 'success'
     })
     await refresh()
   } catch (e: unknown) {
     toast?.add({
       title: errorMessage(e, 'Error'),
-      color: 'red'
+      color: 'error'
     })
   } finally {
     retryingId.value = null
@@ -63,7 +63,7 @@ async function retryAll() {
         n: r.regenerated,
         failed: r.failed.length
       }),
-      color: r.failed.length === 0 ? 'green' : 'amber'
+      color: r.failed.length === 0 ? 'success' : 'warning'
     })
     await refresh()
   } finally {
@@ -81,7 +81,7 @@ async function process() {
   processing.value = true
   try {
     const r = await processNow()
-    toast?.add({ title: t('verifactu.queue.processed', { n: r.processed }), color: 'green' })
+    toast?.add({ title: t('verifactu.queue.processed', { n: r.processed }), color: 'success' })
     await refresh()
   } finally {
     processing.value = false

--- a/backend/app/modules/verifactu/frontend/pages/settings/verifactu/records.vue
+++ b/backend/app/modules/verifactu/frontend/pages/settings/verifactu/records.vue
@@ -126,7 +126,7 @@ onMounted(refresh)
             </td>
             <td class="py-2 px-2">
               <UBadge
-                :color="r.state === 'accepted' ? 'green' : r.state === 'rejected' ? 'red' : 'gray'"
+                :color="r.state === 'accepted' ? 'success' : r.state === 'rejected' ? 'error' : 'neutral'"
                 variant="subtle"
               >
                 {{ t(`verifactu.recordState.${r.state}`) }}

--- a/backend/app/modules/verifactu/frontend/pages/settings/verifactu/vat-mapping.vue
+++ b/backend/app/modules/verifactu/frontend/pages/settings/verifactu/vat-mapping.vue
@@ -5,7 +5,8 @@
 // admin pin its AEAT ``CalificacionOperacion`` / ``OperacionExenta``
 // override. When no override is set, the verifactu hook falls back to
 // the rate-based heuristic.
-import type { VatClassificationItem } from '~/composables/useVerifactu'
+import type { VatClassification, VatClassificationItem } from '../../../composables/useVerifactu'
+import type { UiColor } from '~~/app/config/severity'
 import { PERMISSIONS } from '~~/app/config/permissions'
 import { errorMessage } from '~~/app/utils/error'
 
@@ -20,7 +21,7 @@ const items = ref<VatClassificationItem[]>([])
 const loading = ref(true)
 const saving = ref<string | null>(null)
 
-const CLASSIFICATIONS = [
+const CLASSIFICATIONS: { value: VatClassification, label: string }[] = [
   { value: 'S1', label: 'S1 — Sujeto, no exento (régimen general)' },
   { value: 'S2', label: 'S2 — Sujeto, no exento (inversión sujeto pasivo)' },
   { value: 'E1', label: 'E1 — Exento (art. 20 LIVA — sanitario, financiero…)' },
@@ -31,13 +32,13 @@ const CLASSIFICATIONS = [
   { value: 'E6', label: 'E6 — Exento (otros)' },
   { value: 'N1', label: 'N1 — No sujeta (art. 7, 14, otros — por reglas localización)' },
   { value: 'N2', label: 'N2 — No sujeta (por reglas de localización)' }
-] as const
+]
 
 const AUTO_VALUE = '__auto__'
 
 interface Row {
   data: VatClassificationItem
-  selected: string // override classification or AUTO_VALUE
+  selected: VatClassification | typeof AUTO_VALUE // override classification or AUTO_VALUE
   notes: string
   dirty: boolean
 }
@@ -73,10 +74,10 @@ function effectiveSource(row: Row): 'auto' | 'override' {
   return row.selected === AUTO_VALUE ? 'auto' : 'override'
 }
 
-function classificationColor(code: string): 'green' | 'amber' | 'gray' {
-  if (code.startsWith('S')) return 'green'
-  if (code.startsWith('E')) return 'amber'
-  return 'gray'
+function classificationColor(code: string): UiColor {
+  if (code.startsWith('S')) return 'success'
+  if (code.startsWith('E')) return 'warning'
+  return 'neutral'
 }
 
 async function save(row: Row) {
@@ -99,9 +100,9 @@ async function save(row: Row) {
       row.data = updated
     }
     row.dirty = false
-    toast?.add({ title: t('verifactu.vatMapping.saved'), color: 'green' })
+    toast?.add({ title: t('verifactu.vatMapping.saved'), color: 'success' })
   } catch (e: unknown) {
-    toast?.add({ title: errorMessage(e, t('verifactu.vatMapping.saveFailed')), color: 'red' })
+    toast?.add({ title: errorMessage(e, t('verifactu.vatMapping.saveFailed')), color: 'error' })
   } finally {
     saving.value = null
   }
@@ -130,7 +131,7 @@ onMounted(refresh)
     </header>
 
     <UAlert
-      color="blue"
+      color="info"
       variant="soft"
       icon="i-lucide-info"
       :title="t('verifactu.vatMapping.legalIntroTitle')"

--- a/backend/tests/test_plan_budget_lifecycle.py
+++ b/backend/tests/test_plan_budget_lifecycle.py
@@ -161,6 +161,15 @@ async def test_reject_reactivate_confirm_creates_new_budget(
     r = await client.get(f"/api/v1/budget/budgets/{old_budget_id}", headers=auth_headers)
     assert r.json()["data"]["status"] == "rejected"
 
+    # Patient-side budget lists show the plan link via the denormalized
+    # snapshot (issue #184).
+    r = await client.get(
+        f"/api/v1/budget/budgets?patient_id={setup['patient_id']}", headers=auth_headers
+    )
+    assert r.status_code == 200, r.text
+    plan_number = plan["plan_number"]
+    assert {b["plan_number_snapshot"] for b in r.json()["data"]} == {plan_number}
+
 
 @pytest.mark.asyncio
 async def test_renegotiate_then_confirm_relinks(

--- a/docs/user-manual/en/patients/screens/detail.md
+++ b/docs/user-manual/en/patients/screens/detail.md
@@ -14,7 +14,7 @@ related_permissions:
 related_paths:
   - backend/app/modules/patients/router.py
   - backend/app/modules/patients/frontend/pages/patients/[id].vue
-last_verified_commit: 4752264
+last_verified_commit: e1d6873
 ---
 
 # Patient detail
@@ -97,6 +97,12 @@ a **Pending to charge** card at the top.
 - Each payment in the timeline has a row menu: **View detail**,
   **Assign to quote…** (moves an on-account deposit to the chosen
   quote and, if it has issued invoices, applies it) and **Refund**.
+
+## Budgets tab
+
+**Administration → Budgets** lists the patient's quotes. Quotes generated
+from a treatment plan carry a "Linked to plan `<plan number>`" tag next to
+their date, so reception can tell a plan quote from a standalone one.
 
 ## "Do not contact"
 

--- a/docs/user-manual/es/patients/screens/detail.md
+++ b/docs/user-manual/es/patients/screens/detail.md
@@ -14,7 +14,7 @@ related_permissions:
 related_paths:
   - backend/app/modules/patients/router.py
   - backend/app/modules/patients/frontend/pages/patients/[id].vue
-last_verified_commit: 4752264
+last_verified_commit: e1d6873
 ---
 
 # Ficha del paciente
@@ -97,6 +97,13 @@ tarjeta de **Pendiente de cobrar** al principio.
 - En el menú de cada cobro del historial: **Ver detalle**, **Asignar
   a presupuesto…** (mueve un anticipo a cuenta al presupuesto elegido
   y, si tiene facturas emitidas, las imputa) y **Reembolsar**.
+
+## Pestaña Presupuestos
+
+**Administración → Presupuestos** lista los presupuestos del paciente. Los
+generados desde un plan de tratamiento llevan la etiqueta "Vinculado a
+plan `<número de plan>`" junto a la fecha, para distinguirlos de los
+presupuestos sueltos.
 
 ## "No contactar"
 

--- a/frontend/app/types/index.ts
+++ b/frontend/app/types/index.ts
@@ -189,9 +189,25 @@ export interface PatientCreate {
   billing_email?: string
 }
 
-export interface PatientUpdate extends Partial<PatientCreate> {
+/**
+ * PATCH payload. Every field is optional and an explicit `null` clears the
+ * stored value (the backend applies `exclude_unset`), which is why this is
+ * not `Partial<PatientCreate>` — create never sends `null`.
+ */
+export interface PatientUpdate {
+  first_name?: string
+  last_name?: string
+  phone?: string | null
+  email?: string | null
+  date_of_birth?: string | null
+  notes?: string | null
   status?: 'active' | 'archived'
   do_not_contact?: boolean
+  // Billing fields
+  billing_name?: string | null
+  billing_tax_id?: string | null
+  billing_address?: PatientBillingAddress | null
+  billing_email?: string | null
 }
 
 // Appointment treatment brief (from planned treatment item)
@@ -565,6 +581,13 @@ export interface ToothRecordWithTreatments extends ToothRecord {
   is_rotated: boolean
   displacement_notes?: string
 }
+
+// ============================================================================
+// Clinical tab (patient record) — mode shared by the patients layer's tab and
+// the odontogram layer's <ClinicalModeToggle>.
+// ============================================================================
+
+export type ClinicalMode = 'history' | 'diagnosis' | 'plans' | 'appointments'
 
 // ============================================================================
 // VAT Type Types
@@ -996,6 +1019,8 @@ export interface BudgetListItem {
   valid_until?: string
   total: number
   created_at: string
+  /** Plan number when generated from a treatment plan (denormalized snapshot). */
+  plan_number_snapshot?: string | null
   patient?: PatientBrief
   creator?: UserBrief
 }
@@ -1927,15 +1952,15 @@ export interface PatientExtended extends Patient {
 }
 
 export interface PatientExtendedUpdate extends PatientUpdate {
-  // Extended demographics
-  gender?: string
-  national_id?: string
-  national_id_type?: string
-  profession?: string
-  workplace?: string
+  // Extended demographics (`null` clears, see PatientUpdate)
+  gender?: string | null
+  national_id?: string | null
+  national_id_type?: string | null
+  profession?: string | null
+  workplace?: string | null
   preferred_language?: string
-  address?: PatientAddress
-  photo_url?: string
+  address?: PatientAddress | null
+  photo_url?: string | null
 
   // Emergency contact
   emergency_contact?: EmergencyContact


### PR DESCRIPTION
Part 5/7 of #184 — patients (18), agenda (13), schedules (7), media (1) → 0. Stacked on #195.

- `PatientUpdate`/`PatientExtendedUpdate` declared explicitly with `| null`: the backend applies `exclude_unset`, so an explicit `null` clears a field — the section edit modal already relied on it and `Partial<PatientCreate>` forbade it.
- **Backend**: `BudgetListResponse` exposes `plan_number_snapshot` (ADR 0003 denormalized field). The Administration → Budgets "linked to plan" tag checked a `treatment_plan_id` that never existed on budgets, so it never rendered; it now shows the plan number. Test in `test_plan_budget_lifecycle.py`; patient detail screen MD (en/es) documents the tab.
- agenda: `useAppointments`/`useHomeAgenda` expose their lists with `shallowReadonly` (the deep `readonly()` view forced `DeepReadonly<Appointment>` through every child prop/emit); `t(key, fallback, params)` is not a vue-i18n overload — the keys exist in all 5 locales, so params only; `getCabinetColor` accepts the nullable cabinet; the modal drops a `media` field `PlannedTreatmentItem` no longer has.
- `ClinicalMode` moves to the shared types (the patients tab imported it from odontogram's `.vue`); `useProfessionalHours` re-exports its day types; `useDocuments` drops the `Headers` cast (ofetch already handles `FormData`); `UAvatar :ui.text` → `fallback`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)