### PR TITLE
fix(plugins): install state gates the runtime — only installed modules are mounted; boot migrations follow it (#91)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
           done
 
       - name: Run migrations
-        run: docker compose exec -T backend alembic upgrade heads
+        run: docker compose exec -T backend python -m app.cli db upgrade
 
       - name: Seed demo data
         run: ./scripts/seed-demo.sh --lang es

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ cd frontend && npm run lint
 cd frontend && npm run typecheck:layers && git checkout modules.json   # vue-tsc over host + all module layers (stop the frontend container first)
 
 # Reset DB + reseed demo data (use after tests wipe tables)
-./scripts/reset-db.sh        # drop, alembic upgrade heads
+./scripts/reset-db.sh        # drop, dentalpin db upgrade (core + installed modules)
 ./scripts/seed-demo.sh       # demo clinic, users, sample data
 
 # Demo login
@@ -281,7 +281,8 @@ class MyModel(Base):
 Migrations live in `backend/app/modules/<name>/migrations/versions/` on a per-module branch. See `docs/technical/creating-modules.md` §3 (`migrations/`) for the branching rules and the `--branch-label` invocation.
 
 ```bash
-docker-compose exec backend alembic upgrade heads     # plural — multiple branches
+docker-compose exec backend python -m app.cli db upgrade   # core + installed modules (ADR 0020)
+docker-compose exec backend alembic upgrade heads          # every branch, dev only
 ```
 
 ---
@@ -373,7 +374,7 @@ DEMO_MODE=false           # public demo: blocks user edits/removal + module life
 
 ## Troubleshooting
 
-- **"relation does not exist"** / tables wiped after tests: `./scripts/reset-db.sh` then `./scripts/seed-demo.sh`. Manual fallback: `DELETE FROM alembic_version;` then `alembic upgrade heads`.
+- **"relation does not exist"** / tables wiped after tests: `./scripts/reset-db.sh` then `./scripts/seed-demo.sh`. Manual fallback: `DELETE FROM alembic_version;` then `python -m app.cli db upgrade`.
 - **Frontend changes not showing**: `docker-compose up -d --build frontend`.
 - **Permission denied but should have access**: check `clinic_memberships` row, exact permission string, `/me` payload, then re-login.
 

--- a/backend/app/cli/__main__.py
+++ b/backend/app/cli/__main__.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import sys
 
+from . import db as db_cli
 from . import modules as modules_cli
 
 
@@ -17,6 +18,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     modules_cli.register(sub)
+    db_cli.register(sub)
     return parser
 
 

--- a/backend/app/cli/db.py
+++ b/backend/app/cli/db.py
@@ -1,0 +1,83 @@
+"""``dentalpin db ...`` subcommands.
+
+``db upgrade`` is what the container entrypoint runs before uvicorn
+instead of ``alembic upgrade heads`` (ADR 0020): it applies the core
+heads plus the branch head of every module that is ``installed`` — or,
+when ``core_module`` has no row for it yet, whose manifest says
+``auto_install``. A branch nobody installed is never applied, so an
+uninstalled module's tables do not come back on the next restart
+(issue #91). Installing a module applies its branch through the pending
+processor, as before.
+
+Runs Alembic in-process: there is no event loop in the CLI, so
+``env.py``'s ``asyncio.run`` is fine here (the lifespan can't do that,
+hence the processor's subprocess).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from sqlalchemy import text
+
+from app.core.plugins.alembic_paths import alembic_cfg_path, boot_upgrade_targets
+from app.core.plugins.loader import register_discovered
+from app.core.plugins.state import ModuleState
+from app.database import async_session_maker
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    parser = sub.add_parser("db", help="Database schema operations")
+    db_sub = parser.add_subparsers(dest="db_command", required=True)
+
+    p_upgrade = db_sub.add_parser(
+        "upgrade",
+        help="Apply core migrations plus the branches of installed modules (boot step)",
+    )
+    p_upgrade.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the Alembic targets without applying them",
+    )
+    p_upgrade.set_defaults(func=_cmd_upgrade)
+
+
+def _cmd_upgrade(args: argparse.Namespace) -> int:
+    modules = register_discovered()
+    states = asyncio.run(_load_states())
+
+    def wanted(module) -> bool:
+        state = states.get(module.name)
+        if state is None:
+            return module.get_manifest().auto_install
+        return state == ModuleState.INSTALLED.value
+
+    targets = boot_upgrade_targets(modules, wanted)
+    if not targets:
+        print("db upgrade: no Alembic targets (no script directory?)")
+        return 1
+
+    print(f"db upgrade: targets = {targets}")
+    if args.dry_run:
+        return 0
+
+    from alembic.config import Config
+
+    from alembic import command
+
+    cfg = Config(str(alembic_cfg_path()))
+    for target in targets:
+        command.upgrade(cfg, target)
+    print(f"db upgrade: applied {len(targets)} target(s)")
+    return 0
+
+
+async def _load_states() -> dict[str, str]:
+    """``name -> state`` from ``core_module``, or ``{}`` before the table exists."""
+    async with async_session_maker() as session:
+        exists = await session.scalar(text("SELECT to_regclass('core_module')"))
+        if exists is None:
+            return {}
+        rows = await session.execute(text("SELECT name, state FROM core_module"))
+        return {name: state for name, state in rows.all()}

--- a/backend/app/cli/modules.py
+++ b/backend/app/cli/modules.py
@@ -108,7 +108,7 @@ def _run(
     async def wrapper(args: argparse.Namespace) -> int:
         # Discovery populates the in-memory registry so CLI can see modules
         # even without a running app lifespan.
-        if not module_registry.list_modules():
+        if not module_registry.list_discovered():
             for module in discover_modules():
                 try:
                     module_registry.register(module)

--- a/backend/app/cli/modules.py
+++ b/backend/app/cli/modules.py
@@ -16,8 +16,7 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.plugins import ModuleOperationError, ModuleService
-from app.core.plugins.loader import discover_modules
-from app.core.plugins.registry import module_registry
+from app.core.plugins.loader import register_discovered
 from app.database import async_session_maker
 
 
@@ -107,14 +106,8 @@ def _run(
 ) -> Callable[[argparse.Namespace], Awaitable[int]]:
     async def wrapper(args: argparse.Namespace) -> int:
         # Discovery populates the in-memory registry so CLI can see modules
-        # even without a running app lifespan.
-        if not module_registry.list_discovered():
-            for module in discover_modules():
-                try:
-                    module_registry.register(module)
-                except ValueError:
-                    # Already registered (e.g. tests).
-                    pass
+        # even without a running app lifespan (nothing is mounted).
+        register_discovered()
 
         async with async_session_maker() as session:
             service = ModuleService(session)

--- a/backend/app/core/auth/permissions.py
+++ b/backend/app/core/auth/permissions.py
@@ -75,8 +75,9 @@ def get_role_permissions(role: str) -> list[str]:
 
     1. The core grants in :data:`ROLE_PERMISSIONS` (admin wildcard,
        core-perm assignments).
-    2. ``manifest.role_permissions`` from every module currently in the
-       in-memory registry. Entries are prefixed with ``{module_name}.``
+    2. ``manifest.role_permissions`` from every *active* module (installed
+       and mounted at boot — an uninstalled module grants nothing, issue
+       #91). Entries are prefixed with ``{module_name}.``
        — so a manifest declaring ``{"dentist": ["clinic_hours.read"]}``
        contributes ``"<module>.clinic_hours.read"`` to the dentist role.
     """
@@ -92,7 +93,7 @@ def get_role_permissions(role: str) -> list[str]:
     from app.core.plugins.manifest import ManifestError
     from app.core.plugins.registry import module_registry
 
-    for module in module_registry.list_modules():
+    for module in module_registry.list_active():
         try:
             manifest = module.get_manifest()
         except ManifestError:

--- a/backend/app/core/plugins/README.md
+++ b/backend/app/core/plugins/README.md
@@ -12,14 +12,14 @@ this README is the tour of *core/plugins itself*.
 | File | Role |
 |------|------|
 | `__init__.py` | Re-exports `BaseModule`, `ModuleContext`. Public surface for module authors. |
-| `base.py` | `BaseModule` ABC. The contract every module implements: `manifest`, `get_models`, `get_router`, `get_event_handlers`, `get_permissions`, `get_tools`, `install`/`uninstall`/`post_upgrade` hooks. |
+| `base.py` | `BaseModule` ABC. The contract every module implements: `manifest`, `get_models`, `get_router`, `get_event_handlers`, `get_permissions`, `get_tools`, `get_scheduled_jobs`, `on_activate` (per-boot, installed only) and the `install`/`uninstall`/`post_upgrade` lifecycle hooks. |
 | `context.py` | `ModuleContext` passed to lifecycle hooks (db session, event bus, logger). |
 | `manifest.py` | `Manifest` dataclass + `ManifestError`. Lenient parser — only `name` and `version` are required. |
 | `manifest_validator.py` | Stricter checks layered on top of `Manifest`: semver format, role names, declared permissions, navigation prefixes, branch isolation when `removable=True`. CI gate. |
 | `state.py` | `ModuleState` enum (`uninstalled`/`to_install`/`installed`/…) and `ModuleCategory`. |
 | `topology.py` | `topological_sort` helper used by loader, service, and processor for module dependency ordering. |
-| `loader.py` | Discovery: entry points (PyPI) + filesystem scan (dev). Mounts routers, subscribes events, registers tools. Single boot-time entry point: `load_modules(app)`. |
-| `registry.py` | `module_registry` singleton — in-memory map of name → `BaseModule`. Invalidates the role-permission cache when modules are added. |
+| `loader.py` | Discovery: entry points (PyPI) + filesystem scan (dev). Two boot-time entry points: `register_discovered()` (discover + topo-sort + register, nothing mounted) and `mount_modules(app, modules)` (router, event handlers, tools, `on_activate()`, mark active). The lifespan mounts only `installed` modules (#91). |
+| `registry.py` | `module_registry` singleton — *discovered* modules (name → `BaseModule`) plus the *active* set (mounted this boot). RBAC merge, scheduler, tenancy and feature gates read the active view; lifecycle code reads discovered. |
 | `db_models.py` | `ModuleRecord`, `ModuleOperationLog`, `ExternalId` SQLAlchemy models. The `core_module_*` tables. |
 | `service.py` | `ModuleService`: state-transition API (`install`/`uninstall`/`upgrade`) and read views (`list_modules`/`status`/`doctor`). Reconciles disk → DB at boot. |
 | `processor.py` | `PendingProcessor`: lifespan executor that runs `to_install`/`to_upgrade`/`to_remove` (migrate → seed → lifecycle hook → finalize, with pg_dump backup before uninstall). |

--- a/backend/app/core/plugins/__init__.py
+++ b/backend/app/core/plugins/__init__.py
@@ -2,7 +2,7 @@
 
 from .base import BaseModule
 from .context import ModuleContext
-from .loader import load_modules
+from .loader import mount_modules, register_discovered
 from .manifest import Manifest, ManifestError
 from .registry import module_registry
 from .service import DoctorReport, ModuleInfo, ModuleOperationError, ModuleService
@@ -19,6 +19,7 @@ __all__ = [
     "ModuleOperationError",
     "ModuleService",
     "ModuleState",
-    "load_modules",
+    "mount_modules",
     "module_registry",
+    "register_discovered",
 ]

--- a/backend/app/core/plugins/alembic_paths.py
+++ b/backend/app/core/plugins/alembic_paths.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -54,12 +55,13 @@ def _module_versions_dir(module: BaseModule) -> Path | None:
     return versions_dir if versions_dir.is_dir() else None
 
 
-def _alembic_cfg_path() -> Path:
+def alembic_cfg_path() -> Path:
+    """``backend/alembic.ini`` — shared by the processor, the CLI and the validator."""
     return Path(__file__).resolve().parents[3] / "alembic.ini"
 
 
 def _load_script_directory():
-    cfg_path = _alembic_cfg_path()
+    cfg_path = alembic_cfg_path()
     if not cfg_path.is_file():
         return None
     from alembic.config import Config
@@ -155,3 +157,41 @@ def module_branch_is_isolated(module: BaseModule) -> bool:
         if any(p in owned for p in parents):
             return False
     return True
+
+
+def boot_upgrade_targets(
+    modules: list[BaseModule],
+    wanted: Callable[[BaseModule], bool],
+) -> list[str]:
+    """Alembic targets the boot should upgrade to (ADR 0020).
+
+    Core heads (revision files under ``alembic/versions``) always; then the
+    branch head of every module in ``modules`` for which ``wanted`` is
+    true, in the order given (topological, so dependencies first). Modules
+    without a branch of their own live in the core chain and need nothing.
+
+    Upgrading to a revision that is already an ancestor of the current
+    heads is a no-op, so overlapping targets are harmless; what matters is
+    that a branch nobody wants is never named.
+    """
+    script = _load_script_directory()
+    if script is None:
+        return []
+
+    main_linear = (alembic_cfg_path().parent / "alembic" / "versions").resolve()
+    targets: list[str] = []
+    for head in script.get_heads():
+        rev = script.get_revision(head)
+        rev_path = getattr(rev, "path", None)
+        if rev_path and Path(rev_path).resolve().parent == main_linear:
+            targets.append(head)
+
+    for module in modules:
+        head = resolve_module_branch_head(module)
+        if head is None:
+            continue
+        if wanted(module):
+            targets.append(head)
+        else:
+            logger.info("db upgrade: skipping %s (%s) — not installed", module.name, head)
+    return targets

--- a/backend/app/core/plugins/base.py
+++ b/backend/app/core/plugins/base.py
@@ -108,13 +108,24 @@ class BaseModule(ABC):
         """Return periodic jobs this module wants the scheduler to run.
 
         Default is an empty list. The scheduler registers jobs only for
-        *installed/registered* modules, so the scheduler no longer imports
-        module task functions directly. See
+        *active* modules (installed and mounted at boot), so the scheduler
+        no longer imports module task functions directly. See
         :class:`~app.core.scheduling.ScheduledJob`.
         """
         return []
 
     # --- Lifecycle hooks (v1 defaults are no-ops) ------------------------
+
+    def on_activate(self) -> None:
+        """Called once per boot, right after this module was mounted.
+
+        Runs **only when the module is installed** (``core_module.state``),
+        after its router, event handlers and tools are wired. Use it for
+        in-memory, cross-module registrations that must be re-attached on
+        every restart — compliance hooks, channel adapters. Sync, no DB.
+        There is no counterpart: a module that is not installed on the
+        next boot is simply never activated (modules never hot-unload).
+        """
 
     async def install(self, ctx: ModuleContext) -> None:
         """Called on first install after migrations ran.

--- a/backend/app/core/plugins/loader.py
+++ b/backend/app/core/plugins/loader.py
@@ -159,6 +159,7 @@ def _mount_modules(app: FastAPI, modules: list[BaseModule]) -> None:
             logger.info("Subscribed %s to event: %s", module.name, event_type)
 
         tool_registry.register_from(module)
+        module_registry.activate(module.name)
 
 
 def load_modules(app: FastAPI) -> None:

--- a/backend/app/core/plugins/loader.py
+++ b/backend/app/core/plugins/loader.py
@@ -14,9 +14,15 @@ Discovery happens in two stages:
    that an entry point already provided, so entry points win when both
    are present.
 
-The public entry point for the rest of the app is :func:`load_modules`,
-which discovers, resolves dependencies, and mounts everything in one
-call.
+Discovery and mounting are two steps on purpose (issue #91):
+
+* :func:`register_discovered` — discover, topo-sort and register every
+  module in the :data:`module_registry`. Nothing is mounted; the
+  lifecycle machinery (reconcile, pending processor) needs the full list.
+* :func:`mount_modules` — mount a chosen subset: router, event handlers,
+  tools, ``on_activate()``, and mark it active. The lifespan passes the
+  modules whose ``core_module.state`` is ``installed``; tests and scripts
+  that want everything pass the full discovered list explicitly.
 """
 
 from __future__ import annotations
@@ -24,6 +30,7 @@ from __future__ import annotations
 import importlib
 import logging
 import pkgutil
+from collections.abc import Iterable
 from importlib import metadata
 from pathlib import Path
 
@@ -139,41 +146,55 @@ def discover_modules() -> list[BaseModule]:
     return modules
 
 
-def _mount_modules(app: FastAPI, modules: list[BaseModule]) -> None:
-    """Mount routers + subscribe event handlers + register tools."""
+def register_discovered() -> list[BaseModule]:
+    """Discover every module and register it; return them in load order.
+
+    Idempotent: modules already in the registry (tests, CLI re-entry)
+    are kept as-is. Raises on a dependency cycle — fail loud at boot.
+    """
+    for module in discover_modules():
+        if not module_registry.is_discovered(module.name):
+            module_registry.register(module)
+
+    ordered = _resolve_load_order(module_registry.list_discovered())
+    if not ordered:
+        logger.warning("No modules discovered")
+    return ordered
+
+
+def mount_modules(app: FastAPI, modules: Iterable[BaseModule]) -> list[BaseModule]:
+    """Mount ``modules`` (router, event handlers, tools) and mark them active.
+
+    ``modules`` must come in dependency order (``register_discovered``
+    output, possibly filtered). A module whose declared dependency is not
+    active is skipped with an error — that state is only reachable through
+    ``uninstall --force`` and mounting it would fail at first request
+    anyway. Already-active modules are skipped silently. Returns what was
+    mounted this call.
+    """
     from app.core.agents.tools.registry import tool_registry
     from app.core.events import event_bus
 
+    mounted: list[BaseModule] = []
     for module in modules:
-        module_registry.register(module)
+        if module_registry.is_active(module.name):
+            continue
+        missing = [dep for dep in module.dependencies if not module_registry.is_active(dep)]
+        if missing:
+            logger.error("Not mounting %s: dependencies not active: %s", module.name, missing)
+            continue
+
         app.include_router(
             module.get_router(),
             prefix=f"/api/v1/{module.name}",
             tags=[module.name],
         )
-        logger.info("Mounted router for module: %s", module.name)
-
-        handlers = module.get_event_handlers()
-        for event_type, handler in handlers.items():
+        for event_type, handler in module.get_event_handlers().items():
             event_bus.subscribe(event_type, handler)
-            logger.info("Subscribed %s to event: %s", module.name, event_type)
-
         tool_registry.register_from(module)
+        module.on_activate()
         module_registry.activate(module.name)
+        mounted.append(module)
+        logger.info("Mounted module: %s", module.name)
 
-
-def load_modules(app: FastAPI) -> None:
-    """Discover, resolve dependencies, and load all modules."""
-    modules = discover_modules()
-    if not modules:
-        logger.warning("No modules discovered")
-        return
-
-    try:
-        ordered = _resolve_load_order(modules)
-    except ValueError as exc:
-        logger.error("Failed to resolve module dependencies: %s", exc)
-        raise
-
-    _mount_modules(app, ordered)
-    logger.info("Loaded %d modules: %s", len(ordered), [m.name for m in ordered])
+    return mounted

--- a/backend/app/core/plugins/processor.py
+++ b/backend/app/core/plugins/processor.py
@@ -106,7 +106,7 @@ class PendingProcessor:
             )
             installed_names = {r.name for r in result.scalars()}
 
-        for module in module_registry.list_modules():
+        for module in module_registry.list_discovered():
             if module.name in installed_names:
                 installed.append(module)
 

--- a/backend/app/core/plugins/processor.py
+++ b/backend/app/core/plugins/processor.py
@@ -29,6 +29,7 @@ from .db_models import ModuleRecord
 from .external_id import ExternalIdHelper
 from .operation_log import OperationLog
 from .registry import module_registry
+from .service import ModuleService
 from .state import ModuleState
 from .topology import topological_sort
 from .yaml_loader import load_module_data_files
@@ -99,17 +100,12 @@ class PendingProcessor:
             write_modules_json,
         )
 
