### PR TITLE
docs: regenerate events catalog after #197

### DIFF
--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -460,7 +460,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.INVOICE_SENT`
 - **Publishers:**
-  - `billing` — `backend/app/modules/billing/router.py:697`
+  - `billing` — `backend/app/modules/billing/router.py:699`
 - **Subscribers:**
   - `notifications`
 


### PR DESCRIPTION
`catalog-freshness` went red on `main` after #197: the catalog embeds publisher line numbers and the added import in `billing/router.py` shifted `INVOICE_SENT` from `:697` to `:699`. Regenerated with `generate_catalogs.py`, no other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)