### PR TITLE
fix: backfill legacy on_account allocations into budget target (#180)

### DIFF
--- a/backend/app/modules/payments/CHANGELOG.md
+++ b/backend/app/modules/payments/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- fix(#180): payments recorded before #178 on a budget-linked invoice
+  were labeled `on_account` instead of `budget`, so the quote's
+  "Budget payments" total missed them even though the invoice was
+  correctly paid. `backend/scripts/backfill_on_account_budget_target.py`
+  relabels the affected rows — run once with `--apply` after
+  upgrading (dry-run by default, safe to re-run).
+
 - fix(#179): `/payments` → New payment's patient field was a plain
   text input bound to `patient_id` (a UUID) with a "Search patient…"
   placeholder that didn't actually search — typing a name posted an

--- a/backend/scripts/backfill_on_account_budget_target.py
+++ b/backend/scripts/backfill_on_account_budget_target.py
@@ -1,0 +1,250 @@
+"""One-shot backfill: reclassify legacy ``on_account`` allocations that
+are actually budget collections into ``target_type="budget"`` (#180).
+
+Why this exists: before #178, ``apply_payment_to_invoice`` always
+created an ``on_account`` allocation plus a manual ``InvoicePayment``
+link, even when the invoice belonged to a budget. #178 added the
+``from_budget`` branch that creates a real ``budget`` allocation going
+forward, but rows recorded before that fix are still stored as
+``on_account`` — invisible to the "Budget payments" card
+(``PaymentReadService.total_collected_for_budget`` and siblings only
+sum ``target_type == "budget"`` rows), even though the money is
+already correctly imputed to that budget's invoice.
+
+What it does: for every payment whose *entire* allocation set is a
+single ``on_account`` row, whose ``InvoicePayment`` links point to
+exactly one budget's (non-deleted) invoice(s), and whose linked total
+matches the allocation amount exactly — reclassify it via
+``payments.workflow.reallocate_payment``, the same function the
+"Asignar a presupuesto…" button uses. That function is transactional,
+audit-logs the change (``PaymentHistory``), and fires
+``payment.allocated``, which ``billing.payment_bridge.reconcile_payment``
+consumes in the same transaction (ADR-0019) to reconcile
+``invoice_payments`` — a no-op here, since the link this
+reclassification targets already exists with the exact matching
+amount. Only the allocation's own ``target_type``/``budget_id`` flips;
+no invoice status or balance changes.
+
+A payment with more than one allocation row is *not* the legacy shape
+(``reallocate_payment`` replaces a payment's whole allocation set, so
+touching it would risk dropping its other rows) — flagged for manual
+review, never touched. Same for a payment with no matching link at
+all (genuine unassigned credit, ADR-0010 — already correct) — silently
+skipped, not even flagged. Same for a link spanning more than one
+budget, or a linked total that doesn't exactly match the allocation
+amount — flagged for manual review.
+
+Dry-run by default: prints every allocation it would reclassify
+(payment id, clinic id, budget id, invoice id(s), amount), touches
+nothing. ``--apply`` to execute.
+
+Idempotent: once reclassified, a row's ``target_type`` is no longer
+``on_account`` so a re-run skips it.
+
+Usage::
+
+    docker-compose exec backend python backend/scripts/backfill_on_account_budget_target.py
+    docker-compose exec backend python backend/scripts/backfill_on_account_budget_target.py --apply
+
+Run once after deploying this backfill. Can be re-run safely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from collections import defaultdict
+from decimal import Decimal
+from pathlib import Path
+from uuid import UUID
+
+# Allow running the script directly via `python backend/scripts/...`
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from sqlalchemy import select  # noqa: E402
+
+# Force SQLAlchemy to resolve every cross-module relationship by
+# loading all module models the same way the app does at startup.
+from app.core.plugins.loader import register_discovered  # noqa: E402
+from app.database import async_session_maker  # noqa: E402
+
+for _module in register_discovered():
+    _module.get_models()
+
+from app.core.auth.models import ClinicMembership, User  # noqa: E402
+from app.modules.billing.models import Invoice, InvoicePayment  # noqa: E402
+from app.modules.payments.models import Payment, PaymentAllocation  # noqa: E402
+from app.modules.payments.service import PaymentService  # noqa: E402
+from app.modules.payments.workflow import PaymentWorkflowError, reallocate_payment  # noqa: E402
+
+
+async def _admin_for_clinic(db, clinic_id: UUID) -> User | None:
+    result = await db.execute(
+        select(User)
+        .join(ClinicMembership, ClinicMembership.user_id == User.id)
+        .where(
+            ClinicMembership.clinic_id == clinic_id,
+            ClinicMembership.role == "admin",
+            User.is_active.is_(True),
+        )
+        .order_by(User.created_at)
+        .limit(1)
+    )
+    return result.scalars().first()
+
+
+async def main(apply: bool) -> int:
+    reclassified = 0
+    skipped_no_link = 0
+    flagged_ambiguous = 0
+    skipped_no_admin = 0
+
+    async with async_session_maker() as db:
+        payment_ids_q = await db.execute(
+            select(PaymentAllocation.payment_id)
+            .where(PaymentAllocation.target_type == "on_account")
+            .distinct()
+        )
+        payment_ids = [row[0] for row in payment_ids_q.all()]
+
+        admin_cache: dict[UUID, User | None] = {}
+
+        for payment_id in payment_ids:
+            clinic_id_q = await db.execute(
+                select(Payment.clinic_id).where(Payment.id == payment_id)
+            )
+            clinic_id = clinic_id_q.scalar_one()
+
+            payment = await PaymentService.get(db, clinic_id, payment_id)
+            if payment is None:
+                continue
+
+            # Not the legacy shape: reallocate_payment replaces a payment's
+            # *entire* allocation set, so touching a multi-row payment risks
+            # dropping its other rows. Flag instead of guessing.
+            if len(payment.allocations) != 1 or payment.allocations[0].target_type != "on_account":
+                flagged_ambiguous += 1
+                print(
+                    f"AMBIGUOUS payment={payment_id} clinic={clinic_id}: "
+                    f"{len(payment.allocations)} allocation row(s), not a single on_account row "
+                    "— skipped, needs manual review"
+                )
+                continue
+
+            alloc = payment.allocations[0]
+
+            links_q = await db.execute(
+                select(InvoicePayment.amount, Invoice.budget_id, Invoice.id)
+                .join(Invoice, Invoice.id == InvoicePayment.invoice_id)
+                .where(
+                    InvoicePayment.payment_id == payment_id,
+                    Invoice.budget_id.is_not(None),
+                    Invoice.deleted_at.is_(None),
+                )
+            )
+            rows = links_q.all()
+            if not rows:
+                # Genuine unassigned credit (ADR-0010) — correct as-is.
+                skipped_no_link += 1
+                continue
+
+            by_budget: dict[UUID, list] = defaultdict(list)
+            for amount, budget_id, invoice_id in rows:
+                by_budget[budget_id].append((amount, invoice_id))
+
+            if len(by_budget) != 1:
+                flagged_ambiguous += 1
+                print(
+                    f"AMBIGUOUS payment={payment_id} clinic={clinic_id} amount={alloc.amount}: "
+                    f"linked to {len(by_budget)} different budgets "
+                    f"({sorted(str(b) for b in by_budget)}) — skipped, needs manual review"
+                )
+                continue
+
+            (budget_id, entries) = next(iter(by_budget.items()))
+            linked_total = sum((amount for amount, _ in entries), Decimal("0"))
+            if linked_total != alloc.amount:
+                flagged_ambiguous += 1
+                invoice_ids = sorted(str(iid) for _, iid in entries)
+                print(
+                    f"AMBIGUOUS payment={payment_id} clinic={clinic_id} amount={alloc.amount}: "
+                    f"linked total {linked_total} to budget {budget_id} "
+                    f"(invoices {invoice_ids}) does not match — skipped, needs manual review"
+                )
+                continue
+
+            invoice_ids = sorted(str(iid) for _, iid in entries)
+            print(
+                f"{'APPLY' if apply else 'DRY-RUN'} payment={payment_id} clinic={clinic_id} "
+                f"amount={alloc.amount} -> budget={budget_id} (invoices {invoice_ids})"
+            )
+
+            if not apply:
+                continue
+
+            if clinic_id not in admin_cache:
+                admin_cache[clinic_id] = await _admin_for_clinic(db, clinic_id)
+            admin = admin_cache[clinic_id]
+            if admin is None:
+                skipped_no_admin += 1
+                print(f"  SKIPPED: no active admin found for clinic {clinic_id}")
+                continue
+
+            try:
+                await reallocate_payment(
+                    db,
+                    clinic_id=clinic_id,
+                    payment=payment,
+                    new_allocations=[
+                        {
+                            # A real ``uuid.UUID``, not ``str(budget_id)``:
+                            # ``_validate_allocations_for_clinic`` builds its
+                            # found-budgets dict keyed by ``Budget.id``
+                            # (asyncpg's native UUID type, which hashes/
+                            # compares equal to stdlib ``uuid.UUID`` — the
+                            # type Pydantic always hands it via the API) and
+                            # looks entries up by this value directly. A
+                            # plain ``str`` never hashes equal to a UUID, so
+                            # the lookup would silently miss an existing
+                            # budget every time.
+                            "target_type": "budget",
+                            "target_id": UUID(str(budget_id)),
+                            "amount": alloc.amount,
+                        }
+                    ],
+                    changed_by=admin.id,
+                )
+            except PaymentWorkflowError as exc:
+                print(f"  SKIPPED: reallocate failed: {exc}")
+                continue
+            reclassified += 1
+
+        if apply:
+            await db.commit()
+        else:
+            await db.rollback()
+
+    print(
+        f"backfill_on_account_budget_target: reclassified={reclassified} "
+        f"skipped_no_link={skipped_no_link} flagged_ambiguous={flagged_ambiguous} "
+        f"skipped_no_admin={skipped_no_admin}"
+    )
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually reclassify eligible rows (default: dry-run, prints only).",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    raise SystemExit(asyncio.run(main(args.apply)))

--- a/backend/tests/modules/billing/test_backfill_on_account_budget_target.py
+++ b/backend/tests/modules/billing/test_backfill_on_account_budget_target.py
@@ -1,0 +1,369 @@
+"""Backfill script for #180's legacy on_account rows.
+
+Before #178, ``apply_payment_to_invoice`` always created an
+``on_account`` allocation, even for invoices born from a budget — the
+"Budget payments" card only sums ``target_type == "budget"`` rows, so
+those legacy collections stayed invisible on the quote even though
+they were already correctly imputed to the invoice (#180). This shape
+can no longer be produced through the current API (#178 fixed the
+write path), so these tests seed the pre-#178 row shape directly, the
+same way ``backend/scripts/backfill_on_account_budget_target.py``'s
+own docstring describes it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.models import Clinic, User
+from app.modules.billing.models import Invoice, InvoiceItem, InvoicePayment, InvoiceSeries
+from app.modules.budget.models import Budget
+from app.modules.patients.models import Patient
+from app.modules.payments.models import Payment, PaymentAllocation
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3] / "scripts" / "backfill_on_account_budget_target.py"
+)
+_spec = importlib.util.spec_from_file_location("backfill_on_account_budget_target", SCRIPT_PATH)
+backfill = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(backfill)
+
+
+async def _user_id(db: AsyncSession):
+    return (await db.execute(select(User))).scalars().first().id
+
+
+async def _budget(db: AsyncSession, clinic: Clinic, patient: Patient, total: str) -> Budget:
+    budget = Budget(
+        id=uuid4(),
+        clinic_id=clinic.id,
+        patient_id=patient.id,
+        budget_number=f"PRES-{uuid4().hex[:6]}",
+        status="accepted",
+        valid_from=date.today(),
+        created_by=await _user_id(db),
+        total=Decimal(total),
+    )
+    db.add(budget)
+    await db.commit()
+    return budget
+
+
+async def _issued_invoice(
+    db: AsyncSession, clinic: Clinic, patient: Patient, total: str, budget: Budget | None
+) -> Invoice:
+    if not (
+        await db.execute(select(InvoiceSeries.id).where(InvoiceSeries.clinic_id == clinic.id))
+    ).first():
+        db.add(
+            InvoiceSeries(
+                id=uuid4(),
+                clinic_id=clinic.id,
+                prefix="FAC",
+                series_type="invoice",
+                is_default=True,
+            )
+        )
+    inv = Invoice(
+        id=uuid4(),
+        clinic_id=clinic.id,
+        patient_id=patient.id,
+        status="issued",
+        billing_name="Cliente Test",
+        billing_tax_id="B12345678",
+        subtotal=Decimal(total),
+        total=Decimal(total),
+        issue_date=date.today(),
+        created_by=await _user_id(db),
+        budget_id=budget.id if budget else None,
+    )
+    db.add(inv)
+    await db.flush()
+    db.add(
+        InvoiceItem(
+            id=uuid4(),
+            clinic_id=clinic.id,
+            invoice_id=inv.id,
+            description="Servicio",
+            unit_price=Decimal(total),
+            quantity=1,
+            vat_rate=0.0,
+            line_subtotal=Decimal(total),
+            line_tax=Decimal("0.00"),
+            line_total=Decimal(total),
+            display_order=0,
+        )
+    )
+    await db.commit()
+    return inv
+
+
+async def _legacy_on_account_payment(
+    db: AsyncSession,
+    clinic: Clinic,
+    patient: Patient,
+    amount: str,
+    *,
+    linked_invoices: list[tuple[Invoice, str]],
+) -> Payment:
+    """Seed the pre-#178 shape: one on_account allocation + manual
+    InvoicePayment link(s), exactly like the old unconditional branch
+    of ``apply_payment_to_invoice`` used to create.
+    """
+    actor = await _user_id(db)
+    payment = Payment(
+        id=uuid4(),
+        clinic_id=clinic.id,
+        patient_id=patient.id,
+        amount=Decimal(amount),
+        currency="EUR",
+        method="cash",
+        payment_date=date.today(),
+        recorded_by=actor,
+    )
+    db.add(payment)
+    await db.flush()
+    db.add(
+        PaymentAllocation(
+            id=uuid4(),
+            clinic_id=clinic.id,
+            payment_id=payment.id,
+            target_type="on_account",
+            budget_id=None,
+            amount=Decimal(amount),
+            created_by=actor,
+        )
+    )
+    for invoice, link_amount in linked_invoices:
+        db.add(
+            InvoicePayment(
+                id=uuid4(),
+                clinic_id=clinic.id,
+                invoice_id=invoice.id,
+                payment_id=payment.id,
+                amount=Decimal(link_amount),
+                created_by=actor,
+            )
+        )
+    await db.commit()
+    return payment
+
+
+async def _budget_allocation_total(db: AsyncSession, clinic: Clinic, budget: Budget) -> Decimal:
+    result = await db.execute(
+        select(PaymentAllocation).where(
+            PaymentAllocation.clinic_id == clinic.id,
+            PaymentAllocation.target_type == "budget",
+            PaymentAllocation.budget_id == budget.id,
+        )
+    )
+    return sum((a.amount for a in result.scalars()), Decimal("0"))
+
+
+async def _allocation_for(db: AsyncSession, payment: Payment) -> PaymentAllocation:
+    result = await db.execute(
+        select(PaymentAllocation).where(PaymentAllocation.payment_id == payment.id)
+    )
+    return result.scalars().one()
+
+
+@pytest.mark.asyncio
+async def test_dry_run_touches_nothing(
+    test_clinic: Clinic, test_patient: Patient, db_session: AsyncSession
+) -> None:
+    budget = await _budget(db_session, test_clinic, test_patient, "100.00")
+    inv = await _issued_invoice(db_session, test_clinic, test_patient, "100.00", budget)
+    payment = await _legacy_on_account_payment(
+        db_session, test_clinic, test_patient, "100.00", linked_invoices=[(inv, "100.00")]
+    )
+
+    await backfill.main(apply=False)
+
+    refreshed = await _allocation_for(db_session, payment)
+    assert refreshed.target_type == "on_account"
+    assert await _budget_allocation_total(db_session, test_clinic, budget) == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_apply_reclassifies_deterministic_legacy_row(
+    test_clinic: Clinic, test_patient: Patient, db_session: AsyncSession
+) -> None:
+    budget = await _budget(db_session, test_clinic, test_patient, "100.00")
+    inv = await _issued_invoice(db_session, test_clinic, test_patient, "100.00", budget)
+    payment = await _legacy_on_account_payment(
+        db_session, test_clinic, test_patient, "100.00", linked_invoices=[(inv, "100.00")]
+    )
+
+    await backfill.main(apply=True)
+
+    refreshed = await _allocation_for(db_session, payment)
+    assert (refreshed.target_type, refreshed.budget_id) == ("budget", budget.id)
+    assert await _budget_allocation_total(db_session, test_clinic, budget) == Decimal("100.00")
+
+    # No-op on the pre-existing link: still exactly one row, same amount —
+    # reconcile_payment recognised the objective already matched current.
+    links = (
+        (
+            await db_session.execute(
+                select(InvoicePayment).where(InvoicePayment.payment_id == payment.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(links) == 1
+    assert links[0].amount == Decimal("100.00")
+
+
+@pytest.mark.asyncio
+async def test_apply_leaves_multi_budget_split_untouched(
+    test_clinic: Clinic, test_patient: Patient, db_session: AsyncSession
+) -> None:
+    budget_a = await _budget(db_session, test_clinic, test_patient, "60.00")
+    budget_b = await _budget(db_session, test_clinic, test_patient, "40.00")
+    inv_a = await _issued_invoice(db_session, test_clinic, test_patient, "60.00", budget_a)
+    inv_b = await _issued_invoice(db_session, test_clinic, test_patient, "40.00", budget_b)
+    payment = await _legacy_on_account_payment(
+        db_session,
+        test_clinic,
+        test_patient,
+        "100.00",
+        linked_invoices=[(inv_a, "60.00"), (inv_b, "40.00")],
+    )
+
+    await backfill.main(apply=True)
+
+    refreshed = await _allocation_for(db_session, payment)
+    assert refreshed.target_type == "on_account"
+
+
+@pytest.mark.asyncio
+async def test_apply_leaves_genuine_unassigned_credit_untouched(
+    test_clinic: Clinic, test_patient: Patient, db_session: AsyncSession
+) -> None:
+    payment = await _legacy_on_account_payment(
+        db_session, test_clinic, test_patient, "75.00", linked_invoices=[]
+    )
+
+    await backfill.main(apply=True)
+
+    refreshed = await _allocation_for(db_session, payment)
+    assert refreshed.target_type == "on_account"
+
+
+@pytest.mark.asyncio
+async def test_apply_leaves_multi_allocation_payment_untouched(
+    test_clinic: Clinic,
+    test_patient: Patient,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """A payment split across on_account + budget in one shot is not the
+    legacy shape — ``reallocate_payment`` replaces *all* of a payment's
+    allocation rows, so touching it would risk dropping the other one.
+    Must be flagged and skipped, not guessed at.
+
+    Note: ``reallocate_payment``'s own "new allocations must sum to
+    payment.amount" invariant would *also* reject this particular case
+    (our proposed single-row replacement can never sum to the full
+    payment amount when a sibling row exists) — so the end state alone
+    doesn't prove *this script's* guard is what fired. Assert on the
+    printed reasoning too, so a future edit that weakens/removes the
+    guard is still caught even if it happens to stay accidentally safe.
+    """
+    budget = await _budget(db_session, test_clinic, test_patient, "100.00")
+    inv = await _issued_invoice(db_session, test_clinic, test_patient, "100.00", budget)
+    actor = await _user_id(db_session)
+    payment = Payment(
+        id=uuid4(),
+        clinic_id=test_clinic.id,
+        patient_id=test_patient.id,
+        amount=Decimal("100.00"),
+        currency="EUR",
+        method="cash",
+        payment_date=date.today(),
+        recorded_by=actor,
+    )
+    db_session.add(payment)
+    await db_session.flush()
+    db_session.add(
+        PaymentAllocation(
+            id=uuid4(),
+            clinic_id=test_clinic.id,
+            payment_id=payment.id,
+            target_type="on_account",
+            budget_id=None,
+            amount=Decimal("40.00"),
+            created_by=actor,
+        )
+    )
+    db_session.add(
+        PaymentAllocation(
+            id=uuid4(),
+            clinic_id=test_clinic.id,
+            payment_id=payment.id,
+            target_type="budget",
+            budget_id=budget.id,
+            amount=Decimal("60.00"),
+            created_by=actor,
+        )
+    )
+    db_session.add(
+        InvoicePayment(
+            id=uuid4(),
+            clinic_id=test_clinic.id,
+            invoice_id=inv.id,
+            payment_id=payment.id,
+            amount=Decimal("40.00"),
+            created_by=actor,
+        )
+    )
+    await db_session.commit()
+
+    await backfill.main(apply=True)
+
+    out = capsys.readouterr().out
+    assert f"AMBIGUOUS payment={payment.id}" in out, (
+        "the multi-row guard must be what skips this payment, not an "
+        "accidental catch further downstream"
+    )
+    assert "reallocate failed" not in out
+
+    rows = (
+        (
+            await db_session.execute(
+                select(PaymentAllocation).where(PaymentAllocation.payment_id == payment.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2, "the other allocation row must survive untouched"
+    assert {(r.target_type, r.amount) for r in rows} == {
+        ("on_account", Decimal("40.00")),
+        ("budget", Decimal("60.00")),
+    }
+
+
+@pytest.mark.asyncio
+async def test_apply_is_idempotent(
+    test_clinic: Clinic, test_patient: Patient, db_session: AsyncSession
+) -> None:
+    budget = await _budget(db_session, test_clinic, test_patient, "100.00")
+    inv = await _issued_invoice(db_session, test_clinic, test_patient, "100.00", budget)
+    await _legacy_on_account_payment(
+        db_session, test_clinic, test_patient, "100.00", linked_invoices=[(inv, "100.00")]
+    )
+
+    await backfill.main(apply=True)
+    await backfill.main(apply=True)  # re-run: nothing left to reclassify
+
+    assert await _budget_allocation_total(db_session, test_clinic, budget) == Decimal("100.00")


### PR DESCRIPTION
## Summary

Fixes #180

- Payments recorded before #178 on a budget-linked invoice were
  labeled `on_account` instead of `budget`, so the quote's "Budget
  payments" total missed them even though the invoice itself was
  correctly paid.
- Adds a one-shot script that relabels the affected rows, using the
  same mechanism the "Asignar a presupuesto…" button already uses.

## Modules touched

- payments (standalone script, no module code changed)

## Root cause and fix

`backend/scripts/backfill_on_account_budget_target.py` finds payments
whose *only* allocation is `on_account` but are linked (via
`InvoicePayment`) to exactly one budget's invoice, for the exact same
amount — the pre-#178 fingerprint. It reclassifies each one via
`payments.workflow.reallocate_payment`, so nothing new is invented:
same audit trail, same transactional event that reconciles
`invoice_payments` (a no-op here, since the link already matches).

Anything not unambiguous — more than one allocation row, more than one
linked budget, or a mismatched amount — is left untouched and printed
for manual review, never guessed at. Dry-run by default, `--apply` to
execute, safe to re-run.

## Checklist

### Always

- [x] PR title follows Conventional Commits (`fix:`)
- [x] `cd backend && ruff check . && ruff format --check .` passes
- [ ] ~~`cd frontend && npm run lint` passes~~ (no frontend changes)
- [x] Tests added or updated when behaviour changed
- [x] No cross-module imports outside `manifest.depends` (N/A —
      standalone script, not a module; imports `payments`/`billing`
      the same way the existing `apply_payment_to_invoice` endpoint
      already does)

### If a touched module already exists

- [x] Its `backend/app/modules/payments/CHANGELOG.md` updated under
      `## Unreleased`

## Test plan

- New tests in `test_backfill_on_account_budget_target.py` cover the
  safe case, every skip case (multi-allocation payment, multi-budget
  split, genuine unassigned credit), and that a second run is a no-op.
- Full `billing`/`payments` suite run before and after against real
  Postgres — 32 tests passing before, 38 after, no regressions.
- Two real bugs caught and fixed while building this by actually
  running it against seeded data, not just reading the code: a design
  that could have dropped a payment's other allocation rows in a rare
  case, and a silent string-vs-UUID lookup bug that would have made
  every reclassification fail invisibly while looking like it
  succeeded. Full details on request.

