### PR TITLE
refactor(billing): drop the invoice.patient as Patient cast on invoice edit

### DIFF
--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- refactor(#184): the invoice edit page no longer casts the embedded patient brief to `Patient`; a `displayedPatient` computed falls back from the user's pick to the invoice brief, and `patient_id` is only sent when a different patient was actually chosen.
 - fix(#184): type-check clean. `GET /invoices/{id}/payments` returns `InvoicePaymentDetailResponse` (link row + embedded `PaymentResponse`) — the patient billing summary rendered `payment_date`/`method` the link row never had; `InvoiceDetail.invoice_payments` mirrors the API (`payments` did not exist); invoices embed billing's own patient brief (`InvoicePatientBrief`, with billing fields); the from-budget page loads the full patient for the billing card (the budget brief has no billing fields, so it always showed the fallback); the new-invoice form drops the dead billing inputs the API ignores; readonly items typed `DeepReadonly` where only read.
 - docs(#183): `on_clinic_created` documented as own-session — published after setup commits, and seeding series must not stretch the signup transaction.
 - fix(#178): budget ↔ invoice bridge (`payment_bridge.py`). Payments

--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean. `GET /invoices/{id}/payments` returns `InvoicePaymentDetailResponse` (link row + embedded `PaymentResponse`) — the patient billing summary rendered `payment_date`/`method` the link row never had; `InvoiceDetail.invoice_payments` mirrors the API (`payments` did not exist); invoices embed billing's own patient brief (`InvoicePatientBrief`, with billing fields); the from-budget page loads the full patient for the billing card (the budget brief has no billing fields, so it always showed the fallback); the new-invoice form drops the dead billing inputs the API ignores; readonly items typed `DeepReadonly` where only read.
 - docs(#183): `on_clinic_created` documented as own-session — published after setup commits, and seeding series must not stretch the signup transaction.
 - fix(#178): budget ↔ invoice bridge (`payment_bridge.py`). Payments
   allocated to a budget are imputed to that budget's open invoices

--- a/backend/app/modules/billing/frontend/components/billing/InvoiceItemModal.vue
+++ b/backend/app/modules/billing/frontend/components/billing/InvoiceItemModal.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
+import type { DeepReadonly } from 'vue'
 import type { InvoiceItem, InvoiceItemCreate, TreatmentCatalogItem, VatType } from '~~/app/types'
 import { errorMessage } from '~~/app/utils/error'
 
 const props = defineProps<{
   invoiceId: string
-  editItem?: InvoiceItem // If provided, modal is in edit mode
+  editItem?: DeepReadonly<InvoiceItem> // If provided, modal is in edit mode
 }>()
 
 const open = defineModel<boolean>('open', { default: false })
@@ -213,7 +214,7 @@ function populateFromEditItem() {
   form.quantity = item.quantity
   form.vat_type_id = item.vat_type_id
   form.tooth_number = item.tooth_number
-  form.surfaces = item.surfaces || []
+  form.surfaces = [...(item.surfaces ?? [])]
   form.discount_type = item.discount_type
   form.discount_value = item.discount_value
 

--- a/backend/app/modules/billing/frontend/components/clinical/PatientBillingSummary.vue
+++ b/backend/app/modules/billing/frontend/components/clinical/PatientBillingSummary.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { PatientBillingSummary, InvoiceListItem, PaginatedResponse, Payment } from '~~/app/types'
+import type { PatientBillingSummary, InvoiceListItem, InvoicePaymentDetail, PaginatedResponse } from '~~/app/types'
 import { PERMISSIONS } from '~~/app/config/permissions'
 
 const props = defineProps<{
@@ -20,7 +20,7 @@ const pageSize = 20
 const totalPages = computed(() => Math.ceil(invoicesTotal.value / pageSize))
 const isLoading = ref(true)
 const expandedInvoices = ref<Set<string>>(new Set())
-const invoicePayments = ref<Map<string, Payment[]>>(new Map())
+const invoicePayments = ref<Map<string, InvoicePaymentDetail[]>>(new Map())
 const loadingPayments = ref<Set<string>>(new Set())
 
 async function loadInvoices() {
@@ -367,31 +367,19 @@ watch(() => props.patientId, () => {
                         {{ t('invoice.payments.title') }}
                       </p>
                       <div
-                        v-for="payment in invoicePayments.get(invoice.id)"
-                        :key="payment.id"
+                        v-for="link in invoicePayments.get(invoice.id)"
+                        :key="link.id"
                         class="flex items-center gap-4 text-sm"
-                        :class="{ 'opacity-50': payment.is_voided }"
                       >
                         <span class="text-muted w-20">
-                          {{ formatDate(payment.payment_date) }}
+                          {{ formatDate(link.payment.payment_date) }}
                         </span>
                         <span class="text-muted w-28">
-                          {{ getPaymentMethodLabel(payment.payment_method) }}
+                          {{ getPaymentMethodLabel(link.payment.method) }}
                         </span>
-                        <span
-                          class="font-medium"
-                          :class="payment.is_voided ? 'line-through text-subtle' : 'text-default'"
-                        >
-                          {{ formatCurrency(payment.amount) }}
+                        <span class="font-medium text-default">
+                          {{ formatCurrency(link.amount) }}
                         </span>
-                        <UBadge
-                          v-if="payment.is_voided"
-                          color="error"
-                          variant="subtle"
-                          size="xs"
-                        >
-                          {{ t('invoice.payments.voided') }}
-                        </UBadge>
                       </div>
                     </div>
                   </td>

--- a/backend/app/modules/billing/frontend/composables/useInvoices.ts
+++ b/backend/app/modules/billing/frontend/composables/useInvoices.ts
@@ -22,6 +22,7 @@ import type {
   PaginatedResponse,
   PatientBillingSummary,
   InvoicePayment,
+  InvoicePaymentDetail,
   InvoicePaymentApply,
   SeriesResetRequest
 } from '~~/app/types'
@@ -351,9 +352,9 @@ export function useInvoices() {
   // Payment Operations
   // ============================================================================
 
-  async function fetchPayments(invoiceId: string): Promise<InvoicePayment[]> {
+  async function fetchPayments(invoiceId: string): Promise<InvoicePaymentDetail[]> {
     try {
-      const response = await api.get<ApiResponse<InvoicePayment[]>>(
+      const response = await api.get<ApiResponse<InvoicePaymentDetail[]>>(
         `/api/v1/billing/invoices/${invoiceId}/payments`
       )
       return response.data

--- a/backend/app/modules/billing/frontend/pages/invoices/[id]/edit.vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/[id]/edit.vue
@@ -22,8 +22,11 @@ const invoiceId = computed(() => route.params.id as string)
 
 // State
 const isSaving = ref(false)
+// Patient picked in this session (full record). While unset, the invoice's
+// embedded patient brief is what the screen shows and bills against.
 const selectedPatient = ref<Patient | null>(null)
 const isChangingPatient = ref(false)
+const displayedPatient = computed(() => selectedPatient.value ?? currentInvoice.value?.patient ?? null)
 
 // Form data (no billing fields - billing comes from patient)
 const form = ref({
@@ -56,9 +59,8 @@ const canChangePatient = computed(() => {
 })
 
 // Get effective billing data (from patient for drafts)
-// Use selectedPatient if changed, otherwise use invoice patient
 const effectiveBillingData = computed(() => {
-  const patient = selectedPatient.value || currentInvoice.value?.patient
+  const patient = displayedPatient.value
   if (!patient) return null
 
   return {
@@ -105,11 +107,6 @@ onMounted(async () => {
     due_date: invoice.due_date?.split('T')[0] || '',
     internal_notes: invoice.internal_notes || '',
     public_notes: invoice.public_notes || ''
-  }
-
-  // Set selectedPatient for PatientSearch component
-  if (invoice.patient) {
-    selectedPatient.value = invoice.patient as Patient
   }
 })
 
@@ -171,11 +168,14 @@ async function handleSave() {
 
   try {
     // 1. Update invoice details (no billing fields - comes from patient)
+    // Only send patient_id when the user picked a different patient.
+    const newPatientId = selectedPatient.value?.id
     const patientChanged = canChangePatient.value
-      && selectedPatient.value?.id !== currentInvoice.value?.patient?.id
+      && newPatientId !== undefined
+      && newPatientId !== currentInvoice.value?.patient?.id
 
     await updateInvoice(invoiceId.value, {
-      patient_id: patientChanged ? selectedPatient.value?.id : undefined,
+      patient_id: patientChanged ? newPatientId : undefined,
       payment_term_days: form.value.payment_term_days,
       due_date: form.value.due_date || undefined,
       internal_notes: form.value.internal_notes || undefined,
@@ -260,15 +260,15 @@ function goBack() {
             <div v-if="canChangePatient">
               <!-- Show current patient with change button -->
               <div
-                v-if="selectedPatient && !isChangingPatient"
+                v-if="displayedPatient && !isChangingPatient"
                 class="flex items-center justify-between"
               >
                 <div>
                   <p class="font-medium text-default">
-                    {{ selectedPatient.last_name }}, {{ selectedPatient.first_name }}
+                    {{ displayedPatient.last_name }}, {{ displayedPatient.first_name }}
                   </p>
                   <p class="text-caption text-subtle">
-                    {{ selectedPatient.email || '-' }}
+                    {{ displayedPatient.email || '-' }}
                   </p>
                 </div>
                 <UButton
@@ -291,7 +291,7 @@ function goBack() {
                   />
                 </UFormField>
                 <UButton
-                  v-if="isChangingPatient && selectedPatient"
+                  v-if="isChangingPatient && displayedPatient"
                   variant="ghost"
                   color="neutral"
                   size="sm"

--- a/backend/app/modules/billing/frontend/pages/invoices/[id]/edit.vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/[id]/edit.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { DeepReadonly } from 'vue'
 import type { InvoiceItem, Patient } from '~~/app/types'
 import { errorMessage } from '~~/app/utils/error'
 
@@ -37,14 +38,14 @@ const deletedItemIds = ref<Set<string>>(new Set())
 
 // Item modal state
 const isItemModalOpen = ref(false)
-const editingItem = ref<InvoiceItem | undefined>(undefined)
+const editingItem = ref<DeepReadonly<InvoiceItem> | undefined>(undefined)
 
 function openAddItemModal() {
   editingItem.value = undefined
   isItemModalOpen.value = true
 }
 
-function openEditItemModal(item: InvoiceItem) {
+function openEditItemModal(item: DeepReadonly<InvoiceItem>) {
   editingItem.value = item
   isItemModalOpen.value = true
 }
@@ -124,7 +125,7 @@ function markItemForDeletion(itemId: string) {
 }
 
 // Get item display name (from catalog if available)
-function getItemName(item: InvoiceItem): string {
+function getItemName(item: DeepReadonly<InvoiceItem>): string {
   if (item.catalog_item) {
     return item.catalog_item.names[locale.value] || item.catalog_item.names.es || item.catalog_item.internal_code
   }

--- a/backend/app/modules/billing/frontend/pages/invoices/from-budget/[budgetId].vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/from-budget/[budgetId].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { BudgetDetail, BudgetItem, InvoiceItemFromBudget, VatType } from '~~/app/types'
+import type { ApiResponse, BudgetDetail, BudgetItem, InvoiceItemFromBudget, Patient, VatType } from '~~/app/types'
 import { errorMessage } from '~~/app/utils/error'
 
 const { t, locale } = useI18n()
@@ -16,6 +16,9 @@ const budgetId = route.params.budgetId as string
 const isLoading = ref(true)
 const isSubmitting = ref(false)
 const budget = ref<BudgetDetail | null>(null)
+// Full patient record: the budget only embeds a brief without billing
+// fields, and drafts take their billing party from the patient.
+const patient = ref<Patient | null>(null)
 const vatTypes = ref<VatType[]>([])
 
 // Selected items with quantities to invoice
@@ -39,6 +42,9 @@ onMounted(async () => {
 
     budget.value = budgetData
     vatTypes.value = vatResponse.data
+    if (budgetData?.patient) {
+      patient.value = (await api.get<ApiResponse<Patient>>(`/api/v1/patients/${budgetData.patient.id}`)).data
+    }
 
     // Pre-select all items that have available quantity
     // All items are invoiceable once budget is accepted (no item-level rejection)
@@ -108,6 +114,12 @@ function deselectAll() {
 }
 
 // Get VAT type info
+// Item display name (same rule as the budget detail page)
+function getItemName(item: BudgetItem): string {
+  if (!item.catalog_item) return '-'
+  return item.catalog_item.names[locale.value] || item.catalog_item.names.es || item.catalog_item.internal_code
+}
+
 function getVatType(vatTypeId?: string): VatType | undefined {
   return vatTypes.value.find(v => v.id === vatTypeId)
 }
@@ -301,7 +313,7 @@ function goBack() {
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center gap-2">
                     <span class="font-medium text-default">
-                      {{ item.catalog_item?.name || 'Tratamiento' }}
+                      {{ getItemName(item) }}
                     </span>
                     <UBadge
                       v-if="item.tooth_number"
@@ -378,7 +390,7 @@ function goBack() {
         </UCard>
 
         <!-- Billing data (from patient - read-only) -->
-        <UCard v-if="budget?.patient">
+        <UCard v-if="patient">
           <template #header>
             <div class="flex items-center justify-between">
               <h3 class="font-semibold text-default">
@@ -399,7 +411,7 @@ function goBack() {
                 {{ t('invoice.billingName') }}
               </p>
               <p class="font-medium text-default">
-                {{ budget.patient.billing_name || `${budget.patient.first_name} ${budget.patient.last_name}` }}
+                {{ patient.billing_name || `${patient.first_name} ${patient.last_name}` }}
               </p>
             </div>
             <div>
@@ -407,7 +419,7 @@ function goBack() {
                 {{ t('invoice.taxId') }}
               </p>
               <p class="font-medium text-default">
-                {{ budget.patient.billing_tax_id || '-' }}
+                {{ patient.billing_tax_id || '-' }}
               </p>
             </div>
             <div>
@@ -415,16 +427,16 @@ function goBack() {
                 {{ t('invoice.billingEmail') }}
               </p>
               <p class="font-medium text-default">
-                {{ budget.patient.billing_email || budget.patient.email || '-' }}
+                {{ patient.billing_email || patient.email || '-' }}
               </p>
             </div>
-            <div v-if="budget.patient.billing_address">
+            <div v-if="patient.billing_address">
               <p class="text-caption text-subtle">
                 {{ t('invoice.billingAddress') }}
               </p>
               <p class="font-medium text-default">
-                {{ budget.patient.billing_address.street }},
-                {{ budget.patient.billing_address.postal_code }} {{ budget.patient.billing_address.city }}
+                {{ patient.billing_address.street }},
+                {{ patient.billing_address.postal_code }} {{ patient.billing_address.city }}
               </p>
             </div>
           </div>

--- a/backend/app/modules/billing/frontend/pages/invoices/new.vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/new.vue
@@ -19,18 +19,10 @@ const vatTypes = ref<VatType[]>([])
 const selectedPatient = ref<Patient | null>(null)
 
 // Form data
+// Billing party is not part of the payload: drafts take it from the
+// patient dynamically and it is snapshotted on issue.
 const form = ref({
   patient_id: '',
-  billing_name: '',
-  billing_tax_id: '',
-  billing_email: '',
-  billing_address: {
-    street: '',
-    city: '',
-    postal_code: '',
-    province: '',
-    country: 'ES'
-  },
   payment_term_days: 30,
   due_date: '',
   internal_notes: '',
@@ -67,21 +59,7 @@ onMounted(async () => {
 // When patient is selected
 function handlePatientSelect(patient: Patient | null) {
   selectedPatient.value = patient
-  if (patient) {
-    form.value.patient_id = patient.id
-    // Auto-populate billing data: 1. Patient billing fields, 2. Patient personal info
-    form.value.billing_name = patient.billing_name || `${patient.first_name} ${patient.last_name}`
-    form.value.billing_tax_id = patient.billing_tax_id || ''
-    form.value.billing_email = patient.billing_email || patient.email || ''
-    if (patient.billing_address) {
-      form.value.billing_address = { ...patient.billing_address }
-    }
-  } else {
-    form.value.patient_id = ''
-    form.value.billing_name = ''
-    form.value.billing_tax_id = ''
-    form.value.billing_email = ''
-  }
+  form.value.patient_id = patient?.id ?? ''
 }
 
 // Remove item
@@ -152,10 +130,6 @@ async function handleSubmit() {
   try {
     const invoice = await createInvoice({
       patient_id: form.value.patient_id,
-      billing_name: form.value.billing_name || undefined,
-      billing_tax_id: form.value.billing_tax_id || undefined,
-      billing_email: form.value.billing_email || undefined,
-      billing_address: form.value.billing_address.street ? form.value.billing_address : undefined,
       payment_term_days: form.value.payment_term_days,
       due_date: form.value.due_date || undefined,
       internal_notes: form.value.internal_notes || undefined,
@@ -271,33 +245,15 @@ function goBack() {
           </p>
         </UCard>
 
-        <!-- Billing data -->
+        <!-- Payment terms (billing party comes from the patient) -->
         <UCard>
           <template #header>
             <h3 class="font-semibold text-default">
-              {{ t('invoice.billingData') }}
+              {{ t('invoice.paymentTerms') }}
             </h3>
           </template>
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <UFormField :label="t('invoice.billingName')">
-              <UInput v-model="form.billing_name" />
-            </UFormField>
-
-            <UFormField :label="t('invoice.taxId')">
-              <UInput
-                v-model="form.billing_tax_id"
-                placeholder="NIF/CIF"
-              />
-            </UFormField>
-
-            <UFormField :label="t('invoice.billingEmail')">
-              <UInput
-                v-model="form.billing_email"
-                type="email"
-              />
-            </UFormField>
-
             <UFormField :label="t('invoice.paymentTermDays')">
               <UInput
                 v-model.number="form.payment_term_days"

--- a/backend/app/modules/billing/router.py
+++ b/backend/app/modules/billing/router.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth.dependencies import ClinicContext, get_clinic_context, require_permission
 from app.core.schemas import ApiResponse, PaginatedApiResponse
 from app.database import get_db
+from app.modules.payments.schemas import PaymentResponse
 
 from .hooks import BillingHookRegistry
 from .schemas import (
@@ -28,6 +29,7 @@ from .schemas import (
     InvoiceItemUpdate,
     InvoiceListResponse,
     InvoicePaymentApply,
+    InvoicePaymentDetailResponse,
     InvoicePaymentResponse,
     InvoiceResponse,
     InvoiceSendRequest,
@@ -817,14 +819,14 @@ async def create_credit_note(
 
 @router.get(
     "/invoices/{invoice_id}/payments",
-    response_model=ApiResponse[list[InvoicePaymentResponse]],
+    response_model=ApiResponse[list[InvoicePaymentDetailResponse]],
 )
 async def list_invoice_payments(
     invoice_id: UUID,
     ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
     _: Annotated[None, Depends(require_permission("billing.read"))],
     db: Annotated[AsyncSession, Depends(get_db)],
-) -> ApiResponse[list[InvoicePaymentResponse]]:
+) -> ApiResponse[list[InvoicePaymentDetailResponse]]:
     invoice = await InvoiceService.get_invoice(
         db, ctx.clinic_id, invoice_id, include_items=False, include_payments=False
     )
@@ -832,7 +834,15 @@ async def list_invoice_payments(
         raise HTTPException(status_code=404, detail="Invoice not found")
 
     rows = await InvoicePaymentService.list_for_invoice(db, ctx.clinic_id, invoice_id)
-    return ApiResponse(data=[InvoicePaymentResponse.model_validate(r) for r in rows])
+    return ApiResponse(
+        data=[
+            InvoicePaymentDetailResponse(
+                **InvoicePaymentResponse.model_validate(r).model_dump(),
+                payment=PaymentResponse.from_model(r.payment),
+            )
+            for r in rows
+        ]
+    )
 
 
 @router.post(

--- a/backend/app/modules/billing/schemas.py
+++ b/backend/app/modules/billing/schemas.py
@@ -16,6 +16,7 @@ InvoiceStatus = Literal["draft", "issued", "partial", "paid", "cancelled", "void
 # Payment domain literals live in the payments module; billing only
 # imports them where it orchestrates Payment+InvoicePayment creation.
 from app.modules.payments.schemas import PaymentMethod as PaymentMethodLiteral  # noqa: E402
+from app.modules.payments.schemas import PaymentResponse  # noqa: E402
 
 PaymentMethod = PaymentMethodLiteral
 
@@ -299,6 +300,16 @@ class InvoicePaymentResponse(BaseModel):
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class InvoicePaymentDetailResponse(InvoicePaymentResponse):
+    """Link row with the underlying Payment embedded.
+
+    Served by ``GET /invoices/{id}/payments`` so invoice-side views can show
+    the payment date/method without a call per row to the payments module.
+    """
+
+    payment: PaymentResponse
 
 
 # ============================================================================

--- a/backend/app/modules/billing/service.py
+++ b/backend/app/modules/billing/service.py
@@ -1230,7 +1230,14 @@ class InvoicePaymentService:
                 InvoicePayment.clinic_id == clinic_id,
                 InvoicePayment.invoice_id == invoice_id,
             )
-            .options(joinedload(InvoicePayment.payment))
+            .options(
+                joinedload(InvoicePayment.payment).options(
+                    selectinload(PaymentModel.allocations),
+                    selectinload(PaymentModel.refunds),
+                    joinedload(PaymentModel.recorder),
+                    joinedload(PaymentModel.patient),
+                )
+            )
             .order_by(desc(InvoicePayment.created_at))
         )
         return list(result.scalars().unique().all())

--- a/backend/app/modules/budget/CHANGELOG.md
+++ b/backend/app/modules/budget/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — item helpers on the detail page accept the readonly item view.
 - feat(#184): `BudgetListResponse` exposes `plan_number_snapshot` so patient-side lists can show the plan link without importing treatment_plan.
 - fix(#183): the three plan-sync handlers are transactional (ADR 0019); a failed mirror now fails the request instead of leaving the quote out of sync with the plan.
 - fix(#183): `budget.superseded` is published before commit like every other event — the treatment_plan handler shares the session, so the FK to the new budget row resolves. Removes the documented "sole deviation from the publish-before-commit pattern".

--- a/backend/app/modules/budget/frontend/pages/budgets/[id].vue
+++ b/backend/app/modules/budget/frontend/pages/budgets/[id].vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { DeepReadonly } from 'vue'
 import type { BudgetItem, InvoiceListItem, PaginatedResponse, SignatureCreate } from '~~/app/types'
 import { BUDGET_STATUS_ROLE } from '~~/app/config/severity'
 import { PERMISSIONS } from '~~/app/config/permissions'
@@ -167,7 +168,7 @@ function handleItemAdded() {
   loadBudget()
 }
 
-async function handleRemoveItem(item: BudgetItem) {
+async function handleRemoveItem(item: DeepReadonly<BudgetItem>) {
   if (!currentBudget.value) return
   if (!confirm(t('budget.items.remove') + '?')) return
 
@@ -542,7 +543,7 @@ const infoItems = computed<InfoItem[]>(() => {
   return items
 })
 
-function getItemName(item: BudgetItem): string {
+function getItemName(item: DeepReadonly<BudgetItem>): string {
   if (!item.catalog_item) return '-'
   return item.catalog_item.names[locale.value] || item.catalog_item.names.es || item.catalog_item.internal_code
 }

--- a/backend/app/modules/copilot/CHANGELOG.md
+++ b/backend/app/modules/copilot/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): `PERMISSIONS` imported from `~~/app/config/permissions` (the `~/` form only worked through the layer-aliasing fallback).
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 
 - style(lint): first ESLint pass over this module's frontend layer —

--- a/backend/app/modules/copilot/frontend/components/CopilotSuggestions.vue
+++ b/backend/app/modules/copilot/frontend/components/CopilotSuggestions.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 // Empty-state starter chips. Each chip is gated by the same RBAC string the
 // underlying capability uses, so a user only ever sees what they could do.
-import { PERMISSIONS } from '~/config/permissions'
+import { PERMISSIONS } from '~~/app/config/permissions'
 
 const { t } = useI18n()
 const { can } = usePermissions()

--- a/backend/app/modules/copilot/frontend/pages/copilot/index.vue
+++ b/backend/app/modules/copilot/frontend/pages/copilot/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { PERMISSIONS } from '~/config/permissions'
+import { PERMISSIONS } from '~~/app/config/permissions'
 
 const { t } = useI18n()
 const { can } = usePermissions()

--- a/backend/app/modules/notifications/CHANGELOG.md
+++ b/backend/app/modules/notifications/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — per-type settings read/written through typed helpers (`settingsFor()`, generic `updateLocalSetting`) instead of casts; `UModal :ui.width` is `content` in Nuxt UI v4.
 - fix(#183): the six event handlers are transactional (ADR 0019) and no longer fire `asyncio.create_task` at a fresh session. That task raced the request's commit, and lost for `patient.created`: the patient row was invisible, so the **welcome message was never queued**. Each body runs in a savepoint — queueing must not be able to fail the appointment it announces.
 - refactor: `NotificationGateway.enqueue` flushes instead of committing; the session's owner (`get_db`, or the scheduler job) commits.
 - feat(onboarding): optional getting-started rule `smtp` — suggests configuring the email sender.

--- a/backend/app/modules/notifications/frontend/pages/settings/notifications.vue
+++ b/backend/app/modules/notifications/frontend/pages/settings/notifications.vue
@@ -91,24 +91,24 @@ function onSettingChange() {
   hasChanges.value = true
 }
 
-// Get setting value with fallback
-function getSettingValue(key: string, field: keyof NotificationTypeSettings): boolean | number {
+// Per-type settings edited on this page (channels are not, yet).
+type ScalarSetting = 'enabled' | 'auto_send' | 'hours_before'
+type ScalarSettings = Required<Pick<NotificationTypeSettings, ScalarSetting>>
+
+// Settings for a notification type, with defaults for anything unset
+function settingsFor(key: string): ScalarSettings {
   const setting = localSettings.value[key]
-  if (!setting) {
-    // Return defaults
-    if (field === 'enabled') return true
-    if (field === 'auto_send') return true
-    if (field === 'hours_before') return 24
+  return {
+    enabled: setting?.enabled ?? true,
+    auto_send: setting?.auto_send ?? true,
+    hours_before: setting?.hours_before ?? 24
   }
-  return setting[field] as boolean | number
 }
 
 // Update local setting
-function updateLocalSetting(key: string, field: keyof NotificationTypeSettings, value: boolean | number) {
-  if (!localSettings.value[key]) {
-    localSettings.value[key] = { auto_send: true, enabled: true }
-  }
-  (localSettings.value[key] as Record<string, boolean | number>)[field] = value
+function updateLocalSetting<K extends ScalarSetting>(key: string, field: K, value: ScalarSettings[K]) {
+  const setting = localSettings.value[key] ?? (localSettings.value[key] = { auto_send: true, enabled: true })
+  setting[field] = value
   onSettingChange()
 }
 
@@ -322,14 +322,14 @@ if (!isAdmin.value) {
                 </td>
                 <td class="py-4 px-4 text-center">
                   <USwitch
-                    :model-value="getSettingValue(type.key, 'enabled') as boolean"
+                    :model-value="settingsFor(type.key).enabled"
                     @update:model-value="(v: boolean) => updateLocalSetting(type.key, 'enabled', v)"
                   />
                 </td>
                 <td class="py-4 px-4 text-center">
                   <USwitch
-                    :model-value="getSettingValue(type.key, 'auto_send') as boolean"
-                    :disabled="!getSettingValue(type.key, 'enabled')"
+                    :model-value="settingsFor(type.key).auto_send"
+                    :disabled="!settingsFor(type.key).enabled"
                     @update:model-value="(v: boolean) => updateLocalSetting(type.key, 'auto_send', v)"
                   />
                 </td>
@@ -339,12 +339,12 @@ if (!isAdmin.value) {
                     class="flex items-center justify-center gap-2"
                   >
                     <UInput
-                      :model-value="getSettingValue(type.key, 'hours_before') as number"
+                      :model-value="settingsFor(type.key).hours_before"
                       type="number"
                       min="1"
                       max="168"
                       class="w-16"
-                      :disabled="!getSettingValue(type.key, 'enabled')"
+                      :disabled="!settingsFor(type.key).enabled"
                       @update:model-value="(v: string | number) => updateLocalSetting(type.key, 'hours_before', Number(v))"
                     />
                     <span class="text-caption text-subtle">{{ t('notifications.hoursBefore') }}</span>
@@ -522,7 +522,7 @@ if (!isAdmin.value) {
     <!-- SMTP Configuration Modal -->
     <UModal
       v-model:open="showSmtpModal"
-      :ui="{ width: 'max-w-2xl' }"
+      :ui="{ content: 'max-w-2xl' }"
     >
       <template #content>
         <UCard>

--- a/backend/app/modules/reports/CHANGELOG.md
+++ b/backend/app/modules/reports/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#184): type-check clean — sibling composable imports are relative (the `~/` form resolved to the host for vue-tsc and made half the page implicitly `any`), ISO dates via `.slice(0, 10)`, budget status badge colour is `UiColor`.
 - style(lint): first ESLint pass over this module's frontend layer —
   module layers were outside the linter's base path until now, so
   CI had never checked them. Mostly auto-fixed formatting; see the

--- a/backend/app/modules/reports/frontend/pages/reports/billing.vue
+++ b/backend/app/modules/reports/frontend/pages/reports/billing.vue
@@ -33,8 +33,8 @@ const numberingGaps = ref<NumberingGap[]>([])
 // Date range
 const today = new Date()
 const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1)
-const dateFrom = ref(firstDayOfMonth.toISOString().split('T')[0])
-const dateTo = ref(today.toISOString().split('T')[0])
+const dateFrom = ref(firstDayOfMonth.toISOString().slice(0, 10))
+const dateTo = ref(today.toISOString().slice(0, 10))
 
 // Quick date range options
 const dateRangeOptions = computed(() => [
@@ -87,8 +87,8 @@ watch(selectedRange, (range) => {
       return
   }
 
-  dateFrom.value = from.toISOString().split('T')[0]
-  dateTo.value = to.toISOString().split('T')[0]
+  dateFrom.value = from.toISOString().slice(0, 10)
+  dateTo.value = to.toISOString().slice(0, 10)
 })
 
 // Load all report data

--- a/backend/app/modules/reports/frontend/pages/reports/budgets.vue
+++ b/backend/app/modules/reports/frontend/pages/reports/budgets.vue
@@ -4,7 +4,8 @@ import type {
   BudgetByProfessional,
   BudgetByTreatment,
   BudgetByStatus
-} from '~/composables/useReports'
+} from '../../composables/useReports'
+import type { UiColor } from '~~/app/config/severity'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -27,8 +28,8 @@ const byStatus = ref<BudgetByStatus[]>([])
 // Date range
 const today = new Date()
 const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1)
-const dateFrom = ref(firstDayOfMonth.toISOString().split('T')[0])
-const dateTo = ref(today.toISOString().split('T')[0])
+const dateFrom = ref(firstDayOfMonth.toISOString().slice(0, 10))
+const dateTo = ref(today.toISOString().slice(0, 10))
 
 // Quick date range options
 const dateRangeOptions = computed(() => [
@@ -81,8 +82,8 @@ watch(selectedRange, (range) => {
       return
   }
 
-  dateFrom.value = from.toISOString().split('T')[0]
-  dateTo.value = to.toISOString().split('T')[0]
+  dateFrom.value = from.toISOString().slice(0, 10)
+  dateTo.value = to.toISOString().slice(0, 10)
 })
 
 // Load all report data
@@ -123,8 +124,8 @@ function formatPercent(value: number): string {
 }
 
 // Get status badge color
-function getStatusBadgeColor(status: string): string {
-  const colors: Record<string, 'neutral' | 'success' | 'error' | 'info' | 'warning'> = {
+function getStatusBadgeColor(status: string): UiColor {
+  const colors: Record<string, UiColor> = {
     draft: 'neutral',
     accepted: 'success',
     rejected: 'error',

--- a/backend/app/modules/reports/frontend/pages/reports/scheduling.vue
+++ b/backend/app/modules/reports/frontend/pages/reports/scheduling.vue
@@ -9,7 +9,7 @@ import type {
   PunctualityStats,
   SchedulingSummary,
   WaitingTimeStats
-} from '~/composables/useReports'
+} from '../../composables/useReports'
 
 const { t } = useI18n()
 const router = useRouter()

--- a/backend/tests/modules/billing/test_payment_bridge.py
+++ b/backend/tests/modules/billing/test_payment_bridge.py
@@ -346,3 +346,30 @@ async def test_manual_invoice_still_collects_on_account(
         "data"
     ]
     assert (invj["status"], Decimal(str(invj["total_paid"]))) == ("paid", Decimal("50.00"))
+
+
+@pytest.mark.asyncio
+async def test_invoice_payments_list_embeds_payment(
+    client: AsyncClient,
+    auth_headers: dict,
+    test_clinic: Clinic,
+    test_patient: Patient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /invoices/{id}/payments returns link rows with the Payment embedded.
+
+    Invoice-side views render date/method from it (issue #184).
+    """
+    inv = await _draft_invoice(db_session, test_clinic, test_patient, "50.00", None)
+    await _issue(client, auth_headers, inv.id)
+    link = await _pay_invoice(client, auth_headers, inv.id, "50.00")
+
+    r = await client.get(f"/api/v1/billing/invoices/{inv.id}/payments", headers=auth_headers)
+    assert r.status_code == 200, r.text
+    rows = r.json()["data"]
+    assert [row["id"] for row in rows] == [link["id"]]
+    assert Decimal(str(rows[0]["amount"])) == Decimal("50.00")
+    payment = rows[0]["payment"]
+    assert payment["id"] == link["payment_id"]
+    assert (payment["method"], payment["payment_date"]) == ("cash", TODAY)
+    assert Decimal(str(payment["net_amount"])) == Decimal("50.00")

--- a/docs/user-manual/en/billing/screens/invoices_new.md
+++ b/docs/user-manual/en/billing/screens/invoices_new.md
@@ -13,7 +13,7 @@ related_permissions:
 related_paths:
   - backend/app/modules/billing/frontend/pages/invoices/new.vue
   - backend/app/modules/billing/router.py
-last_verified_commit: b1b82f5
+last_verified_commit: e1d6873
 ---
 
 # New invoice
@@ -29,9 +29,11 @@ entry errors.
 
 ## At a glance
 
-- **Receiver.** Defaults to the patient. *Different payer* lets you
-  point to a third party (company, insurer, family member) with
-  their own fiscal data.
+- **Receiver.** The patient. Billing data (name, tax ID, address,
+  email) is not typed here: drafts read it live from the patient
+  record and it is snapshotted when the invoice is issued. A badge
+  tells you whether the patient's billing data is complete, with a
+  link to fix it on the patient card.
 - **Free lines.** Add catalog items with quantity, discount, VAT.
   You can also add manual lines (no catalog item) when needed for
   special charges.
@@ -45,9 +47,8 @@ entry errors.
 
 > Requires `billing.write`.
 
-1. Pick the patient. If the invoice is for a different payer,
-   click *Different payer* and fill in tax ID, name, and fiscal
-   address.
+1. Pick the patient. If the badge says billing data is missing,
+   complete it on the patient card first (link under the selector).
 2. Add lines: catalog item, quantity, discount, VAT.
 3. Review totals (subtotal, discount, VAT, total).
 4. **Save**. The invoice is born in `draft`. To issue, open the

--- a/docs/user-manual/es/billing/screens/invoices_new.md
+++ b/docs/user-manual/es/billing/screens/invoices_new.md
@@ -13,7 +13,7 @@ related_permissions:
 related_paths:
   - backend/app/modules/billing/frontend/pages/invoices/new.vue
   - backend/app/modules/billing/router.py
-last_verified_commit: b1b82f5
+last_verified_commit: e1d6873
 ---
 
 # Nueva factura
@@ -28,9 +28,11 @@ Para facturar a partir de un presupuesto aceptado usa la
 
 ## De un vistazo
 
-- **Receptor.** Por defecto el paciente. *Pagador distinto* permite
-  apuntar a un tercero (compañía, mutua, familiar) con sus propios
-  datos fiscales.
+- **Receptor.** El paciente. Los datos de facturación (nombre, NIF,
+  dirección, email) no se teclean aquí: el borrador los lee en vivo
+  de la ficha del paciente y se congelan al emitir. Una etiqueta
+  indica si al paciente le faltan datos de facturación, con enlace
+  para completarlos en su ficha.
 - **Líneas libres.** Añade ítems del catálogo con cantidad,
   descuento, IVA. También puedes meter líneas manuales (sin ítem
   del catálogo) cuando lo necesites para cargos especiales.
@@ -44,8 +46,9 @@ Para facturar a partir de un presupuesto aceptado usa la
 
 > Requiere `billing.write`.
 
-1. Selecciona paciente. Si la factura va a otro pagador, pulsa
-   *Pagador distinto* y completa NIF, nombre y dirección fiscal.
+1. Selecciona paciente. Si la etiqueta indica que faltan datos de
+   facturación, complétalos en la ficha del paciente (enlace bajo el
+   selector).
 2. Añade líneas: ítem del catálogo, cantidad, descuento, IVA.
 3. Revisa totales (subtotal, descuento, IVA, total).
 4. **Guardar**. La factura nace en `draft`. Para emitirla, abre el

--- a/frontend/app/types/index.ts
+++ b/frontend/app/types/index.ts
@@ -1423,6 +1423,19 @@ export interface PaymentsTrends {
 }
 
 // Billing-side link to a Payment (issue #53).
+/**
+ * Patient summary embedded in invoice responses (billing's own
+ * `PatientBrief`): unlike the shared brief it carries the billing party
+ * fields, because drafts take billing data from the patient dynamically.
+ */
+export interface InvoicePatientBrief extends PatientBrief {
+  billing_name?: string | null
+  billing_tax_id?: string | null
+  billing_address?: PatientBillingAddress | null
+  billing_email?: string | null
+  has_complete_billing_info: boolean
+}
+
 export interface InvoicePayment {
   id: string
   invoice_id: string
@@ -1430,6 +1443,11 @@ export interface InvoicePayment {
   amount: number
   created_by: string
   created_at: string
+}
+
+/** Invoice↔payment link row with the payment embedded (GET /invoices/{id}/payments). */
+export interface InvoicePaymentDetail extends InvoicePayment {
+  payment: PaymentRecord
 }
 
 export interface InvoicePaymentApply {
@@ -1546,39 +1564,6 @@ export interface InvoiceItemUpdate {
   display_order?: number
 }
 
-// Payment
-export interface Payment {
-  id: string
-  invoice_id: string
-  amount: number
-  payment_method: PaymentMethod
-  payment_date: string
-  reference?: string
-  notes?: string
-  recorded_by: string
-  created_at: string
-  // Voiding
-  is_voided: boolean
-  voided_at?: string
-  voided_by?: string
-  void_reason?: string
-  // Related
-  recorder?: UserBrief
-  voider?: UserBrief
-}
-
-export interface PaymentCreate {
-  amount: number
-  payment_method: PaymentMethod
-  payment_date?: string
-  reference?: string
-  notes?: string
-}
-
-export interface PaymentVoidRequest {
-  reason: string
-}
-
 // Invoice History
 export interface InvoiceHistoryEntry {
   id: string
@@ -1654,7 +1639,7 @@ export interface Invoice {
   updated_at: string
   deleted_at?: string
   // Related
-  patient?: PatientBrief
+  patient?: InvoicePatientBrief
   creator?: UserBrief
   issuer?: UserBrief
   budget?: BudgetBrief
@@ -1663,7 +1648,7 @@ export interface Invoice {
 
 export interface InvoiceDetail extends Invoice {
   items: InvoiceItem[]
-  payments: Payment[]
+  invoice_payments: InvoicePayment[]
 }
 
 export interface InvoiceListItem {
@@ -1680,7 +1665,7 @@ export interface InvoiceListItem {
   // {"ES": {state, severity, error_message, ...}}). Owned by the
   // active compliance module — billing exposes it raw.
   compliance_data?: Record<string, Record<string, unknown>> | null
-  patient?: PatientBrief
+  patient?: InvoicePatientBrief
   creator?: UserBrief
 }
 


### PR DESCRIPTION
Follow-up to #197 (stacked on it: it needs `InvoicePatientBrief`).

`edit.vue` seeded `selectedPatient` — typed `Patient` because it feeds `PatientVisualSelector` — with the invoice's embedded brief through `as Patient`. Now:
- `selectedPatient` only holds what the user picks in this session.
- `displayedPatient = selectedPatient ?? currentInvoice.patient` drives the "current patient" block, the cancel button and `effectiveBillingData` (billing name/tax id/email/address exist on the brief).
- `patient_id` is sent only when a different patient was actually chosen (before, an unset selection compared `undefined !== id` and relied on `?.id` being undefined).

Behaviour: identical, except that after clicking *Change* the selector starts empty instead of pre-highlighting the current patient (it needs a full `Patient`, which the invoice does not embed).

Verified: `nuxt typecheck` 0 errors, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)