### PR TITLE
fix: /payments New payment patient search (#179), budget picker wrong URL

### DIFF
--- a/backend/app/modules/payments/CHANGELOG.md
+++ b/backend/app/modules/payments/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- fix(#179): `/payments` → New payment's patient field was a plain
+  text input bound to `patient_id` (a UUID) with a "Search patient…"
+  placeholder that didn't actually search — typing a name posted an
+  invalid `patient_id` and the modal showed a generic error.
+  `PaymentCreateModal` now uses `PatientVisualSelector`, same as New
+  quote/New invoice/New appointment. Switching the selected patient
+  also resets the "Apply to" destination back to on-account, so a
+  budget chosen for a previous patient can't silently carry over.
 - fix(#183): the earned-ledger handlers are transactional (ADR 0019). Revenue is booked in the same transaction as the treatment; a failed request no longer leaves an orphan `PatientEarnedEntry` (there is no FK to `treatments` to catch one).
 - fix(#178): `payment.allocated` and `payment.refunded` are published
   transactionally (`db=db`, ADR 0019) so billing mirrors budget

--- a/backend/app/modules/payments/CLAUDE.md
+++ b/backend/app/modules/payments/CLAUDE.md
@@ -125,8 +125,8 @@ the public endpoints.
   Schemas validate at the boundary so 4xx never reach the workflow.
 - **Cross-clinic budgets** are rejected by the workflow. UI must filter
   budget pickers to current clinic — `AllocationTargetSelect` lists the
-  patient's accepted/completed budgets from `/api/v1/budgets` (issue
-  #178: never ask reception for a UUID).
+  patient's accepted/completed budgets from `/api/v1/budget/budgets`
+  (issue #178: never ask reception for a UUID).
 - **`on_account` is unlinked by design.** An anticipo touches neither
   invoices nor budgets until reassigned; the create modal says so
   under "Destino" and the ledger offers "Asignar a presupuesto…". Money

--- a/backend/app/modules/payments/frontend/components/AllocationTargetSelect.vue
+++ b/backend/app/modules/payments/frontend/components/AllocationTargetSelect.vue
@@ -35,7 +35,7 @@ async function load() {
     const params = new URLSearchParams({ patient_id: props.patientId, page_size: '100' })
     params.append('status', 'accepted')
     params.append('status', 'completed')
-    const res = await api.get<PaginatedResponse<BudgetListItem>>(`/api/v1/budgets?${params}`)
+    const res = await api.get<PaginatedResponse<BudgetListItem>>(`/api/v1/budget/budgets?${params}`)
     budgets.value = res.data
   } catch {
     budgets.value = []

--- a/backend/app/modules/payments/frontend/components/PaymentCreateModal.vue
+++ b/backend/app/modules/payments/frontend/components/PaymentCreateModal.vue
@@ -15,6 +15,7 @@
  */
 
 import type {
+  Patient,
   PaymentAllocationCreate,
   PaymentMethod,
   PaymentRecord
@@ -107,6 +108,12 @@ const formError = ref<string | null>(null)
 // while the split hasn't been edited by hand (issue #178).
 const primaryTarget = ref<string>(props.defaultBudgetId || 'on_account')
 const patientBudgetCount = ref(0)
+// Unlocked-patient picker (issue #179) — only used at /payments/new,
+// where isPatientLocked is false. Source of truth for form.patient_id;
+// synced below so every other reference in this file (canSubmit,
+// submit(), AllocationTargetSelect) keeps reading form.patient_id
+// unchanged.
+const selectedPatient = ref<Patient | null>(null)
 const hasBudgetTargets = computed(() => patientBudgetCount.value > 0 || isBudgetContext.value)
 const isSubmitting = ref(false)
 const showAdvanced = ref(false)
@@ -119,6 +126,7 @@ watch(() => props.open, async (isOpen) => {
   if (isOpen) {
     form.value = buildInitialForm()
     primaryTarget.value = props.defaultBudgetId || 'on_account'
+    selectedPatient.value = null
     formError.value = null
     showAdvanced.value = false
     showSecondaryMethods.value = false
@@ -147,6 +155,22 @@ watch(primaryTarget, (target) => {
   if (!sole) return
   sole.target_type = target === 'on_account' ? 'on_account' : 'budget'
   sole.target_id = target === 'on_account' ? undefined : target
+})
+
+// Sync the picker into form.patient_id. Switching to a *different*
+// patient also resets the destination back to "a cuenta" — a budget
+// id chosen for the previous patient must never carry over onto the
+// new one (AllocationTargetSelect has no such guard itself).
+watch(selectedPatient, (patient, previous) => {
+  form.value.patient_id = patient?.id || ''
+  if (patient?.id === previous?.id) return
+  primaryTarget.value = 'on_account'
+  splitManually.value = false
+  form.value.allocations = [{
+    target_type: 'on_account',
+    target_id: undefined,
+    amount: Number(form.value.amount) || 0
+  }]
 })
 
 const allocationsSum = computed(() =>
@@ -261,8 +285,9 @@ function handleKeydown(e: KeyboardEvent) {
         @keydown="handleKeydown"
       >
         <!-- Patient header (read-only when locked). The admin flow at
-             /payments/new is the only place where the picker stays an
-             editable input — everywhere else we already know the patient. -->
+             /payments/new is the only place where the patient isn't
+             already known — PatientVisualSelector search/create picker
+             there, same as elsewhere in the app (issue #179). -->
         <div
           v-if="isPatientLocked"
           class="flex items-center gap-3 p-3 rounded-token-md bg-surface-muted"
@@ -285,8 +310,9 @@ function handleKeydown(e: KeyboardEvent) {
           v-else
           :label="t('payments.new.patient')"
         >
-          <UInput
-            v-model="form.patient_id"
+          <PatientVisualSelector
+            v-model="selectedPatient"
+            in-modal
             :placeholder="t('payments.new.patientPlaceholder')"
           />
         </UFormField>

--- a/frontend/tests/e2e/payments-new-patient-search.spec.ts
+++ b/frontend/tests/e2e/payments-new-patient-search.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from './_fixtures'
+
+/**
+ * /payments — New payment patient search (issue #179).
+ *
+ * Regression case: the patient field at /payments/new used to be a
+ * plain text box bound to a UUID with a "Search patient…" placeholder
+ * that didn't actually search. Typing a name posted an invalid
+ * `patient_id` and the modal showed a generic "Could not record the
+ * payment" error. Fixed by swapping in the same PatientVisualSelector
+ * used everywhere else (New quote, New invoice, New appointment).
+ */
+
+const API_BASE = process.env.E2E_API_BASE || 'http://localhost:8000'
+
+test.describe('payments — new payment patient search', () => {
+  test.use({ role: 'receptionist' })
+
+  test('receptionist finds a patient by name and records a payment', async ({ loggedIn }) => {
+    await loggedIn.goto('/payments')
+    await loggedIn.waitForLoadState('networkidle')
+
+    // Create a fresh, uniquely-named patient inline (same "+ Crear" flow
+    // as agenda-quick-patient-create.spec.ts) — avoids depending on
+    // which exact seed patients exist.
+    const suffix = Date.now().toString().slice(-6)
+    const firstName = 'Paytest'
+    const lastName = `Patient ${suffix}`
+
+    await loggedIn.getByRole('button', { name: /New payment/i }).first().click()
+
+    const searchInput = loggedIn.locator('input[data-testid="visual-selector-input"]').first()
+    await expect(searchInput).toBeVisible({ timeout: 10_000 })
+    await searchInput.fill(`${firstName} ${lastName}`)
+
+    const createRow = loggedIn.locator('[data-testid="patient-selector-create-row"]')
+    await expect(createRow).toBeVisible({ timeout: 5_000 })
+    await createRow.click()
+
+    const createForm = loggedIn.locator('[data-testid="patient-selector-create-form"]')
+    await expect(createForm).toBeVisible()
+    await createForm.locator('[data-testid="patient-selector-create-submit"]').click()
+
+    // Patient card replaces the selector — the picker resolved a real
+    // UUID, not raw typed text.
+    await expect(loggedIn.getByText(`${lastName}, ${firstName}`, { exact: false })).toBeVisible({ timeout: 5_000 })
+
+    // Fill amount + submit.
+    const amountInput = loggedIn.locator('input[type="number"]').first()
+    await amountInput.fill('50')
+    await loggedIn.getByRole('button', { name: /Cash/i }).click()
+    await loggedIn.getByRole('button', { name: /€?50|record/i }).last().click()
+
+    // No generic error, modal closes.
+    await expect(loggedIn.getByText(/Could not record the payment/i)).toHaveCount(0)
+
+    // Persistence check via the API, not just UI state.
+    const ctx = loggedIn.context()
+    const cookies = await ctx.cookies()
+    const token = cookies.find(c => c.name === 'access_token')?.value
+    const res = await ctx.request.get(
+      `${API_BASE}/api/v1/patients?search=${encodeURIComponent(lastName)}`,
+      { headers: token ? { Authorization: `Bearer ${token}` } : {} }
+    )
+    expect(res.ok()).toBeTruthy()
+    const patientBody = (await res.json()) as { data: Array<{ id: string, first_name: string, last_name: string }> }
+    const patient = patientBody.data.find(p => p.first_name === firstName && p.last_name === lastName)
+    expect(patient, `expected patient ${firstName} ${lastName} to exist`).toBeDefined()
+
+    const paymentsRes = await ctx.request.get(
+      `${API_BASE}/api/v1/payments?patient_id=${patient!.id}`,
+      { headers: token ? { Authorization: `Bearer ${token}` } : {} }
+    )
+    expect(paymentsRes.ok()).toBeTruthy()
+    const paymentsBody = (await paymentsRes.json()) as { data: Array<{ amount: string }> }
+    expect(paymentsBody.data.length, 'expected the 50 payment to be persisted for the new patient').toBeGreaterThan(0)
+  })
+
+  test('switching to a different patient resets the destination back to "a cuenta"', async ({ loggedIn }) => {
+    // Regression guard: AllocationTargetSelect reloads its budget list on
+    // patient change but never resets the selected target itself — a
+    // budget id chosen for patient A must not silently carry over onto
+    // patient B once the field is a real picker instead of dead text.
+    await loggedIn.goto('/payments')
+    await loggedIn.waitForLoadState('networkidle')
+    await loggedIn.getByRole('button', { name: /New payment/i }).first().click()
+
+    const searchInput = loggedIn.locator('input[data-testid="visual-selector-input"]').first()
+    await expect(searchInput).toBeVisible({ timeout: 10_000 })
+
+    const suffix = Date.now().toString().slice(-6)
+    async function createPatient(last: string) {
+      await searchInput.fill(`Paytest ${last}`)
+      const createRow = loggedIn.locator('[data-testid="patient-selector-create-row"]')
+      await expect(createRow).toBeVisible({ timeout: 5_000 })
+      await createRow.click()
+      await loggedIn.locator('[data-testid="patient-selector-create-form"]')
+        .locator('[data-testid="patient-selector-create-submit"]').click()
+      await expect(loggedIn.getByText(`${last}, Paytest`, { exact: false })).toBeVisible({ timeout: 5_000 })
+    }
+
+    await createPatient(`A${suffix}`)
+
+    // If patient A has no open budgets the target select only offers
+    // "a cuenta" — that's fine, the assertion below only needs to see
+    // the default label, not exercise an actual budget switch.
+    const targetLabel = loggedIn.getByText(/a cuenta|on account/i).first()
+    await expect(targetLabel).toBeVisible({ timeout: 5_000 })
+
+    // Deselect via the selected-patient card's own "x" button, then
+    // search again for a second, different patient.
+    const clearBtn = loggedIn.locator('.bg-surface-muted button').first()
+    await clearBtn.click()
+    await createPatient(`B${suffix}`)
+
+    // Still showing "a cuenta" — never silently locked onto a stale target.
+    await expect(loggedIn.getByText(/a cuenta|on account/i).first()).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('hygienist (payments read-only) cannot reach New payment', async ({ page }) => {
+    const ctx = page.context()
+    const form = new URLSearchParams({ username: 'hygienist@demo.clinic', password: 'demo1234' })
+    const loginRes = await ctx.request.post(`${API_BASE}/api/v1/auth/login`, {
+      data: form.toString(),
+      headers: { 'content-type': 'application/x-www-form-urlencoded' }
+    })
+    if (!loginRes.ok()) test.skip(true, 'hygienist seed user not available')
+    const tokens = (await loginRes.json()) as { access_token: string }
+    await ctx.addCookies([{ name: 'access_token', value: tokens.access_token, url: 'http://localhost:3000' }])
+
+    await page.goto('/payments')
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByRole('button', { name: /New payment/i })).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary

Two fixes, found together while testing one flow — reported as one PR since fixing #179 is what surfaced the second bug.

**#179 — New payment's patient field wasn't a search.** `/payments` → New payment had a plain text box bound to `patient_id` (a UUID), with a "Search patient…" placeholder that didn't search anything. Typing a name posted an invalid `patient_id` and the modal showed a generic "Could not record the payment" error. Fixed by using `PatientVisualSelector`, the same picker already used on New quote / New invoice / New appointment.

**Budget destination picker was calling the wrong URL.** While testing #179 end-to-end (a working patient search made this reachable for the first time), the "Apply to" budget dropdown came back empty for a patient who does have an open budget. `AllocationTargetSelect.vue` was calling `GET /api/v1/budgets`, but the real mounted route is `GET /api/v1/budget/budgets` — every other budget-consuming file in the repo already uses the correct prefixed path. Looks like it's been wrong since #178 introduced this component; nothing surfaced it because the patient field never resolved a real patient before now. One-line fix, plus the same wrong URL corrected in `payments/CLAUDE.md`'s doc comment.

## Type of Change
- [x] Bug fix

## Changes

- `backend/app/modules/payments/frontend/components/PaymentCreateModal.vue` — swaps the raw `UInput` for `PatientVisualSelector` (`in-modal`); switching the selected patient now also resets the "Apply to" destination back to on-account, so a budget picked for a previous patient can't silently carry over onto a newly selected one.
- `backend/app/modules/payments/frontend/components/AllocationTargetSelect.vue` — `/api/v1/budgets` → `/api/v1/budget/budgets`. Shared by all three real consumers (`PaymentCreateModal`'s main + advanced-split selects, `PaymentReallocateModal`), so this one fix covers all of them.
- `backend/app/modules/payments/CLAUDE.md` — same URL correction in the doc comment.
- `backend/app/modules/payments/CHANGELOG.md` — `fix(#179)` entry.
- `frontend/tests/e2e/payments-new-patient-search.spec.ts` — new e2e spec: patient search → select → submit → persistence check via the API; patient-switch resets the destination back to on-account; hygienist (payments read-only) can't reach New payment.

## Testing

- `eslint` clean on all touched/new files.
- `nuxt typecheck` — could not get a clean run in this environment; it fails on an unrelated `vue-router/volar` package-export error unconnected to these files (matches the `vue-tsc`/CI-typecheck gap already described in #184). Flagging in case it's a known local-toolchain issue on your end too.
- No existing unit test suite to run against (repo has none for the frontend layers); backend test suite untouched since no `.py` files changed.
- Manually verified end to end via `docker-compose` + demo seed data: patient search resolves and selects a real patient, payment submits and appears on the patient's timeline, the budget destination dropdown now shows the patient's actual budget, and switching to a different patient mid-form resets the destination instead of keeping the first patient's budget selected.

## Screenshots

![Working demo](https://gist.githubusercontent.com/hirad121/01a2ccd9bb16ad4bab60f9a53763bf49/raw/ed7e618661f45160ddb61459b64c4546301eebb3/DentalPin-After-PR179.gif)
