### PR TITLE
fix(payments): deflake e2e payment-persistence race

### DIFF
--- a/frontend/tests/e2e/payments-new-patient-search.spec.ts
+++ b/frontend/tests/e2e/payments-new-patient-search.spec.ts
@@ -49,7 +49,13 @@ test.describe('payments — new payment patient search', () => {
     const amountInput = loggedIn.locator('input[type="number"]').first()
     await amountInput.fill('50')
     await loggedIn.getByRole('button', { name: /Cash/i }).click()
+    // Wait for the POST to complete before asserting persistence — the
+    // API check below races the in-flight request otherwise (main went
+    // red on the #208 merge because of exactly that).
+    const postDone = loggedIn.waitForResponse(r =>
+      r.url().includes('/api/v1/payments') && r.request().method() === 'POST')
     await loggedIn.getByRole('button', { name: /€?50|record/i }).last().click()
+    expect((await postDone).ok(), 'POST /payments should succeed').toBeTruthy()
 
     // No generic error, modal closes.
     await expect(loggedIn.getByText(/Could not record the payment/i)).toHaveCount(0)


### PR DESCRIPTION
The e2e test from #211 (`payments-new-patient-search.spec.ts`) clicks the payment submit button and immediately queries `GET /payments` through `ctx.request` — no synchronization with the in-flight `POST /payments`. On a slow runner the GET lands before the payment commits and the persistence assertion sees 0 rows.

This is what turned main red on the #208 merge run ([job](https://github.com/martinezsalmeron/dentalpin/actions/runs/32466712187/job/96724736550)): the failure snapshot shows the modal already closed (which only happens after a successful POST) and the patient-created assertion passed — the payment was recorded, the check just raced it. #208 (patient_relationships) is unrelated; it only shifted timing.

Fix: `waitForResponse` on the POST before the API check, and assert the POST itself succeeded for a clearer failure message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6x6joFPFZ884awAxULjwz