### PR TITLE
fix: dispose global engine before drop_all to fix full-suite local deadlock (#188)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -129,6 +129,15 @@ async def db_session() -> AsyncGenerator[AsyncSession, None]:
     async with test_session_maker() as session:
         yield session
 
+    # Dispose the global app engine's pool before drop_all: own-session
+    # event handlers (patient_timeline & co.) leave connections on
+    # app.database.engine, and if those outlive the drop their locks
+    # block it — the full-suite deadlock in #188. _dispose_app_engine
+    # (autouse, above) is set up first and so torn down *last* — after
+    # this drop_all — so relying on it alone isn't enough; dispose
+    # explicitly here, first.
+    await app_engine.dispose()
+
     async with test_engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
 

--- a/backend/tests/test_db_session_teardown_order.py
+++ b/backend/tests/test_db_session_teardown_order.py
@@ -1,0 +1,66 @@
+"""Regression for #188: full-suite local deadlock.
+
+``db_session``'s per-test ``drop_all`` must run *after* the global
+``app.database.engine`` is disposed, not before. If it runs first, a
+lingering own-session connection (patient_timeline & co., which use
+``app.database.async_session_maker`` directly) can still hold locks that
+block the ``DROP TABLE`` — the deadlock reported in #188.
+
+This doesn't reproduce the deadlock itself (timing/protocol-dependent
+across event loops, and per #188 doesn't reliably reproduce even in CI).
+Instead it asserts the concrete, controllable invariant the fix provides:
+``engine.dispose()`` is called before ``Base.metadata.drop_all`` during
+``db_session`` teardown.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.database as database_module
+
+_ORDER: list[str] = []
+
+
+@pytest.fixture(autouse=True)
+def _spy_dispose_and_drop_all(monkeypatch):
+    """Record call order of engine.dispose() and Base.metadata.drop_all()."""
+    engine_cls = type(database_module.engine)
+    real_dispose = engine_cls.dispose
+
+    async def spy_dispose(self, *args, **kwargs):
+        _ORDER.append("dispose")
+        return await real_dispose(self, *args, **kwargs)
+
+    monkeypatch.setattr(engine_cls, "dispose", spy_dispose)
+
+    real_drop_all = database_module.Base.metadata.drop_all
+
+    def spy_drop_all(bind, **kwargs):
+        _ORDER.append("drop_all")
+        return real_drop_all(bind, **kwargs)
+
+    monkeypatch.setattr(database_module.Base.metadata, "drop_all", spy_drop_all)
+
+
+@pytest.mark.asyncio
+async def test_a_uses_db_session(db_session: AsyncSession) -> None:
+    """Just needs to go through one full db_session setup/teardown cycle."""
+    assert db_session is not None
+
+
+@pytest.mark.asyncio
+async def test_b_dispose_happened_before_drop_all() -> None:
+    """Runs after test_a's teardown has fully completed (serial, no xdist).
+
+    Pre-fix: only the autouse ``_dispose_app_engine`` fixture disposes the
+    engine, and it's torn down *last* (LIFO) — so drop_all is recorded
+    before dispose and this fails. Post-fix: db_session disposes
+    explicitly first.
+    """
+    assert "dispose" in _ORDER, "engine.dispose() was never called"
+    assert "drop_all" in _ORDER, "Base.metadata.drop_all() was never called"
+    assert _ORDER.index("dispose") < _ORDER.index("drop_all"), (
+        f"dispose must happen before drop_all, got order: {_ORDER}"
+    )


### PR DESCRIPTION
## Summary

Fixes the local full-suite deadlock in #188: `db_session` now disposes
`app.database.engine` before `drop_all`, not after.

## Root cause

`_dispose_app_engine` (autouse) is set up first, so it's torn down
*last* — after `db_session`'s `drop_all`. A lingering connection on the
global engine (own-session handlers like `patient_timeline` use it
directly) can still hold a lock the drop needs — exactly your blocking
graph. Only `create_all`/`drop_all` site in the suite, so one fix
covers it.

## Fix

```python
async with test_session_maker() as session:
    yield session

await app_engine.dispose()          # new — before drop_all, not after

async with test_engine.begin() as conn:
    await conn.run_sync(Base.metadata.drop_all)
```

Same pattern already used ad hoc in `test_patient_timeline.py` and the
4 `test_copilot_*.py` files — this makes it the default instead of a
per-file workaround. Those local fixtures are left as-is (redundant
now, harmless).

## Tests

`test_db_session_teardown_order.py` (new) asserts dispose happens
before drop_all — verified against real Postgres: **fails** on pre-fix
code (`['drop_all', 'dispose']`), **passes** on the fix.

Didn't finish a full local suite run (this container's `docker exec`
is much slower than CI's runner — stopped at 15%, 0 new failures).
Deferring to CI, which already passes the same suite in one process.

## Not fixed here

Your other repro (`test_module_service.py` + 2 others failing in
isolation, `UniqueViolationError` on `pg_type`) didn't reproduce for
me on a fresh DB — 18 passed, 0 failed. Flagging back rather than
guessing; let me know your exact repro conditions if you still hit it.