-        installed: list[_BaseModule] = []
         async with self._session_factory() as session:
-            result = await session.execute(
-                select(ModuleRecord).where(ModuleRecord.state == ModuleState.INSTALLED.value)
-            )
-            installed_names = {r.name for r in result.scalars()}
+            installed_names = await ModuleService.installed_names(session)
 
-        for module in module_registry.list_discovered():
-            if module.name in installed_names:
-                installed.append(module)
-
+        installed: list[_BaseModule] = [
+            m for m in module_registry.list_discovered() if m.name in installed_names
+        ]
         entries = collect_layers(installed)
         write_modules_json(entries, DEFAULT_FRONTEND_ROOT)
 

--- a/backend/app/core/plugins/processor.py
+++ b/backend/app/core/plugins/processor.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.config import settings
 
+from .alembic_paths import alembic_cfg_path
 from .context import ModuleContext
 from .db_models import ModuleRecord
 from .external_id import ExternalIdHelper
@@ -441,7 +442,7 @@ def _alembic_cmd(args: list[str]) -> str | None:
     ``args`` is forwarded verbatim to the ``alembic`` CLI (e.g.
     ``["upgrade", "schedules@head"]`` or ``["downgrade", "base"]``).
     """
-    cfg_path = _alembic_cfg_path()
+    cfg_path = alembic_cfg_path()
     backend_root = cfg_path.parent
 
     try:
@@ -474,16 +475,12 @@ def _alembic_cmd(args: list[str]) -> str | None:
     return None
 
 
-def _alembic_cfg_path() -> Path:
-    return Path(__file__).resolve().parents[3] / "alembic.ini"
-
-
 def _parent_revision(revision: str) -> str:
     """Return the ``down_revision`` of ``revision``, or ``'base'`` if none."""
     from alembic.config import Config
     from alembic.script import ScriptDirectory
 
-    script = ScriptDirectory.from_config(Config(str(_alembic_cfg_path())))
+    script = ScriptDirectory.from_config(Config(str(alembic_cfg_path())))
     rev = script.get_revision(revision)
     down = rev.down_revision
     if down is None:
@@ -510,7 +507,7 @@ def _module_branch_label(revision: str) -> str | None:
     from alembic.config import Config
     from alembic.script import ScriptDirectory
 
-    script = ScriptDirectory.from_config(Config(str(_alembic_cfg_path())))
+    script = ScriptDirectory.from_config(Config(str(alembic_cfg_path())))
     rev = script.get_revision(revision)
     while rev is not None:
         if rev._orig_branch_labels:

--- a/backend/app/core/plugins/registry.py
+++ b/backend/app/core/plugins/registry.py
@@ -1,4 +1,19 @@
-"""Module registry for tracking loaded modules."""
+"""Module registry: what is on disk vs. what is live in this process.
+
+Two sets, deliberately separate (issue #91):
+
+* **discovered** — every module the loader found (entry points + dev
+  filesystem scan). The lifecycle machinery (reconcile, install,
+  uninstall) needs all of them, whatever their ``core_module.state``.
+* **active** — the subset the loader mounted at boot because its state is
+  ``installed``: router mounted, event handlers subscribed, tools
+  registered. Anything that asks "is module X live?" (RBAC grants,
+  scheduler jobs, tenant ``modules_enabled``, feature gates in other
+  modules) must use the *active* view.
+
+Activation is a boot-time decision: modules never hot-load, so there is
+no ``deactivate``; a restart re-evaluates from the DB.
+"""
 
 import logging
 from typing import TYPE_CHECKING
@@ -10,49 +25,74 @@ logger = logging.getLogger(__name__)
 
 
 class ModuleRegistry:
-    """Registry that tracks all loaded modules.
-
-    Provides methods to query loaded modules and their capabilities.
-    """
+    """In-memory map of discovered modules plus the set of active names."""
 
     def __init__(self) -> None:
         self._modules: dict[str, BaseModule] = {}
+        self._active: set[str] = set()
+
+    # --- discovered -----------------------------------------------------
 
     def register(self, module: "BaseModule") -> None:
-        """Register a module instance."""
+        """Record a discovered module instance (not yet active)."""
         if module.name in self._modules:
             raise ValueError(f"Module '{module.name}' is already registered")
         self._modules[module.name] = module
-        # Drop the role-permission cache so the merge picks up the
-        # newly-registered module's manifest grants on next lookup.
-        from app.core.auth.permissions import invalidate_role_permissions_cache
-
-        invalidate_role_permissions_cache()
         logger.info(f"Registered module: {module.name} v{module.version}")
 
+    def unregister(self, name: str) -> None:
+        """Forget a module entirely (tests, fixtures). No-op if unknown."""
+        self._modules.pop(name, None)
+        if name in self._active:
+            self._active.discard(name)
+            _invalidate_permissions()
+
     def get(self, name: str) -> "BaseModule | None":
-        """Get a module by name, or None if not found."""
+        """Get a discovered module by name, or None if not found."""
         return self._modules.get(name)
 
-    def is_loaded(self, name: str) -> bool:
-        """Check if a module is loaded."""
+    def is_discovered(self, name: str) -> bool:
         return name in self._modules
 
-    def list_modules(self) -> list["BaseModule"]:
-        """Return list of all loaded modules."""
+    def list_discovered(self) -> list["BaseModule"]:
+        """Every discovered module, in registration (topological) order."""
         return list(self._modules.values())
 
-    def get_all_permissions(self) -> list[str]:
-        """Return all permissions from all loaded modules, fully namespaced.
+    # --- active ---------------------------------------------------------
 
-        Each permission is prefixed with the module name:
-        'patients.read' from 'clinical' module becomes 'clinical.patients.read'
+    def activate(self, name: str) -> None:
+        """Mark a discovered module as live in this process."""
+        if name not in self._modules:
+            raise ValueError(f"Cannot activate unknown module '{name}'")
+        self._active.add(name)
+        # The role-permission merge reads the active set; drop its cache so
+        # the module's manifest grants apply on next lookup.
+        _invalidate_permissions()
+
+    def is_active(self, name: str) -> bool:
+        return name in self._active
+
+    def list_active(self) -> list["BaseModule"]:
+        """Active modules, in registration (topological) order."""
+        return [m for m in self._modules.values() if m.name in self._active]
+
+    def get_all_permissions(self) -> list[str]:
+        """Every permission of every *active* module, fully namespaced.
+
+        ``'read'`` declared by module ``patients`` becomes ``'patients.read'``.
         """
-        permissions: list[str] = []
-        for module in self._modules.values():
-            for perm in module.get_permissions():
-                permissions.append(f"{module.name}.{perm}")
-        return permissions
+        return [
+            f"{module.name}.{perm}"
+            for module in self.list_active()
+            for perm in module.get_permissions()
+        ]
+
+
+def _invalidate_permissions() -> None:
+    # Local import: the auth package imports this registry transitively.
+    from app.core.auth.permissions import invalidate_role_permissions_cache
+
+    invalidate_role_permissions_cache()
 
 
 # Global singleton instance

--- a/backend/app/core/plugins/router.py
+++ b/backend/app/core/plugins/router.py
@@ -29,6 +29,7 @@ from app.core.auth.permissions import has_permission
 from app.core.schemas import ApiResponse
 from app.database import get_db
 
+from .registry import module_registry
 from .service import ModuleOperationError, ModuleService
 from .state import ModuleState
 
@@ -77,18 +78,21 @@ async def active_modules(
     db: Annotated[AsyncSession, Depends(get_db)],
     ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
 ) -> ApiResponse[list[dict[str, Any]]]:
-    """Modules in ``installed`` state + nav items visible to the caller.
+    """Modules that are ``installed`` *and* mounted in this process, with
+    the nav items visible to the caller.
 
     This is the frontend's source of truth for the sidebar. Every
     authenticated user may read it; navigation entries are filtered by
     the caller's role-based permissions so the response is already
-    tailored to what the UI should render.
+    tailored to what the UI should render. The registry check keeps the
+    UI honest when a module is ``installed`` in the DB but the loader
+    skipped it (a dependency was force-uninstalled).
     """
     svc = ModuleService(db)
     active: list[dict[str, Any]] = []
 
     for info in await svc.list_modules():
-        if info.state != ModuleState.INSTALLED:
+        if info.state != ModuleState.INSTALLED or not module_registry.is_active(info.name):
             continue
 
         module = svc.discovered()

--- a/backend/app/core/plugins/service.py
+++ b/backend/app/core/plugins/service.py
@@ -235,6 +235,18 @@ class ModuleService:
         result = await self.db.execute(select(ModuleRecord))
         return {r.name: r for r in result.scalars()}
 
+    @staticmethod
+    async def installed_names(db: AsyncSession) -> set[str]:
+        """Names of the modules whose ``core_module.state`` is ``installed``.
+
+        The boot sequence mounts exactly this set (issue #91); seeds and
+        the frontend-layer sync gate on it too.
+        """
+        result = await db.execute(
+            select(ModuleRecord.name).where(ModuleRecord.state == ModuleState.INSTALLED.value)
+        )
+        return set(result.scalars())
+
     # --- Query ----------------------------------------------------------
 
     async def list_modules(self) -> list[ModuleInfo]:

--- a/backend/app/core/plugins/service.py
+++ b/backend/app/core/plugins/service.py
@@ -20,7 +20,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .alembic_paths import resolve_module_branch_head
 from .base import BaseModule
 from .db_models import ModuleOperationLog, ModuleRecord
-from .loader import discover_modules
 from .manifest import Manifest, ManifestError
 from .operation_log import LogEntry, log_entry_from_row
 from .registry import module_registry
@@ -117,8 +116,8 @@ class ModuleService:
     # --- Discovery + reconciliation -------------------------------------
 
     def discovered(self) -> list[BaseModule]:
-        """Return modules currently loaded in the in-memory registry."""
-        return module_registry.list_modules()
+        """Every module found on disk, whatever its install state."""
+        return module_registry.list_discovered()
 
     async def reconcile_with_db(self) -> None:
         """Ensure ``core_module`` contains one row per discovered module.
@@ -593,16 +592,3 @@ class ModuleService:
         except ManifestError as exc:
             logger.error("Manifest error for %s: %s", module.name, exc)
             return None
-
-
-async def rediscover_and_reconcile(db: AsyncSession) -> None:
-    """Entry point used by the app lifespan.
-
-    Assumes :func:`load_modules` already ran and filled the in-memory
-    registry; this just mirrors the current state into ``core_module``.
-    """
-    svc = ModuleService(db)
-    await svc.reconcile_with_db()
-    # Also discover here in case `discover_modules()` was not called yet.
-    if not module_registry.list_modules():
-        discover_modules()

--- a/backend/app/core/plugins/service.py
+++ b/backend/app/core/plugins/service.py
@@ -122,11 +122,12 @@ class ModuleService:
     async def reconcile_with_db(self) -> None:
         """Ensure ``core_module`` contains one row per discovered module.
 
-        For v1 (Etapa 1): discovered modules that are new in the DB are
-        inserted as ``installed`` (their routers/handlers are already
-        mounted by :func:`load_modules`, so they are effectively live).
-        Discovered modules already in the DB have their ``version`` +
-        ``manifest_snapshot`` refreshed if the version changed.
+        Discovered modules that are new in the DB are inserted as
+        ``installed`` when their manifest says ``auto_install=True`` and as
+        ``uninstalled`` otherwise; the lifespan mounts the ``installed`` set
+        right after this (issue #91). Discovered modules already in the DB
+        have their ``version`` + ``manifest_snapshot`` refreshed if the
+        version changed.
 
         Modules present in DB but missing from disk are left alone here
         — :meth:`doctor` surfaces them as orphans.
@@ -160,19 +161,11 @@ class ModuleService:
             if record is None:
                 # Modules with ``auto_install=False`` must wait for an
                 # explicit Install action from the admin UI before they
-                # become active. They appear in the registry but stay
-                # in ``uninstalled`` state — their lifecycle install()
-                # hook is NOT called, their event handlers do not fire,
-                # and ``base_revision`` is left blank until the user
-                # promotes them.
-                #
-                # Note that the underlying Alembic migration was still
-                # applied as part of the main ``alembic upgrade heads``
-                # at boot (the schema lives on disk, not behind state).
-                # When the user later triggers Install, the processor's
-                # ``_run_migrate`` is a no-op (already at head) and the
-                # rest of the pipeline (seed → lifecycle hook → finalize)
-                # runs normally, eventually setting state=installed.
+                # become active. They stay ``uninstalled``: discovered, but
+                # not mounted — no router, handlers, tools, jobs or grants
+                # — and ``base_revision`` is left blank until the user
+                # promotes them. Install runs the full processor pipeline
+                # (migrate → seed → lifecycle hook → finalize).
                 if manifest.auto_install:
                     initial_state = ModuleState.INSTALLED.value
                     initial_installed_at = now

--- a/backend/app/core/scheduler.py
+++ b/backend/app/core/scheduler.py
@@ -39,10 +39,10 @@ def _build_trigger(job: ScheduledJob) -> CronTrigger | IntervalTrigger:
 def init_scheduler() -> None:
     """Initialize and start the scheduler.
 
-    Jobs are collected from the *registered* modules via
-    ``BaseModule.get_scheduled_jobs()`` — the scheduler no longer imports
-    module task functions directly, so an uninstalled module contributes
-    no job (ADR 0014 import-coupling fix).
+    Jobs are collected from the *active* modules (installed and mounted at
+    boot, issue #91) via ``BaseModule.get_scheduled_jobs()`` — the
+    scheduler no longer imports module task functions directly, so an
+    uninstalled module contributes no job (ADR 0014 import-coupling fix).
     """
     global scheduler
 
@@ -53,7 +53,7 @@ def init_scheduler() -> None:
 
     scheduler = get_scheduler()
 
-    for module in module_registry.list_modules():
+    for module in module_registry.list_active():
         for job in module.get_scheduled_jobs():
             if scheduler.get_job(job.id):
                 logger.info("Scheduler job '%s' already exists, skipping", job.id)

--- a/backend/app/core/scheduling.py
+++ b/backend/app/core/scheduling.py
@@ -2,7 +2,8 @@
 
 A module declares its periodic jobs by returning :class:`ScheduledJob`
 specs from ``BaseModule.get_scheduled_jobs()``. The scheduler
-(:mod:`app.core.scheduler`) iterates the *registered* modules and wires
+(:mod:`app.core.scheduler`) iterates the *active* modules (installed and
+mounted at boot) and wires
 each spec into APScheduler — so an uninstalled module contributes no job
 and the scheduler no longer imports module task functions directly
 (removes the import-coupling tech debt recorded in ADR 0014).

--- a/backend/app/core/tenancy/single.py
+++ b/backend/app/core/tenancy/single.py
@@ -25,7 +25,7 @@ class SingleTenantResolver:
     """Resolver that always returns the same tenant.
 
     The tenant is built once from ``settings.DATABASE_URL`` and the set of
-    modules currently loaded in the ``ModuleRegistry``. Subsequent
+    modules active (installed and mounted) in the ``ModuleRegistry``. Subsequent
     ``resolve()`` / ``resolve_by_slug()`` calls return the cached instance.
     """
 
@@ -34,7 +34,7 @@ class SingleTenantResolver:
             slug=DEFAULT_TENANT_SLUG,
             db_url=settings.DATABASE_URL,
             storage_prefix="",
-            modules_enabled=frozenset(module.name for module in module_registry.list_modules()),
+            modules_enabled=frozenset(module.name for module in module_registry.list_active()),
         )
 
     async def resolve(self, request: Request) -> TenantContext:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,8 +41,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # (defaults to ``-`` outside a request).
     setup_logging()
 
-    # Startup
-    mount_modules(app, register_discovered())
+    # Startup — discover everything, settle DB state, then mount only what
+    # is installed (issue #91). Order matters: the processor may install or
+    # remove modules in this very boot, and the mount step reads the result.
+    discovered = register_discovered()
 
     # Sync in-memory registry into core_module (best-effort).
     try:
@@ -60,7 +62,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     except Exception:
         logger.exception("Pending module processor raised")
 
-    # Initialize scheduler for background jobs
+    # Not best-effort: if the DB is unreachable here, booting with zero
+    # modules would serve a healthy-looking but empty API. Let it raise —
+    # the container restarts and retries, as it already does when the
+    # entrypoint's migrations fail.
+    async with async_session_maker() as session:
+        installed = await ModuleService.installed_names(session)
+    mounted = mount_modules(app, [m for m in discovered if m.name in installed])
+    logger.info(
+        "Mounted %d/%d modules: %s", len(mounted), len(discovered), [m.name for m in mounted]
+    )
+
+    # Initialize scheduler for background jobs (active modules only)
     init_scheduler()
 
     yield

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -232,7 +232,7 @@ async def readiness_check(
     Probes a core table so monitoring catches the case where the DB volume
     gets recreated under a running container (schema gone, every business
     endpoint 500s). Recovery from that state belongs in the entrypoint
-    (`alembic upgrade heads`) plus an explicit container restart — not in
+    (`dentalpin db upgrade`) plus an explicit container restart — not in
     the proxy healthcheck, since Docker's `restart: unless-stopped` does
     not auto-restart on healthcheck failure.
     """

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,7 +23,7 @@ from app.core.log_context import (
     set_request_context,
     setup_logging,
 )
-from app.core.plugins.loader import load_modules
+from app.core.plugins.loader import mount_modules, register_discovered
 from app.core.plugins.processor import PendingProcessor
 from app.core.plugins.service import ModuleService
 from app.core.scheduler import init_scheduler, shutdown_scheduler
@@ -42,7 +42,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     setup_logging()
 
     # Startup
-    load_modules(app)
+    mount_modules(app, register_discovered())
 
     # Sync in-memory registry into core_module (best-effort).
     try:

--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- docs(#91): `BillingHookRegistry` docstring shows the real hook (`BaseModule.on_activate`) instead of the never-implemented `on_load/on_unload`.
 - refactor(#184): the invoice edit page no longer casts the embedded patient brief to `Patient`; a `displayedPatient` computed falls back from the user's pick to the invoice brief, and `patient_id` is only sent when a different patient was actually chosen.
 - fix(#184): type-check clean. `GET /invoices/{id}/payments` returns `InvoicePaymentDetailResponse` (link row + embedded `PaymentResponse`) — the patient billing summary rendered `payment_date`/`method` the link row never had; `InvoiceDetail.invoice_payments` mirrors the API (`payments` did not exist); invoices embed billing's own patient brief (`InvoicePatientBrief`, with billing fields); the from-budget page loads the full patient for the billing card (the budget brief has no billing fields, so it always showed the fallback); the new-invoice form drops the dead billing inputs the API ignores; readonly items typed `DeepReadonly` where only read.
 - docs(#183): `on_clinic_created` documented as own-session — published after setup commits, and seeding series must not stretch the signup transaction.

--- a/backend/app/modules/billing/hooks.py
+++ b/backend/app/modules/billing/hooks.py
@@ -276,15 +276,13 @@ class BillingHookRegistry:
     Country modules register their hooks here.
     The billing module queries this registry to find applicable hooks.
 
-    Usage by country module:
+    Usage by country module (re-attached on every boot the module is
+    installed — see ``BaseModule.on_activate``):
 
-        # In verifactu_es/__init__.py
+        # In verifactu/__init__.py
         class VerifactuModule(BaseModule):
-            def on_load(self):
+            def on_activate(self) -> None:
                 BillingHookRegistry.register(VerifactuHook())
-
-            def on_unload(self):
-                BillingHookRegistry.unregister("ES")
     """
 
     _hooks: dict[str, BillingComplianceHook] = {}

--- a/backend/app/modules/migration_import/CHANGELOG.md
+++ b/backend/app/modules/migration_import/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#91): the verifactu gate uses `module_registry.is_active("verifactu")` (installed and mounted) instead of `is_loaded` (merely on disk), so an uninstalled verifactu no longer flips imports into compliance mode.
 - fix(#184): type-check clean — semantic badge/toast colours; `scoreBadgeColor()` returns `UiColor`.
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 

--- a/backend/app/modules/migration_import/CLAUDE.md
+++ b/backend/app/modules/migration_import/CLAUDE.md
@@ -29,7 +29,7 @@ Routes mounted at `/api/v1/migration_import/`.
 
 **`verifactu` is intentionally NOT in `depends`.** Portuguese/French
 clinics import without it. The fiscal-document mapper detects it at
-runtime through `module_registry.is_loaded("verifactu")` and gates
+runtime through `module_registry.is_active("verifactu")` and gates
 legal-hash preservation behind an operator opt-in checkbox shown in
 the preview step.
 

--- a/backend/app/modules/migration_import/mappers/fiscal_document.py
+++ b/backend/app/modules/migration_import/mappers/fiscal_document.py
@@ -43,7 +43,7 @@ _LEGAL_FIELDS = (
 
 
 def _verifactu_active(ctx: MapperContext) -> bool:
-    return ctx.import_fiscal_compliance and module_registry.is_loaded("verifactu")
+    return ctx.import_fiscal_compliance and module_registry.is_active("verifactu")
 
 
 class FiscalDocumentMapper:
@@ -198,7 +198,7 @@ class FiscalDocumentMapper:
         if not has_legal:
             return
         code = (
-            "verifactu.opt_out" if module_registry.is_loaded("verifactu") else "verifactu.skipped"
+            "verifactu.opt_out" if module_registry.is_active("verifactu") else "verifactu.skipped"
         )
         ctx.db.add(
             ImportWarning(

--- a/backend/app/modules/migration_import/service.py
+++ b/backend/app/modules/migration_import/service.py
@@ -204,7 +204,7 @@ class ImportJobService:
             files = ImportJobService._build_files_summary(handle)
             verifactu_detected = _detect_verifactu_data(handle)
 
-        verifactu_installed = module_registry.is_loaded("verifactu")
+        verifactu_installed = module_registry.is_active("verifactu")
 
         from .schemas import ImportJobResponse
 

--- a/backend/app/modules/schedules/CHANGELOG.md
+++ b/backend/app/modules/schedules/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- docs(#91): `events.py` header states the real contract — handlers are only subscribed while the module is installed.
 - fix(#184): type-check clean — `useProfessionalHours` re-exports `Shift`/`WeekdayShifts`, override forms keep `reason` as a string and normalise to `null` on submit, shift edits guard the indexed row.
 - docs(#183): `on_clinic_created` documented as own-session (published after setup commits); the appointment handlers are payload-only logging.
 - feat(onboarding): `ClinicHoursQuickModal` — inline weekly-hours editor with two presets, used as the getting-started mini-modal.

--- a/backend/app/modules/schedules/events.py
+++ b/backend/app/modules/schedules/events.py
@@ -1,8 +1,8 @@
 """Event handlers.
 
 * Agenda appointment lifecycle — purely informational (analytics cache);
-  never block the appointment flow. If schedules is uninstalled the bus
-  simply stops calling these functions.
+  never block the appointment flow. While schedules is uninstalled the
+  loader does not subscribe these functions at all (issue #91).
 * ``clinic.created`` — seed a Mon–Fri weekly template so a fresh clinic
   doesn't start "open 24/7".
 """

--- a/backend/app/modules/verifactu/CHANGELOG.md
+++ b/backend/app/modules/verifactu/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#91): the billing hook is registered from `on_activate()` (every boot the module is installed, never while it isn't); the three APScheduler jobs are declared via `get_scheduled_jobs()` instead of being added from `install()` (they used to vanish on the next restart); `verifactu.record.rejected` is subscribed via `get_event_handlers()`. `tasks.register_jobs/unregister_jobs/register_event_handlers` removed.
 - fix(#184): type-check clean — toasts/badges/alerts use Nuxt UI v4 semantic colours (`red/green/amber/blue/gray` were rendering uncoloured), `VatClassification` codes are typed once in `useVerifactu` and shared with the VAT-mapping page, the invoice slot's local `errorMessage` computed no longer shadows the `errorMessage()` util it calls, sibling composable imports are relative.
 - docs(#183): `on_invoice_paid` documented as own-session/payload-only (ADR 0019).
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.

--- a/backend/app/modules/verifactu/__init__.py
+++ b/backend/app/modules/verifactu/__init__.py
@@ -12,6 +12,7 @@ fiscal records are sent to AEAT (uninstall blocks).
 from fastapi import APIRouter
 
 from app.core.plugins import BaseModule
+from app.core.scheduling import ScheduledJob
 
 from .models import (
     VerifactuCertificate,
@@ -46,22 +47,6 @@ class VerifactuModule(BaseModule):
         },
     }
 
-    def __init__(self) -> None:
-        # Register the BillingComplianceHook on every backend boot — the
-        # one-time ``install`` lifecycle only runs when the user clicks
-        # Install in the admin UI; subsequent restarts wipe the in-memory
-        # registry, so hooks must be re-attached at module load time.
-        # Idempotent: ``BillingHookRegistry`` keys by country_code.
-        from app.modules.billing.hooks import BillingHookRegistry
-
-        from .hook import VerifactuHook
-        from .tasks import register_event_handlers
-
-        BillingHookRegistry.register(VerifactuHook())
-        # Same reasoning for the event bus subscription — re-attach on
-        # boot so the rejected-record email handler survives restarts.
-        register_event_handlers()
-
     def get_models(self) -> list:
         return [
             VerifactuSettings,
@@ -83,24 +68,35 @@ class VerifactuModule(BaseModule):
         ]
 
     def get_event_handlers(self) -> dict:
+        from app.core.events import EventType
+
         from .events import on_invoice_paid
+        from .tasks import on_rejected_event
 
         return {
             "invoice.paid": on_invoice_paid,
+            EventType.VERIFACTU_RECORD_REJECTED: on_rejected_event,
         }
+
+    def get_scheduled_jobs(self) -> list[ScheduledJob]:
+        from .tasks import scheduled_jobs
+
+        return scheduled_jobs()
+
+    def on_activate(self) -> None:
+        # Re-attached on every boot the module is installed (issue #91):
+        # the billing workflow looks the hook up by country at request
+        # time, so it must live in this process, not in the DB.
+        from app.modules.billing.hooks import BillingHookRegistry
+
+        from .hook import VerifactuHook
+
+        BillingHookRegistry.register(VerifactuHook())
 
     async def install(self, ctx) -> None:
         from sqlalchemy import select
 
-        from app.modules.billing.hooks import BillingHookRegistry
         from app.modules.catalog.models import VatType
-
-        from .hook import VerifactuHook
-        from .tasks import register_jobs
-
-        BillingHookRegistry.register(VerifactuHook())
-        register_jobs()
-        ctx.logger.info("verifactu hook registered for country=ES")
 
         # Seed default AEAT classification for every existing
         # zero-rated VAT type. For dental clinics, rate=0 typically
@@ -132,10 +128,7 @@ class VerifactuModule(BaseModule):
     async def uninstall(self, ctx) -> None:
         from sqlalchemy import select
 
-        from app.modules.billing.hooks import BillingHookRegistry
-
         from .models import VerifactuRecord
-        from .tasks import unregister_jobs
 
         result = await ctx.db.execute(
             select(VerifactuRecord.id)
@@ -149,9 +142,6 @@ class VerifactuModule(BaseModule):
                 "libro de facturación 4 años. Exporta el libro antes de "
                 "intentar desinstalar."
             )
-        from .tasks import unregister_event_handlers
-
-        BillingHookRegistry.unregister("ES")
-        unregister_jobs()
-        unregister_event_handlers()
-        ctx.logger.info("verifactu hook unregistered")
+        # Nothing to detach: the hook, jobs and handlers are only wired by
+        # the loader while the module is installed, and the processor runs
+        # before mounting on the next boot.

--- a/backend/app/modules/verifactu/tasks.py
+++ b/backend/app/modules/verifactu/tasks.py
@@ -1,8 +1,8 @@
 """APScheduler integration for Verifactu background jobs + event handlers.
 
-The scheduler is owned by the host app at :mod:`app.core.scheduler`.
-We register our jobs from :func:`register_jobs`, called from the
-module's startup hook.
+The scheduler is owned by the host app at :mod:`app.core.scheduler`;
+the module hands it the specs below via ``VerifactuModule.get_scheduled_jobs``
+(only while installed — issue #91).
 
 Jobs:
 
@@ -16,7 +16,8 @@ Jobs:
 Event handlers:
 
 * ``verifactu.record.rejected`` → email clinic admins about an AEAT
-  rejection (throttled to 1 alert per clinic per 30 min).
+  rejection (throttled to 1 alert per clinic per 30 min). Subscribed via
+  ``VerifactuModule.get_event_handlers``.
 """
 
 from __future__ import annotations
@@ -25,14 +26,11 @@ import logging
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from apscheduler.triggers.cron import CronTrigger
-from apscheduler.triggers.interval import IntervalTrigger
 from sqlalchemy import select
 
 from app.core.auth.models import Clinic, ClinicMembership, User
 from app.core.email import email_service
-from app.core.events import EventType, event_bus
-from app.core.scheduler import get_scheduler
+from app.core.scheduling import ScheduledJob
 from app.database import async_session_maker
 
 from .models import VerifactuSettings
@@ -43,8 +41,6 @@ logger = logging.getLogger(__name__)
 JOB_ID_SUBMISSIONS = "verifactu_submissions"
 JOB_ID_REAPER = "verifactu_stuck_reaper"
 JOB_ID_CERT_CHECK = "verifactu_cert_expiry"
-
-ALL_JOB_IDS = (JOB_ID_SUBMISSIONS, JOB_ID_REAPER, JOB_ID_CERT_CHECK)
 
 REJECTED_ALERT_THROTTLE = timedelta(minutes=30)
 
@@ -71,56 +67,32 @@ async def daily_cert_check() -> None:
     await check_expiring_certs(async_session_maker)
 
 
-def register_jobs() -> None:
-    """Idempotent registration; safe under uvicorn --reload."""
+def scheduled_jobs() -> list[ScheduledJob]:
+    """Specs for :meth:`VerifactuModule.get_scheduled_jobs`."""
 
-    scheduler = get_scheduler()
-
-    if not scheduler.get_job(JOB_ID_SUBMISSIONS):
-        scheduler.add_job(
-            process_verifactu_submissions,
-            IntervalTrigger(seconds=60),
+    return [
+        ScheduledJob(
             id=JOB_ID_SUBMISSIONS,
+            func=process_verifactu_submissions,
+            trigger="interval",
+            trigger_args={"seconds": 60},
             name="Drain Verifactu submission queue",
-            replace_existing=True,
-        )
-
-    if not scheduler.get_job(JOB_ID_REAPER):
-        scheduler.add_job(
-            reap_stuck_records,
-            IntervalTrigger(minutes=5),
+        ),
+        ScheduledJob(
             id=JOB_ID_REAPER,
+            func=reap_stuck_records,
+            trigger="interval",
+            trigger_args={"minutes": 5},
             name="Reap Verifactu records stuck in 'sending'",
-            replace_existing=True,
-        )
-
-    if not scheduler.get_job(JOB_ID_CERT_CHECK):
-        scheduler.add_job(
-            daily_cert_check,
-            CronTrigger(hour=8, minute=0),
+        ),
+        ScheduledJob(
             id=JOB_ID_CERT_CHECK,
+            func=daily_cert_check,
+            trigger="cron",
+            trigger_args={"hour": 8, "minute": 0},
             name="Check Verifactu certificates expiring soon",
-            replace_existing=True,
-        )
-
-
-def unregister_jobs() -> None:
-    """Remove every Verifactu job from the scheduler.
-
-    Called from :meth:`VerifactuModule.uninstall` so the host scheduler
-    doesn't keep firing into a module that no longer has the imports
-    available.
-    """
-
-    scheduler = get_scheduler()
-    for job_id in ALL_JOB_IDS:
-        if scheduler.get_job(job_id):
-            scheduler.remove_job(job_id)
-
-
-# ---------------------------------------------------------------------------
-# Event handlers
-# ---------------------------------------------------------------------------
+        ),
+    ]
 
 
 async def _admins_for(db, clinic_id: UUID) -> list[User]:
@@ -212,8 +184,8 @@ async def _notify_rejected(payload: dict) -> None:
             await db.commit()
 
 
-def _on_rejected_event(payload: dict) -> None:
-    """Bus adapter — forwards to the async handler."""
+def on_rejected_event(payload: dict) -> None:
+    """Bus adapter for ``verifactu.record.rejected`` — forwards to the async handler."""
     import asyncio
 
     try:
@@ -221,14 +193,3 @@ def _on_rejected_event(payload: dict) -> None:
         loop.create_task(_notify_rejected(payload))
     except RuntimeError:
         asyncio.run(_notify_rejected(payload))
-
-
-def register_event_handlers() -> None:
-    """Idempotent — replaces previous subscription on re-register."""
-
-    event_bus.unsubscribe(EventType.VERIFACTU_RECORD_REJECTED, _on_rejected_event)
-    event_bus.subscribe(EventType.VERIFACTU_RECORD_REJECTED, _on_rejected_event)
-
-
-def unregister_event_handlers() -> None:
-    event_bus.unsubscribe(EventType.VERIFACTU_RECORD_REJECTED, _on_rejected_event)

--- a/backend/app/modules/whatsapp_kapso/CHANGELOG.md
+++ b/backend/app/modules/whatsapp_kapso/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#91): `KapsoAdapter` is registered in the channel registry from `on_activate()` — on every boot the module is installed — instead of at import time, so an uninstalled module no longer serves WhatsApp (and no longer queries `whatsapp_kapso_settings` once its tables are gone).
 - i18n: add Tamil locale (`ta.json`) with full UI coverage.
 
 - style(lint): first ESLint pass over this module's frontend layer —

--- a/backend/app/modules/whatsapp_kapso/__init__.py
+++ b/backend/app/modules/whatsapp_kapso/__init__.py
@@ -1,8 +1,10 @@
 """whatsapp_kapso — WhatsApp delivery for notifications via Kapso.
 
 Community, removable. Registers a ``KapsoAdapter`` into the notifications
-channel registry at import time (the only cross-module dependency, declared in
-``manifest.depends``). ``notifications`` does not depend on this module.
+channel registry from ``on_activate`` — i.e. on every boot the module is
+installed, and never while it is not (issue #91). That is the only
+cross-module dependency, declared in ``manifest.depends``;
+``notifications`` does not depend on this module.
 
 Issue #63. See ADR 0016 (channel adapters) + ADR 0017 (inbound/conversation).
 """
@@ -25,9 +27,6 @@ if TYPE_CHECKING:
 
 # Table names exercised by the round-trip uninstall test.
 KAPSO_TABLES = {"whatsapp_kapso_settings", "whatsapp_kapso_templates"}
-
-# Register the adapter once, at import time. Idempotent in the registry.
-channel_registry.register(KapsoAdapter())
 
 
 class WhatsappKapsoModule(BaseModule):
@@ -56,7 +55,10 @@ class WhatsappKapsoModule(BaseModule):
         # Namespaced → whatsapp_kapso.settings.read / .write
         return ["settings.read", "settings.write"]
 
+    def on_activate(self) -> None:
+        # Idempotent in the registry. Not registered ⇒ the gateway falls
+        # back to the next configured channel (email).
+        channel_registry.register(KapsoAdapter())
+
     async def uninstall(self, ctx: ModuleContext) -> None:
-        # Drop the adapter so a uninstalled module stops serving WhatsApp;
-        # the channel then falls back to email in the gateway.
         channel_registry.unregister("whatsapp_kapso")

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -5,7 +5,7 @@ if [ "${RUN_MIGRATIONS:-1}" = "1" ]; then
   # One-time heal for the Fase C schedules-branch rewire (issue #56):
   # DBs bootstrapped while schedules lived on the main linear chain have
   # the schedules tables but no row in alembic_version for the new
-  # branch. Stamp sch_0001 so "alembic upgrade heads" is a no-op instead
+  # branch. Stamp sch_0001 so the boot upgrade is a no-op instead
   # of re-creating tables that already exist.
   PG_URL="$(python -c 'from app.config import settings; print(settings.DATABASE_URL.replace("postgresql+asyncpg://","postgresql://"))')"
   psql "$PG_URL" -v ON_ERROR_STOP=1 <<'SQL' || true
@@ -24,8 +24,10 @@ END
 $$;
 SQL
 
-  echo "[entrypoint] Running alembic upgrade heads..."
-  alembic upgrade heads
+  # Core heads + the branches of installed modules only (ADR 0020): an
+  # uninstalled module's tables must not come back on restart (#91).
+  echo "[entrypoint] Running dentalpin db upgrade..."
+  python -m app.cli db upgrade
 fi
 
 if [ "${SEED_ON_STARTUP:-0}" = "1" ]; then

--- a/backend/scripts/backfill_verifactu_severity.py
+++ b/backend/scripts/backfill_verifactu_severity.py
@@ -33,11 +33,11 @@ from sqlalchemy import select  # noqa: E402
 
 # Force SQLAlchemy to resolve every cross-module relationship by
 # loading all module models the same way the app does at startup.
-from app.core.plugins.loader import load_modules  # noqa: E402
+from app.core.plugins.loader import register_discovered  # noqa: E402
 from app.database import async_session_maker  # noqa: E402
-from app.main import app as _app  # noqa: E402
 
-load_modules(_app)
+for _module in register_discovered():
+    _module.get_models()
 
 from app.modules.billing.models import Invoice  # noqa: E402
 from app.modules.verifactu.models import VerifactuRecord  # noqa: E402

--- a/backend/scripts/seed_demo.py
+++ b/backend/scripts/seed_demo.py
@@ -93,12 +93,9 @@ async def _module_is_installed(db: AsyncSession, name: str) -> bool:
     Optional-module seeds gate themselves on this so uninstalling a
     module also silently skips its demo data on re-seed.
     """
-    from app.core.plugins.db_models import ModuleRecord
-    from app.core.plugins.state import ModuleState
+    from app.core.plugins.service import ModuleService
 
-    result = await db.execute(select(ModuleRecord).where(ModuleRecord.name == name))
-    record = result.scalar_one_or_none()
-    return record is not None and record.state == ModuleState.INSTALLED.value
+    return name in await ModuleService.installed_names(db)
 
 
 async def _load_catalog_map(db: AsyncSession) -> dict[str, dict]:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -15,7 +15,7 @@ from app.config import settings
 
 # Import all models so SQLAlchemy can configure relationships
 from app.core.auth.models import Clinic, ClinicMembership, User  # noqa: F401
-from app.core.plugins.loader import load_modules
+from app.core.plugins.loader import mount_modules, register_discovered
 from app.database import Base, get_db
 from app.database import engine as app_engine
 from app.main import app
@@ -90,8 +90,9 @@ from app.modules.verifactu.models import (  # noqa: F401
     VerifactuVatClassification,
 )
 
-# Load modules manually for tests (normally done in lifespan)
-load_modules(app)
+# Tests run with every discovered module mounted (the lifespan mounts only
+# the installed ones; conftest is the one place that explicitly wants all).
+mount_modules(app, register_discovered())
 
 # Use the DATABASE_URL directly - CI already provides the test database URL
 # For local development, ensure DATABASE_URL points to test database

--- a/backend/tests/fixtures/sample_module/__init__.py
+++ b/backend/tests/fixtures/sample_module/__init__.py
@@ -58,3 +58,20 @@ class SampleModule(BaseModule):
 
     def get_tools(self) -> list:
         return []
+
+    # --- observability for the activation tests (issue #91) ---------------
+
+    SAMPLE_EVENT = "sample_community.ping"
+
+    def __init__(self) -> None:
+        self.activated = False
+        self.seen_events: list[dict] = []
+
+    def get_event_handlers(self) -> dict:
+        return {self.SAMPLE_EVENT: self._on_ping}
+
+    def _on_ping(self, payload: dict) -> None:
+        self.seen_events.append(payload)
+
+    def on_activate(self) -> None:
+        self.activated = True

--- a/backend/tests/test_agents_registry.py
+++ b/backend/tests/test_agents_registry.py
@@ -215,7 +215,7 @@ async def test_every_existing_module_returns_a_list_of_tools():
     """Every module's get_tools() must return a list (default is empty)."""
     from app.core.plugins.registry import module_registry
 
-    modules = module_registry.list_modules()
+    modules = module_registry.list_discovered()
     assert modules, "no modules loaded — conftest load_modules failed"
     for module in modules:
         tools = module.get_tools()

--- a/backend/tests/test_agents_registry.py
+++ b/backend/tests/test_agents_registry.py
@@ -216,7 +216,7 @@ async def test_every_existing_module_returns_a_list_of_tools():
     from app.core.plugins.registry import module_registry
 
     modules = module_registry.list_discovered()
-    assert modules, "no modules loaded — conftest load_modules failed"
+    assert modules, "no modules loaded — conftest register_discovered failed"
     for module in modules:
         tools = module.get_tools()
         assert isinstance(tools, list), f"{module.name}.get_tools() must return list"

--- a/backend/tests/test_boot_upgrade_roundtrip.py
+++ b/backend/tests/test_boot_upgrade_roundtrip.py
@@ -1,0 +1,106 @@
+"""``dentalpin db upgrade`` respects install state across restarts (ADR 0020).
+
+The bug from issue #91: uninstall downgraded a module's branch, and the
+next boot's ``alembic upgrade heads`` recreated its tables with the row
+still ``uninstalled``. Drives the real CLI + Alembic via subprocess against
+the test DB, like ``test_uninstall_roundtrip``.
+
+Marked ``alembic_roundtrip`` — excluded from the default run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from app.config import settings
+
+pytestmark = pytest.mark.alembic_roundtrip
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+ALEMBIC_INI = BACKEND_ROOT / "alembic.ini"
+
+PERIO_TABLES = {"periodontogram_snapshots", "periodontogram_teeth", "periodontogram_sites"}
+
+
+def _run(*args: str) -> None:
+    subprocess.run(list(args), cwd=BACKEND_ROOT, check=True)
+
+
+def _dsn() -> str:
+    return settings.DATABASE_URL.replace("postgresql+asyncpg://", "postgresql://")
+
+
+async def _sql(query: str, *params) -> list:
+    conn = await asyncpg.connect(_dsn())
+    try:
+        return await conn.fetch(query, *params)
+    finally:
+        await conn.close()
+
+
+def _tables() -> set[str]:
+    rows = asyncio.run(
+        _sql(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name != 'alembic_version'"
+        )
+    )
+    return {r["table_name"] for r in rows}
+
+
+def _drop_everything() -> None:
+    """Empty ``public`` (tables + alembic_version) — ``downgrade base`` is not
+    an option while the graph has a one-way migration (see
+    ``test_alembic_roundtrip.ONE_WAY_REVISIONS``)."""
+    rows = asyncio.run(_sql("SELECT tablename FROM pg_tables WHERE schemaname = 'public'"))
+    for row in rows:
+        asyncio.run(_sql(f'DROP TABLE IF EXISTS "{row["tablename"]}" CASCADE'))
+
+
+def _set_state(name: str, state: str) -> None:
+    asyncio.run(
+        _sql(
+            """
+            INSERT INTO core_module (name, version, state, category, removable, auto_install,
+                                     last_state_change, manifest_snapshot)
+            VALUES ($1, '0.0.0', $2, 'official', true, false, now(), '{}'::jsonb)
+            ON CONFLICT (name) DO UPDATE SET state = EXCLUDED.state
+            """,
+            name,
+            state,
+        )
+    )
+
+
+def test_db_upgrade_applies_only_core_and_installed_branches() -> None:
+    _drop_everything()
+
+    # Fresh DB, no core_module rows: core + auto_install modules only.
+    _run("python", "-m", "app.cli", "db", "upgrade")
+    tables = _tables()
+    assert "users" in tables and "core_module" in tables
+    assert PERIO_TABLES.isdisjoint(tables), (
+        f"opt-in branch applied on fresh boot: {PERIO_TABLES & tables}"
+    )
+
+    # Admin installs periodontogram: its branch is applied on the next boot.
+    _set_state("periodontogram", "installed")
+    _run("python", "-m", "app.cli", "db", "upgrade")
+    assert PERIO_TABLES.issubset(_tables())
+
+    # Uninstall (the processor downgrades ``<label>@-<owned revisions>`` —
+    # one file for periodontogram — and writes uninstalled), then
+    # restart: the tables must NOT come back — the #91 bug.
+    _run("alembic", "-c", str(ALEMBIC_INI), "downgrade", "periodontogram@-1")
+    _set_state("periodontogram", "uninstalled")
+    assert PERIO_TABLES.isdisjoint(_tables())
+    _run("python", "-m", "app.cli", "db", "upgrade")
+    assert PERIO_TABLES.isdisjoint(_tables()), "uninstalled module's tables resurrected on restart"
+
+    # Leave the DB at heads for whatever runs next in this job.
+    _run("alembic", "-c", str(ALEMBIC_INI), "upgrade", "heads")

--- a/backend/tests/test_boot_upgrade_targets.py
+++ b/backend/tests/test_boot_upgrade_targets.py
@@ -1,0 +1,50 @@
+"""``boot_upgrade_targets`` — which Alembic heads a boot applies (ADR 0020).
+
+Pure graph test on the real ``alembic.ini`` + discovered modules; no DB.
+"""
+
+from __future__ import annotations
+
+from app.core.plugins.alembic_paths import (
+    boot_upgrade_targets,
+    resolve_module_branch_head,
+)
+from app.core.plugins.loader import register_discovered
+
+
+def test_targets_are_core_heads_plus_wanted_module_heads() -> None:
+    modules = register_discovered()
+    targets = boot_upgrade_targets(modules, wanted=lambda m: True)
+
+    assert targets[0].isdigit(), "core head comes first"
+    for module in modules:
+        head = resolve_module_branch_head(module)
+        if head is not None:
+            assert head in targets, f"{module.name} head {head} missing"
+    # A module whose branch tip is not a global head (budget chains into
+    # payments) must still be named — ``heads`` alone would miss it.
+    assert resolve_module_branch_head(next(m for m in modules if m.name == "budget")) in targets
+
+
+def test_unwanted_module_branch_is_never_named() -> None:
+    modules = register_discovered()
+    perio = next(m for m in modules if m.name == "periodontogram")
+    perio_head = resolve_module_branch_head(perio)
+    assert perio_head is not None
+
+    targets = boot_upgrade_targets(modules, wanted=lambda m: m.name != "periodontogram")
+    assert perio_head not in targets
+    # …and everything else is untouched.
+    for module in modules:
+        if module.name == "periodontogram":
+            continue
+        head = resolve_module_branch_head(module)
+        if head is not None:
+            assert head in targets
+
+
+def test_core_heads_do_not_depend_on_wanted() -> None:
+    modules = register_discovered()
+    only_core = boot_upgrade_targets(modules, wanted=lambda m: False)
+    assert only_core, "core heads are always applied"
+    assert all(t.isdigit() for t in only_core), only_core

--- a/backend/tests/test_cli_modules.py
+++ b/backend/tests/test_cli_modules.py
@@ -22,7 +22,7 @@ from app.core.plugins.service import ModuleService
 
 
 def _seed_registry() -> None:
-    if module_registry.list_modules():
+    if module_registry.list_discovered():
         return
     for module in discover_modules():
         try:

--- a/backend/tests/test_cli_modules.py
+++ b/backend/tests/test_cli_modules.py
@@ -16,24 +16,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cli.__main__ import build_parser
 from app.cli.modules import _cmd_doctor, _cmd_info, _cmd_list, _cmd_status
-from app.core.plugins.loader import discover_modules
-from app.core.plugins.registry import module_registry
+from app.core.plugins.loader import register_discovered
 from app.core.plugins.service import ModuleService
-
-
-def _seed_registry() -> None:
-    if module_registry.list_discovered():
-        return
-    for module in discover_modules():
-        try:
-            module_registry.register(module)
-        except ValueError:
-            pass
 
 
 @pytest.mark.asyncio
 async def test_cli_list_json(db_session: AsyncSession, capsys) -> None:
-    _seed_registry()
+    register_discovered()
     await ModuleService(db_session).reconcile_with_db()
 
     exit_code = await _cmd_list(
@@ -51,7 +40,7 @@ async def test_cli_list_json(db_session: AsyncSession, capsys) -> None:
 
 @pytest.mark.asyncio
 async def test_cli_list_text_table(db_session: AsyncSession, capsys) -> None:
-    _seed_registry()
+    register_discovered()
     await ModuleService(db_session).reconcile_with_db()
 
     exit_code = await _cmd_list(
@@ -67,7 +56,7 @@ async def test_cli_list_text_table(db_session: AsyncSession, capsys) -> None:
 
 @pytest.mark.asyncio
 async def test_cli_info_unknown_returns_nonzero(db_session: AsyncSession, capsys) -> None:
-    _seed_registry()
+    register_discovered()
     await ModuleService(db_session).reconcile_with_db()
 
     exit_code = await _cmd_info(
@@ -79,7 +68,7 @@ async def test_cli_info_unknown_returns_nonzero(db_session: AsyncSession, capsys
 
 @pytest.mark.asyncio
 async def test_cli_info_known_module(db_session: AsyncSession, capsys) -> None:
-    _seed_registry()
+    register_discovered()
     await ModuleService(db_session).reconcile_with_db()
 
     exit_code = await _cmd_info(
@@ -95,7 +84,7 @@ async def test_cli_info_known_module(db_session: AsyncSession, capsys) -> None:
 
 @pytest.mark.asyncio
 async def test_cli_status_reports_counts(db_session: AsyncSession, capsys) -> None:
-    _seed_registry()
+    register_discovered()
     await ModuleService(db_session).reconcile_with_db()
 
     exit_code = await _cmd_status(
@@ -111,7 +100,7 @@ async def test_cli_status_reports_counts(db_session: AsyncSession, capsys) -> No
 
 @pytest.mark.asyncio
 async def test_cli_doctor_clean(db_session: AsyncSession, capsys) -> None:
-    _seed_registry()
+    register_discovered()
     await ModuleService(db_session).reconcile_with_db()
 
     exit_code = await _cmd_doctor(

--- a/backend/tests/test_e2e_community_install.py
+++ b/backend/tests/test_e2e_community_install.py
@@ -24,15 +24,12 @@ from tests.fixtures.sample_module import SampleModule
 @pytest.fixture
 def sample_registered():
     """Register SampleModule for the duration of one test, then unregister."""
-    existing = module_registry.get("sample_community")
-    if existing is None:
-        instance = SampleModule()
-        module_registry.register(instance)
-    # Deregister via private field — registry has no public remove.
+    if module_registry.get("sample_community") is None:
+        module_registry.register(SampleModule())
     try:
         yield module_registry.get("sample_community")
     finally:
-        module_registry._modules.pop("sample_community", None)  # noqa: SLF001
+        module_registry.unregister("sample_community")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_event_bus_transactional.py
+++ b/backend/tests/test_event_bus_transactional.py
@@ -82,7 +82,7 @@ def _transactional_events() -> set[str]:
 
     return {
         event
-        for module in module_registry.list_modules()
+        for module in module_registry.list_discovered()
         for event, handler in module.get_event_handlers().items()
         if _wants_db(handler)
     }

--- a/backend/tests/test_module_activation.py
+++ b/backend/tests/test_module_activation.py
@@ -1,0 +1,163 @@
+"""Only installed modules are live at runtime (issue #91).
+
+``register_discovered`` fills the registry; ``mount_modules`` wires a
+chosen subset and marks it active. The lifespan passes the modules whose
+``core_module.state`` is ``installed``, so an ``uninstalled`` module has no
+routes, no event handlers, no tools, no scheduler jobs and grants no
+permissions — whatever is on disk.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.auth.permissions import get_role_permissions
+from app.core.events import event_bus
+from app.core.plugins import BaseModule
+from app.core.plugins.db_models import ModuleRecord
+from app.core.plugins.loader import mount_modules
+from app.core.plugins.processor import PendingProcessor
+from app.core.plugins.registry import module_registry
+from app.core.plugins.service import ModuleService
+from app.core.plugins.state import ModuleState
+from tests.fixtures.sample_module import SampleModule
+
+PING = "/api/v1/sample_community/ping"
+
+
+class _DependentModule(BaseModule):
+    manifest = {
+        "name": "needs_ghost",
+        "version": "0.1.0",
+        "depends": ["ghost_module"],
+        "auto_install": False,
+        "removable": True,
+        "role_permissions": {"receptionist": ["read"]},
+    }
+
+    def get_models(self) -> list:
+        return []
+
+    def get_router(self) -> APIRouter:
+        return APIRouter()
+
+    def get_permissions(self) -> list[str]:
+        return ["read"]
+
+    def get_tools(self) -> list:
+        return []
+
+
+@pytest.fixture
+def sample() -> Iterator[SampleModule]:
+    module = SampleModule()
+    module_registry.register(module)
+    try:
+        yield module
+    finally:
+        event_bus.unsubscribe(SampleModule.SAMPLE_EVENT, module._on_ping)  # noqa: SLF001
+        module_registry.unregister("sample_community")
+
+
+async def _status(app: FastAPI, path: str) -> int:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        return (await client.get(path)).status_code
+
+
+@pytest.mark.asyncio
+async def test_mount_modules_wires_only_the_given_modules(sample: SampleModule) -> None:
+    app = FastAPI()
+
+    assert mount_modules(app, []) == []
+    assert not module_registry.is_active("sample_community")
+    assert await _status(app, PING) == 404
+    assert not sample.activated
+
+    assert mount_modules(app, [sample]) == [sample]
+    assert module_registry.is_active("sample_community")
+    assert await _status(app, PING) == 200
+    assert sample.activated
+    await event_bus.publish(SampleModule.SAMPLE_EVENT, {"n": 1})
+    assert sample.seen_events == [{"n": 1}]
+
+    # Idempotent: a second pass neither re-mounts nor re-subscribes.
+    routes_before = len(app.routes)
+    assert mount_modules(app, [sample]) == []
+    assert len(app.routes) == routes_before
+    await event_bus.publish(SampleModule.SAMPLE_EVENT, {"n": 2})
+    assert sample.seen_events == [{"n": 1}, {"n": 2}]
+
+
+def test_mount_skips_module_whose_dependency_is_not_active(caplog) -> None:
+    module = _DependentModule()
+    module_registry.register(module)
+    try:
+        with caplog.at_level(logging.ERROR):
+            assert mount_modules(FastAPI(), [module]) == []
+        assert not module_registry.is_active("needs_ghost")
+        assert "ghost_module" in caplog.text
+    finally:
+        module_registry.unregister("needs_ghost")
+
+
+def test_role_permissions_follow_activation() -> None:
+    """Manifest grants apply once the module is active — not while it is
+    merely on disk, and not after it is gone."""
+    module = _DependentModule()
+    module_registry.register(module)
+    try:
+        assert "needs_ghost.read" not in get_role_permissions("receptionist")
+        assert "needs_ghost.read" not in module_registry.get_all_permissions()
+
+        module_registry.activate("needs_ghost")
+        assert "needs_ghost.read" in get_role_permissions("receptionist")
+        assert "needs_ghost.read" in module_registry.get_all_permissions()
+    finally:
+        module_registry.unregister("needs_ghost")
+    assert "needs_ghost.read" not in get_role_permissions("receptionist")
+
+
+@pytest.mark.asyncio
+async def test_boot_mounts_only_installed_modules(
+    db_session: AsyncSession, sample: SampleModule, tmp_path, monkeypatch
+) -> None:
+    """The lifespan recipe: reconcile → process pending → mount ``installed``."""
+    from app.core.plugins import frontend_layers
+
+    monkeypatch.setattr(frontend_layers, "DEFAULT_FRONTEND_ROOT", tmp_path)
+    svc = ModuleService(db_session)
+    await svc.reconcile_with_db()
+
+    # auto_install=False ⇒ reconciled as uninstalled ⇒ not mounted.
+    assert "sample_community" not in await ModuleService.installed_names(db_session)
+    app = FastAPI()
+    mount_modules(app, [m for m in [sample] if m.name in await svc.installed_names(db_session)])
+    assert await _status(app, PING) == 404
+    assert not module_registry.is_active("sample_community")
+
+    # Admin installs + "restart": the processor finalises state=installed.
+    await svc.install("sample_community")
+    await PendingProcessor(async_sessionmaker(db_session.bind, expire_on_commit=False)).run()
+    installed = await ModuleService.installed_names(db_session)
+    assert "sample_community" in installed
+    app = FastAPI()
+    mount_modules(app, [m for m in [sample] if m.name in installed])
+    assert await _status(app, PING) == 200
+    assert module_registry.is_active("sample_community")
+
+    # Uninstall finalised (what _remove writes) + "restart": gone again.
+    record = (
+        await db_session.execute(
+            select(ModuleRecord).where(ModuleRecord.name == "sample_community")
+        )
+    ).scalar_one()
+    record.state = ModuleState.UNINSTALLED.value
+    await db_session.commit()
+    assert "sample_community" not in await ModuleService.installed_names(db_session)

--- a/backend/tests/test_module_install_flow.py
+++ b/backend/tests/test_module_install_flow.py
@@ -14,7 +14,7 @@ from app.core.plugins.state import ModuleState
 
 
 def _seed_registry() -> None:
-    if module_registry.list_modules():
+    if module_registry.list_discovered():
         return
     for module in discover_modules():
         try:

--- a/backend/tests/test_module_install_flow.py
+++ b/backend/tests/test_module_install_flow.py
@@ -7,24 +7,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.plugins.db_models import ModuleRecord
-from app.core.plugins.loader import discover_modules
-from app.core.plugins.registry import module_registry
+from app.core.plugins.loader import register_discovered
 from app.core.plugins.service import ModuleOperationError, ModuleService
 from app.core.plugins.state import ModuleState
 
 
-def _seed_registry() -> None:
-    if module_registry.list_discovered():
-        return
-    for module in discover_modules():
-        try:
-            module_registry.register(module)
-        except ValueError:
-            pass
-
-
 async def _reconcile(db_session: AsyncSession) -> None:
-    _seed_registry()
+    register_discovered()
     await ModuleService(db_session).reconcile_with_db()
 
 

--- a/backend/tests/test_modules_active_endpoint.py
+++ b/backend/tests/test_modules_active_endpoint.py
@@ -133,3 +133,48 @@ async def test_active_navigation_filtered_for_hygienist(
 async def test_active_requires_auth(client: AsyncClient) -> None:
     response = await client.get("/api/v1/modules/-/active")
     assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_active_requires_the_module_to_be_mounted(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``installed`` in the DB is not enough — the loader must have mounted
+    it this boot (issue #91). Otherwise the sidebar would link to routes
+    that 404."""
+    from sqlalchemy import select
+
+    from app.core.plugins.db_models import ModuleRecord
+    from app.core.plugins.registry import module_registry
+    from app.core.plugins.state import ModuleState
+    from tests.fixtures.sample_module import SampleModule
+
+    token = await _register_and_assign(
+        client, db_session, email="admin-mounted@example.com", role="admin"
+    )
+    module_registry.register(SampleModule())
+    try:
+        await _reconcile(db_session)
+        record = (
+            await db_session.execute(
+                select(ModuleRecord).where(ModuleRecord.name == "sample_community")
+            )
+        ).scalar_one()
+        record.state = ModuleState.INSTALLED.value
+        await db_session.commit()
+
+        headers = {"Authorization": f"Bearer {token}"}
+        names = {
+            m["name"]
+            for m in (await client.get("/api/v1/modules/-/active", headers=headers)).json()["data"]
+        }
+        assert "sample_community" not in names
+
+        module_registry.activate("sample_community")
+        names = {
+            m["name"]
+            for m in (await client.get("/api/v1/modules/-/active", headers=headers)).json()["data"]
+        }
+        assert "sample_community" in names
+    finally:
+        module_registry.unregister("sample_community")

--- a/backend/tests/test_scheduler_jobs.py
+++ b/backend/tests/test_scheduler_jobs.py
@@ -17,6 +17,7 @@ from app.modules.budget import BudgetModule
 from app.modules.copilot import CopilotModule
 from app.modules.notifications import NotificationsModule
 from app.modules.treatment_plan import TreatmentPlanModule
+from app.modules.verifactu import VerifactuModule
 
 
 def test_modules_declare_their_jobs() -> None:
@@ -25,6 +26,13 @@ def test_modules_declare_their_jobs() -> None:
         BudgetModule: {"expire_budgets", "send_budget_reminders", "purge_budget_access_logs"},
         TreatmentPlanModule: {"auto_close_expired_plans"},
         CopilotModule: {"copilot_morning_digests"},
+        # Declared, not self-registered from install() — so the jobs exist
+        # on every boot the module is installed, and never otherwise (#91).
+        VerifactuModule: {
+            "verifactu_submissions",
+            "verifactu_stuck_reaper",
+            "verifactu_cert_expiry",
+        },
     }
     for module_cls, ids in expected.items():
         jobs = module_cls().get_scheduled_jobs()

--- a/backend/tests/test_tenancy_resolver.py
+++ b/backend/tests/test_tenancy_resolver.py
@@ -29,7 +29,7 @@ def resolver(monkeypatch: pytest.MonkeyPatch) -> SingleTenantResolver:
     m2 = MagicMock()
     m2.name = "agenda"
     fake_registry = MagicMock()
-    fake_registry.list_modules.return_value = [m1, m2]
+    fake_registry.list_active.return_value = [m1, m2]
     monkeypatch.setattr("app.core.tenancy.single.module_registry", fake_registry)
     return SingleTenantResolver()
 

--- a/docs/adr/0002-per-module-alembic-branches.md
+++ b/docs/adr/0002-per-module-alembic-branches.md
@@ -26,7 +26,7 @@ Every later migration in that module is on the same branch (its
 
 Operational implications:
 
-- `alembic upgrade heads` (plural) is the canonical command.
+- `alembic upgrade heads` (plural) is the canonical command to apply *every* branch; the container boot runs `dentalpin db upgrade`, which names only core + installed branches (ADR 0020).
 - `alembic upgrade head` is wrong here and may pick an arbitrary branch.
 - Cross-module FKs are still allowed but only against modules listed in
   `manifest.depends` (so we know the dep was up before us).

--- a/docs/adr/0012-multi-tenancy-brief.md
+++ b/docs/adr/0012-multi-tenancy-brief.md
@@ -207,7 +207,7 @@ Ambos exportados desde `dentalpin/core/deps.py` o equivalente.
 
 #### 2.3 Setup en `lifespan` de la app
 
-En el `lifespan` de FastAPI (`backend/app/main.py`, ya existe; ahí se llama `load_modules(app)`):
+En el `lifespan` de FastAPI (`backend/app/main.py`, ya existe; ahí se llama `register_discovered()` + `mount_modules(app, installed)`):
 
 ```python
 @asynccontextmanager

--- a/docs/adr/0016-channel-adapter-architecture.md
+++ b/docs/adr/0016-channel-adapter-architecture.md
@@ -20,7 +20,9 @@ module to any vendor and without breaking module isolation.
 The **channel-adapter contract and registry live inside `notifications`**
 (`backend/app/modules/notifications/channels/`), not in core. A vendor module
 declares `depends=["notifications"]`, imports the public contract, and
-**registers its adapter at import time** via `channel_registry.register(...)`.
+**registers its adapter from `BaseModule.on_activate()`** via
+`channel_registry.register(...)` — originally at import time; amended by ADR
+0020 so an uninstalled vendor module is never registered.
 Delivery goes through a **durable outbox**: `enqueue` persists a `queued`
 `communication_messages` row (committing with the request) and a scheduled
 `dispatch_outbox` job sends it with `FOR UPDATE SKIP LOCKED` + exponential
@@ -45,9 +47,10 @@ in core; core only records which adapter serves which channel per clinic
 
 ### Bad / accepted trade-offs
 
-- Import-time registration is an import side-effect (the codebase otherwise
-  prefers explicit `BaseModule` hooks). Mitigated by dependency-ordered loading
-  (`topological_sort`) + idempotent `register`.
+- ~~Import-time registration is an import side-effect (the codebase otherwise
+  prefers explicit `BaseModule` hooks).~~ **Superseded by ADR 0020**: the
+  adapter is registered from `on_activate()`, which the loader calls only for
+  installed modules, on every boot. `register` stays idempotent.
 - A process crash mid-send can leave a row in `sending` (visible in the logs
   view). Upgrade path: sweep stale `sending` rows back to `failed`.
 - WhatsApp proactive sends are template-only (Meta 24h-window rule) in V1.

--- a/docs/adr/0020-install-state-gates-runtime.md
+++ b/docs/adr/0020-install-state-gates-runtime.md
@@ -1,0 +1,111 @@
+# 0020 — Install state gates the runtime (only `installed` modules are live)
+
+- **Status:** accepted
+- **Date:** 2026-08-19
+- **Deciders:** Ramón Martínez (DentalPin Core)
+- **Tags:** modules, lifecycle, migrations
+
+## Context
+
+`core_module.state` (`installed` / `uninstalled` / `to_*`) was written by the
+install and uninstall flows and read by nothing at runtime. The loader mounted
+every module found on disk — router, event handlers, copilot tools — and the
+scheduler, the RBAC merge and `TenantContext.modules_enabled` all iterated the
+same "everything discovered" list (audit 2026-07-03 S1, issue #91). Two modules
+even registered themselves before any state could be consulted: `verifactu`
+attached its billing hook in `__init__` and `whatsapp_kapso` its channel adapter
+at import time.
+
+`auto_install=False` was therefore cosmetic: an uninstalled module kept firing
+handlers against dropped tables, its routes answered (or 500'd), and PR #189's
+`recall_reminders` — a patient-facing handler — would have gone live on the
+first deploy while the admin UI said "not installed". Separately,
+`docker-entrypoint.sh` ran `alembic upgrade heads` on every boot, so an
+uninstalled module's branch (and tables) came back on the next restart.
+
+## Decision
+
+**A module is live in a process iff its `core_module.state` is `installed`.**
+
+- Boot order: `register_discovered()` (discover + register, nothing mounted) →
+  `reconcile_with_db()` → `PendingProcessor.run()` →
+  `mount_modules(app, installed)` → `init_scheduler()`. Mounting is the one
+  step that is *not* best-effort: if the DB is unreachable there, the process
+  raises and the container restarts rather than serving an empty API.
+- `ModuleRegistry` keeps two views: **discovered** (lifecycle machinery:
+  reconcile, processor, CLI) and **active** (RBAC grants, scheduler jobs,
+  `modules_enabled`, `/-/active`, feature gates such as
+  `migration_import`'s `is_active("verifactu")`). `is_loaded()` /
+  `list_modules()` no longer exist — callers choose on purpose.
+- `BaseModule.on_activate()` is the only place for in-memory cross-module
+  registrations (hook registries, channel adapters). It runs once per boot,
+  after the module is mounted, only for installed modules. Nothing ever
+  registers from `__init__` or at import time.
+- Modules still never hot-(un)load: there is no `deactivate`. A restart
+  re-evaluates from the DB, which is the contract the admin UI already states
+  ("restart required").
+- Boot migrations follow the same rule: `python -m app.cli db upgrade`
+  applies the core heads plus the branch head of each module that is
+  `installed` (or, with no row yet, `auto_install=True`), instead of
+  `alembic upgrade heads`. Installing a module applies its branch through the
+  processor (`alembic upgrade <name>@head`), as before.
+
+## Consequences
+
+### Good
+
+- "Uninstalled" means uninstalled: no routes, handlers, tools, jobs, grants or
+  schema resurrection. `auto_install=False` is a real opt-in.
+- `creating-modules.md`'s existing promise ("uninstalling a module drops its
+  grants automatically") and three docstrings become true instead of aspirational.
+- `modules_enabled` finally has an enforcement point (ADR 0012 direction).
+- `verifactu`'s scheduler jobs, previously added only from `install()` and lost
+  on the next restart, are declared via `get_scheduled_jobs()`.
+
+### Bad / accepted trade-offs
+
+- Deployments whose DB has an in-use module in `uninstalled` (possible on
+  instances reconciled before `auto_install` existed) go dark for that module
+  after upgrading. Mitigation: `dentalpin modules list` before deploying;
+  `modules install <name>` + restart for anything in use (idempotent: migrate
+  is a no-op, seed + lifecycle hook + finalize run).
+- A module `installed` in the DB whose dependency is not active (only reachable
+  via `uninstall --force`) is skipped with an error log and hidden from
+  `/-/active`; the loader does not try to repair state.
+- `db upgrade` does not downgrade anything. Tables an older boot created for a
+  module that was never installed stay until that module is installed and
+  uninstalled once.
+
+## Alternatives considered
+
+- **Hot unsubscribe/unmount on uninstall** — requires owner metadata on the bus,
+  router removal in Starlette and a `deactivate` contract, for a system whose
+  admin UI already says "restart required". Rejected: complexity without a user
+  benefit.
+- **Filter Alembic `version_locations` by state** (original design §6.2) — a
+  stale `alembic_version` row for an excluded directory would make Alembic
+  crash-loop at boot, and offline mode has no DB. Rejected in favour of keeping
+  the full graph loaded and filtering the *targets*.
+- **Per-module guard inside each opt-in handler** (`if state != installed:
+  return`) — fixes one symptom per module and keeps the core lie. Rejected.
+
+## How to verify the rule still holds
+
+- `backend/tests/test_module_activation.py` — mount gating, `on_activate`,
+  dependency skip, permissions following activation, the reconcile → install →
+  mount round-trip.
+- `backend/tests/test_modules_active_endpoint.py::test_active_requires_the_module_to_be_mounted`.
+- `backend/tests/test_boot_upgrade_targets.py` (unit) and the
+  `alembic_roundtrip` CI job (`test_boot_upgrade_roundtrip.py`): an
+  uninstalled module's tables stay absent across `db upgrade`.
+- `grep -rn "channel_registry.register\|BillingHookRegistry.register" backend/app/modules` —
+  every hit must be inside an `on_activate`.
+
+## References
+
+- `backend/app/core/plugins/loader.py` (`register_discovered`, `mount_modules`)
+- `backend/app/core/plugins/registry.py`
+- `backend/app/main.py` (lifespan)
+- `backend/app/cli/db.py`, `backend/docker-entrypoint.sh`
+- `docs/technical/module-system-architecture.md` §5.2 step 6 (the original intent)
+- `docs/technical/audit-2026-07-03.md` S1 · Issue #91 · PR #189

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -106,7 +106,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 | `treatment_plan.treatment_added` | `EventType.TREATMENT_PLAN_TREATMENT_ADDED` | `treatment_plan` | `budget` |
 | `treatment_plan.treatment_completed` | `EventType.TREATMENT_PLAN_TREATMENT_COMPLETED` | `treatment_plan` | `patient_timeline`, `recalls` |
 | `treatment_plan.treatment_removed` | `EventType.TREATMENT_PLAN_TREATMENT_REMOVED` | `treatment_plan` | `budget` |
-| `verifactu.record.rejected` | `EventType.VERIFACTU_RECORD_REJECTED` | `verifactu` | — |
+| `verifactu.record.rejected` | `EventType.VERIFACTU_RECORD_REJECTED` | `verifactu` | `verifactu` |
 
 ## Detail
 
@@ -847,4 +847,5 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Constant:** `EventType.VERIFACTU_RECORD_REJECTED`
 - **Publishers:**
   - `verifactu` — `backend/app/modules/verifactu/services/submission_queue.py:271`
-- **Subscribers:** —
+- **Subscribers:**
+  - `verifactu`

--- a/docs/modules-catalog.md
+++ b/docs/modules-catalog.md
@@ -30,7 +30,7 @@ Maintained by `backend/scripts/generate_catalogs.py`. CI fails if a manifest cha
 | `reports` | 0.1.0 | official | patients, agenda, catalog, budget, billing, payments | auto | no | 3 | 0 | 0 | yes |
 | `schedules` | 0.1.0 | official | agenda | auto | yes | 8 | 0 | 4 | yes |
 | `treatment_plan` | 0.1.0 | official | patients, agenda, odontogram, catalog, budget, media | auto | no | 5 | 13 | 7 | yes |
-| `verifactu` | 0.1.0 | official | billing, catalog | manual | yes | 5 | 1 | 1 | yes |
+| `verifactu` | 0.1.0 | official | billing, catalog | manual | yes | 5 | 1 | 2 | yes |
 | `whatsapp_kapso` | 0.1.0 | community | notifications, patients | manual | yes | 2 | 0 | 0 | yes |
 
 ## Modules
@@ -584,6 +584,7 @@ Cumplimiento Veri*Factu (AEAT) para clínicas en España.
   - `verifactu.record.rejected`
 - **Events consumed:**
   - `invoice.paid`
+  - `verifactu.record.rejected`
 - **Module CLAUDE.md:** [`backend/app/modules/verifactu/CLAUDE.md`](../backend/app/modules/verifactu/CLAUDE.md)
 
 ### `whatsapp_kapso` — v0.1.0

--- a/docs/modules/migration_import.md
+++ b/docs/modules/migration_import.md
@@ -39,7 +39,7 @@ and hydrates the current clinic with the extracted data. Issue #78.
   `(clinic_id, source_system, canonical_uuid, entity_type)`.
   Re-running a job is a no-op.
 - **`verifactu` opt-in at runtime**: the fiscal-document mapper
-  detects the module at runtime via `module_registry.is_loaded(...)`.
+  detects the module at runtime via `module_registry.is_active(...)`.
   Legal hashes (Hash / HashControl / ATCUD / QR) are preserved only
   when (a) verifactu is loaded AND (b) the operator ticked
   *"Importar datos legales Verifactu"* in the preview.

--- a/docs/technical/audit-2026-07-03.md
+++ b/docs/technical/audit-2026-07-03.md
@@ -22,6 +22,8 @@ independently. That convergence is the strongest evidence each is real and load-
 ### S1 — Install state is tracked in the DB and consumed by nothing
 *(module-isolation #1/#2 · event-bus #3 · copilot #6 · backend M-modscan)*
 
+**Resolved (issue #91, ADR 0020):** the loader mounts only `installed` modules; `dentalpin db upgrade` applies only core + installed branches at boot.
+
 The plugin system records each module's state in `ModuleRecord`, but neither the boot
 sequence nor the loader ever reads it.
 

--- a/docs/technical/creating-modules.md
+++ b/docs/technical/creating-modules.md
@@ -31,7 +31,7 @@ A module is a Python package that groups together:
 - Service-layer business logic (optional)
 - Event handlers (optional)
 - RBAC permissions (strongly encouraged)
-- Lifecycle hooks (`install`, `uninstall`, `post_upgrade`)
+- Lifecycle hooks (`install`, `uninstall`, `post_upgrade`) and the per-boot `on_activate`
 - Seed data files (optional, YAML)
 - A Nuxt Layer for the frontend (optional)
 
@@ -245,7 +245,18 @@ class InventoryModule(BaseModule):
 
     async def post_upgrade(self, ctx: ModuleContext, from_version: str) -> None:
         await lifecycle.post_upgrade(ctx, from_version)
+
+    def on_activate(self) -> None:
+        # Per boot, installed only: in-memory cross-module registrations
+        # (compliance hooks, channel adapters). Sync, no DB. See §5.
+        ...
 ```
+
+Never register anything into another module's in-memory registry (a hook
+registry, the channel registry, the event bus) from `__init__` or at
+import time: discovery instantiates and imports every module on disk,
+installed or not. Put it in `on_activate()` — the loader calls it only for
+modules the admin actually installed (issue #91).
 
 ### `models.py`
 
@@ -667,8 +678,10 @@ State machine tracked in `core_module`:
 uninstalled ──install──▶ to_install ──restart──▶ installed
 installed   ──upgrade──▶ to_upgrade ──restart──▶ installed
 installed   ──uninstall─▶ to_remove ──restart──▶ uninstalled
-installed   ◀──toggle──▶ disabled    (no restart, no DB write)
 ```
+
+(`disabled` exists in the enum and is treated as "not active" by the
+loader, but nothing writes it yet — there is no toggle.)
 
 On each restart, the **pending processor** runs every module in
 `to_*` state, in topological order, through these steps:
@@ -680,6 +693,18 @@ On each restart, the **pending processor** runs every module in
 Every step is logged to `core_module_operation_log` with
 `started/completed/failed`. Crashes leave a trail; the next restart
 can detect and retry.
+
+### What is live at runtime
+
+On each boot, **after** the pending processor has run, the loader mounts
+only the modules whose state is `installed`: router, event handlers,
+copilot tools, scheduler jobs, manifest `role_permissions`, `on_activate()`.
+A module in `uninstalled`, a `to_install` that failed, or the reserved
+`disabled` state is still *discovered* (it shows in `dentalpin modules
+list`, it can be installed) but is invisible at runtime — no routes, no
+handlers, no grants. `module_registry.is_active(name)` is the question to
+ask when one module needs to know whether another is really on
+(`is_discovered` only says "on disk"). Issue #91 / ADR 0020.
 
 ### External IDs
 

--- a/docs/technical/creating-modules.md
+++ b/docs/technical/creating-modules.md
@@ -486,15 +486,17 @@ alembic revision --autogenerate \
 `backend/alembic.ini`'s `version_locations` lists every module's
 `migrations/versions` directory so `alembic history | heads | upgrade`
 find them before `env.py` runs. Because each branch adds a head, the
-backend entrypoint and the round-trip tests use the plural form:
-`alembic upgrade heads`.
+round-trip tests use the plural form `alembic upgrade heads`. The
+container entrypoint runs `python -m app.cli db upgrade` instead, which
+names the core heads plus the branch head of every *installed* module —
+an uninstalled module's branch is never applied at boot (ADR 0020).
 
 #### Why branches matter for removability
 
 In the legacy main-linear layout every module's revisions were
 threaded through a single chain. A module near the middle of the
 chain could not be uninstalled without also downgrading every module
-above it — the `alembic upgrade heads` that runs on the next boot then
+above it — the `alembic upgrade heads` that used to run on the next boot then
 re-applied the target module's migration, and the tables came back.
 The user-facing "module uninstalled" message was cosmetic only.
 

--- a/docs/technical/migration_import/overview.md
+++ b/docs/technical/migration_import/overview.md
@@ -78,7 +78,7 @@ doesn't fail the whole job.
 `fiscal_document` mapper:
 
 1. Always creates the commercial invoice (number, totals, dates).
-2. Detects verifactu via `module_registry.is_loaded("verifactu")`.
+2. Detects verifactu via `module_registry.is_active("verifactu")` (installed and mounted).
 3. Preserves the legal hashes (`legal_hash`, `hash_control`, `atcud`,
    `qr_code`) only when both verifactu is loaded **and**
    `ImportJob.import_fiscal_compliance` is true.

--- a/docs/technical/module-system-architecture.md
+++ b/docs/technical/module-system-architecture.md
@@ -314,6 +314,8 @@ installed    ──uninstall──►  to_remove ──restart──►  uninsta
 installed    ◄────toggle────►  disabled          (sin reinicio, sin tocar DB)
 ```
 
+*(Estado 2026-08: `disabled` existe en el enum y el loader lo trata como no activo, pero ningún toggle lo escribe todavía.)*
+
 **Invariantes**:
 - Solo los estados `to_*` son transitorios. Tras cada reinicio, el registry los resuelve.
 - Un módulo en `disabled` tiene migraciones aplicadas y datos intactos, pero su router/handlers no están montados en el proceso actual.
@@ -415,6 +417,7 @@ En el `lifespan` de FastAPI, antes de aceptar tráfico:
 4. **Bootstrap inicial** (solo primera vez, DB vacía): marcar todos los módulos con `auto_install: True` como `to_install`.
 5. **Procesar `to_*` pendientes**: en orden topológico. Si falla uno, continúa con los independientes y marca el fallido con error.
 6. **Montar en runtime**: para cada módulo `installed` y no `disabled`, montar router en `/api/v1/<name>/`, suscribir event handlers, registrar permisos.
+   *(Implementado en #91 / ADR 0020: `register_discovered()` → reconcile → processor → `mount_modules(app, installed)`; además tools, jobs y el hook `on_activate()`.)*
 7. FastAPI ready.
 
 ---

--- a/docs/technical/verifactu/events.md
+++ b/docs/technical/verifactu/events.md
@@ -12,13 +12,19 @@ Per-module slice of [`docs/events-catalog.md`](../../events-catalog.md)
 
 ## Published
 
-_This module does not publish any events._
+| Event | Where | Payload |
+|-------|-------|---------|
+| `verifactu.record.rejected` | `services/submission_queue.py` | `clinic_id`, `record_id`, `invoice_id`, AEAT error summary — emitted when AEAT rejects a record. |
 
 ## Subscribed
 
-| Event | Handler | Effect |
-|-------|---------|--------|
-| `invoice.paid` | _Handler module path._ | _What it does in response._ |
+| Event | Handler | Mode | Effect |
+|-------|---------|------|--------|
+| `invoice.paid` | `events.on_invoice_paid` | own-session, payload-only (ADR 0019) | Queues the fiscal record for the paid invoice. |
+| `verifactu.record.rejected` | `tasks.on_rejected_event` | own-session (spawns a task) | Emails the clinic admins, throttled to one alert per clinic per 30 min. |
+
+Both are wired through `VerifactuModule.get_event_handlers()`, so they are
+subscribed only while the module is installed (issue #91 / ADR 0020).
 
 ## Adding a new event
 

--- a/scripts/dentalpin-reset-demo.sh
+++ b/scripts/dentalpin-reset-demo.sh
@@ -40,14 +40,13 @@ GRANT ALL ON SCHEMA public TO dental;
 GRANT ALL ON SCHEMA public TO public;
 SQL
 
-# `heads` (plural) is required: DentalPin uses one Alembic branch per
-# module, so `alembic upgrade head` errors out with "Multiple head
-# revisions are present" and — combined with `set -e` — aborts the
-# script before Step 3 can restart the backend, leaving the running
-# container pointing at a dropped schema until someone restarts it
-# by hand.
-log "Step 2/4: alembic upgrade heads"
-docker exec "$BACK" alembic upgrade heads
+# Same command the container entrypoint runs: core heads plus the
+# branches of installed modules (ADR 0020). Never `alembic upgrade head`
+# (singular): one branch per module means multiple heads, and with
+# `set -e` that would abort the script before Step 3 restarts the
+# backend, leaving the running container on a dropped schema.
+log "Step 2/4: dentalpin db upgrade"
+docker exec "$BACK" python -m app.cli db upgrade
 
 log "Step 3/4: restart backend (reconcile module registry)"
 docker restart "$BACK" >/dev/null

--- a/scripts/reset-db.sh
+++ b/scripts/reset-db.sh
@@ -26,7 +26,7 @@ END $$;
 EOF
 
 # Run migrations
-docker compose exec -T backend alembic upgrade heads
+docker compose exec -T backend python -m app.cli db upgrade
 
 # Restart the backend so the module registry reconciles against the
 # fresh schema. Without this, `core_module` stays empty until the next


### PR DESCRIPTION
Closes #91. ADR 0020.

## What was wrong

`core_module.state` was written by install/uninstall and read by nothing at runtime. The loader mounted every module on disk (router, handlers, tools); the scheduler, the RBAC merge and `modules_enabled` iterated the same list; `verifactu` attached its billing hook in `__init__` and `whatsapp_kapso` its adapter at import time; and `docker-entrypoint.sh` ran `alembic upgrade heads` on every boot, so an uninstalled module's tables came back on restart. `auto_install=False` was cosmetic — PR #189 (`recall_reminders`, patient-facing handler) would have gone live on the first deploy while the admin UI said "not installed".

## What changes (one commit per step)

1. **Registry: discovered ≠ active.** `is_loaded()`/`list_modules()` are gone; callers pick `list_discovered()` (lifecycle) or `list_active()`/`is_active()` (RBAC, scheduler, tenancy, `migration_import`'s verifactu gate).
2. **Loader: `register_discovered()` + `mount_modules(app, modules)`**, `load_modules()` deleted. New `BaseModule.on_activate()` (per boot, installed only) — verifactu's hook and whatsapp_kapso's adapter move there; verifactu's jobs become `get_scheduled_jobs()` (they used to be added from `install()` and vanish on the next restart) and its rejected-record handler goes through `get_event_handlers()`.
3. **Lifespan mounts only `installed`** (`register_discovered` → reconcile → processor → `mount_modules(installed)` → scheduler). That step is not best-effort: DB down ⇒ raise ⇒ container restarts. `/-/active` also requires the registry to have mounted the module.
4. **Docs/docstrings tell the truth**; dead `rediscover_and_reconcile` removed; ADR 0020; ADR 0016 amended; audit S1 resolved; verifactu `events.md` was a placeholder.
5. **`python -m app.cli db upgrade`**: core heads + branch head of each installed module (or `auto_install` when no row yet). A branch nobody installed is never named, so uninstalled tables don't resurrect. In-process Alembic (no loop in the CLI).
6. **Entrypoint, reset scripts, CI e2e** use `db upgrade`.

## Tests

- `tests/test_module_activation.py` (mount gating, `on_activate`, dependency skip, grants follow activation, reconcile→install→mount round-trip), `test_modules_active_endpoint.py::test_active_requires_the_module_to_be_mounted`, `test_scheduler_jobs.py` (verifactu), `test_boot_upgrade_targets.py` (real graph), `test_boot_upgrade_roundtrip.py` (`alembic_roundtrip`: fresh boot → install → uninstall+restart, tables stay gone).
- Full suite: 911 passed; `-m alembic_roundtrip`: 9 passed; ruff, catalogs `--check`, docs coverage `--strict`, docs layout: green.
- Real dev stack restarted on this branch: entrypoint applied 17 targets, lifespan mounted 17/22 (`accounting_export`, `migration_import`, `periodontogram`, `verifactu`, `whatsapp_kapso` are `uninstalled` there), `/api/v1/whatsapp_kapso/*` → 404, `/health` 200.

## ⚠️ Before deploying anywhere

"Uninstalled" now means uninstalled. Any instance whose DB has an **in-use** module in `uninstalled` (e.g. verifactu on an instance reconciled before `auto_install` existed) goes dark for that module after this ships. Run `docker compose exec backend python -m app.cli modules list` on each prod/demo DB first; for anything in use, `python -m app.cli modules install <name>` + restart (idempotent: migrate is a no-op, seed + lifecycle hook + finalize run).

## Follow-ups

- PR #189 no longer needs a per-handler install guard.
- `DISABLED` remains an enum value with no writer (documented as such).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
