### PR TITLE
fix(catalog): allow editing price/VAT/status on system treatments (#237)

### DIFF
--- a/backend/app/modules/catalog/CHANGELOG.md
+++ b/backend/app/modules/catalog/CHANGELOG.md
@@ -7,6 +7,10 @@
   are editable; only structural fields (`SYSTEM_ITEM_LOCKED_FIELDS`) return
   403 when changed. Modal: `is_active` switch enabled, tooltip on the
   *System* badge, 403 toast shows the server detail.
+- fix: the treatment modal sent `odontogram_mapping.visualization_rules`
+  as the legacy string list, so saving any mapped treatment (create or
+  edit) failed with 422. It now sends only type + clinical category; the
+  layered rules stay server-owned.
 - fix: `GET /catalog/odontogram-treatments` also returns **unmapped
   global-scope items** (`global_mouth`/`global_arch`) with
   `odontogram_treatment_type`/`clinical_category` as `null` — hygiene and

--- a/backend/app/modules/catalog/CHANGELOG.md
+++ b/backend/app/modules/catalog/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(#237): `PUT /catalog/items/{id}` no longer rejects every edit on
+  system items. Price, cost, VAT, names, duration, sessions and `is_active`
+  are editable; only structural fields (`SYSTEM_ITEM_LOCKED_FIELDS`) return
+  403 when changed. Modal: `is_active` switch enabled, tooltip on the
+  *System* badge, 403 toast shows the server detail.
 - fix: `GET /catalog/odontogram-treatments` also returns **unmapped
   global-scope items** (`global_mouth`/`global_arch`) with
   `odontogram_treatment_type`/`clinical_category` as `null` — hygiene and

--- a/backend/app/modules/catalog/CLAUDE.md
+++ b/backend/app/modules/catalog/CLAUDE.md
@@ -61,6 +61,12 @@ None.
   must not duplicate categories. `seed_clinic_defaults` is the single entry
   point (derives preset/prices from the clinic); `seed_catalog` is the
   low-level worker.
+- **System items are partially locked** — `SYSTEM_ITEM_LOCKED_FIELDS` in
+  `router.py` (code, category, pricing strategy, scope, diagnostic,
+  surfaces) return 403 only when the value actually changes; price, cost,
+  VAT, names, duration, sessions and `is_active` are clinic-owned and
+  editable. Rows are per-clinic and downstream consumers snapshot the
+  price, so editing it never rewrites history (#237).
 - **Categories are mandatory on items** (`category_id` NOT NULL). Anything
   that can leave a clinic with zero categories blocks treatment creation —
   keep the seed endpoint and the categories UI working.

--- a/backend/app/modules/catalog/frontend/components/catalog/CatalogItemModal.vue
+++ b/backend/app/modules/catalog/frontend/components/catalog/CatalogItemModal.vue
@@ -10,7 +10,6 @@ import type {
 import {
   ALL_TREATMENT_TYPES,
   TREATMENT_CATEGORIES,
-  VISUALIZATION_RULES,
   isSurfaceTreatment
 } from '~~/app/config/odontogramConstants'
 
@@ -278,16 +277,6 @@ watch(odontogramType, (newType) => {
   }
 })
 
-function getVisualizationRules(treatmentType: string): string[] {
-  const rules: string[] = []
-  for (const [rule, treatments] of Object.entries(VISUALIZATION_RULES)) {
-    if (treatments.includes(treatmentType)) {
-      rules.push(rule)
-    }
-  }
-  return rules
-}
-
 const isValid = computed(() => {
   if (!formData.value.internal_code || !itemName.value || !formData.value.category_id) {
     return false
@@ -322,10 +311,10 @@ function handleSubmit() {
     sessions: sessionsEnabled.value ? sessionsToPayload() : []
   }
   if (odontogramType.value && clinicalCategory.value) {
+    // visualization_rules are layered dicts owned by the seed/backend; the
+    // legacy string list this form used to send was rejected with 422.
     payload.odontogram_mapping = {
       odontogram_treatment_type: odontogramType.value,
-      visualization_rules: getVisualizationRules(odontogramType.value),
-      visualization_config: {},
       clinical_category: clinicalCategory.value
     }
   }

--- a/backend/app/modules/catalog/frontend/components/catalog/CatalogItemModal.vue
+++ b/backend/app/modules/catalog/frontend/components/catalog/CatalogItemModal.vue
@@ -395,14 +395,18 @@ function handleClose() {
                 >
                   {{ t('common.inactive') }}
                 </UBadge>
-                <UBadge
+                <UTooltip
                   v-if="item?.is_system"
-                  variant="subtle"
-                  color="info"
-                  size="xs"
+                  :text="t('catalog.systemItemHint')"
                 >
-                  {{ t('catalog.system') }}
-                </UBadge>
+                  <UBadge
+                    variant="subtle"
+                    color="info"
+                    size="xs"
+                  >
+                    {{ t('catalog.system') }}
+                  </UBadge>
+                </UTooltip>
               </div>
             </div>
             <UButton
@@ -502,10 +506,7 @@ function handleClose() {
                     {{ t('catalog.activeHint') }}
                   </p>
                 </div>
-                <USwitch
-                  v-model="formData.is_active"
-                  :disabled="isSystem"
-                />
+                <USwitch v-model="formData.is_active" />
               </div>
             </div>
 

--- a/backend/app/modules/catalog/frontend/composables/useCatalog.ts
+++ b/backend/app/modules/catalog/frontend/composables/useCatalog.ts
@@ -314,11 +314,11 @@ export function useCatalog() {
 
       return response.data
     } catch (e: unknown) {
-      const fetchError = e as { statusCode?: number }
+      const fetchError = e as { statusCode?: number, data?: { message?: string } }
       if (fetchError.statusCode === 403) {
         toast.add({
           title: t('common.error'),
-          description: t('catalog.cannotModifySystemItem'),
+          description: fetchError.data?.message || t('catalog.cannotModifySystemItem'),
           color: 'error'
         })
       } else {

--- a/backend/app/modules/catalog/router.py
+++ b/backend/app/modules/catalog/router.py
@@ -384,6 +384,20 @@ async def create_item(
     return ApiResponse(data=CatalogItemResponse.model_validate(item))
 
 
+# Structural fields owned by the seeder. Commercial/clinical values
+# (price, cost, VAT, names, duration, sessions, is_active) stay editable (#237).
+SYSTEM_ITEM_LOCKED_FIELDS = frozenset(
+    {
+        "internal_code",
+        "category_id",
+        "pricing_strategy",
+        "treatment_scope",
+        "is_diagnostic",
+        "requires_surfaces",
+    }
+)
+
+
 @router.put("/items/{item_id}", response_model=ApiResponse[CatalogItemResponse])
 async def update_item(
     item_id: UUID,
@@ -397,11 +411,21 @@ async def update_item(
     if not item:
         raise HTTPException(status_code=404, detail="Catalog item not found")
 
+    update_data = data.model_dump(exclude_unset=True)
     if item.is_system:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Cannot modify system catalog item",
-        )
+        # The modal resubmits the whole form, locked fields included with their
+        # current value: only reject when a locked field actually changes.
+        changed = {
+            k
+            for k in SYSTEM_ITEM_LOCKED_FIELDS & update_data.keys()
+            if update_data[k] != getattr(item, k)
+        }
+        if changed:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Cannot modify system catalog item fields: {sorted(changed)}",
+            )
+        update_data.pop("odontogram_mapping", None)  # seeded mapping is preserved
 
     # Verify category if changing
     if data.category_id and data.category_id != item.category_id:
@@ -422,9 +446,7 @@ async def update_item(
             )
 
     try:
-        updated = await CatalogService.update_item(
-            db, ctx.clinic_id, item, data.model_dump(exclude_unset=True)
-        )
+        updated = await CatalogService.update_item(db, ctx.clinic_id, item, update_data)
     except SessionTemplateError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)

--- a/backend/tests/test_catalog.py
+++ b/backend/tests/test_catalog.py
@@ -1248,3 +1248,51 @@ async def test_update_item_sessions_omitted_preserves_template(
     )
     assert update.status_code == 200
     assert len(update.json()["data"]["sessions"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_update_system_item_allows_price_but_locks_structure(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    catalog_clinic_setup: dict,
+):
+    """#237: system items accept commercial edits; structural fields stay locked."""
+    from app.modules.catalog.models import TreatmentCatalogItem
+
+    category_id = await _create_catalog_category(client, auth_headers, "system_lock")
+    item = TreatmentCatalogItem(
+        clinic_id=catalog_clinic_setup["clinic_id"],
+        category_id=category_id,
+        internal_code="SYS-001",
+        names={"es": "Limpieza"},
+        default_price=0,
+        is_system=True,
+    )
+    db_session.add(item)
+    await db_session.flush()
+    url = f"/api/v1/catalog/items/{item.id}"
+
+    # Modal-style payload: locked fields resent with their current value
+    ok = await client.put(
+        url,
+        json={
+            "internal_code": "SYS-001",
+            "default_price": 123.45,
+            "cost_price": 40,
+            "is_active": False,
+        },
+        headers=auth_headers,
+    )
+    assert ok.status_code == 200, ok.text
+    data = ok.json()["data"]
+    assert data["default_price"] == "123.45"
+    assert data["is_active"] is False
+    assert data["is_system"] is True
+
+    locked = await client.put(url, json={"internal_code": "SYS-002"}, headers=auth_headers)
+    assert locked.status_code == 403
+    assert "internal_code" in locked.json()["message"]
+
+    still_locked = await client.delete(url, headers=auth_headers)
+    assert still_locked.status_code == 403

--- a/backend/tests/test_catalog.py
+++ b/backend/tests/test_catalog.py
@@ -1296,3 +1296,52 @@ async def test_update_system_item_allows_price_but_locks_structure(
 
     still_locked = await client.delete(url, headers=auth_headers)
     assert still_locked.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_system_item_preserves_seeded_odontogram_mapping(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    catalog_clinic_setup: dict,
+):
+    """The modal resends odontogram_mapping without rules; seeded rules survive."""
+    from app.modules.catalog.models import TreatmentCatalogItem, TreatmentOdontogramMapping
+
+    clinic_id = catalog_clinic_setup["clinic_id"]
+    category_id = await _create_catalog_category(client, auth_headers, "system_map")
+    item = TreatmentCatalogItem(
+        clinic_id=clinic_id,
+        category_id=category_id,
+        internal_code="SYS-MAP",
+        names={"es": "Corona"},
+        default_price=100,
+        is_system=True,
+    )
+    db_session.add(item)
+    await db_session.flush()
+    rules = [{"layer": "cenital_pattern", "pattern": "diagonal_stripes", "color": "#000"}]
+    db_session.add(
+        TreatmentOdontogramMapping(
+            clinic_id=clinic_id,
+            catalog_item_id=item.id,
+            odontogram_treatment_type="crown",
+            visualization_rules=rules,
+            clinical_category="restauradora",
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.put(
+        f"/api/v1/catalog/items/{item.id}",
+        json={
+            "default_price": 150,
+            "odontogram_mapping": {
+                "odontogram_treatment_type": "crown",
+                "clinical_category": "restauradora",
+            },
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data"]["odontogram_mapping"]["visualization_rules"] == rules

--- a/docs/technical/catalog/permissions.md
+++ b/docs/technical/catalog/permissions.md
@@ -11,8 +11,8 @@ Returned by `CatalogModule.get_permissions()`
 | Permission | Allows | Required by |
 |------------|--------|-------------|
 | `catalog.read` | Browse categories, VAT types, treatments and odontogram mappings. Every role has it. | `GET /api/v1/catalog/categories`, `GET /api/v1/catalog/categories/{id}`, `GET /api/v1/catalog/vat-types`, `GET /api/v1/catalog/vat-types/default`, `GET /api/v1/catalog/vat-types/{id}`, `GET /api/v1/catalog/items`, `GET /api/v1/catalog/items/popular`, `GET /api/v1/catalog/items/search`, `GET /api/v1/catalog/items/{id}`, `GET /api/v1/catalog/odontogram-treatments`, `GET /api/v1/catalog/odontogram-treatments/by-category` |
-| `catalog.write` | Create, edit and (soft-)delete treatments. | `POST /api/v1/catalog/items`, `PUT /api/v1/catalog/items/{id}`, `DELETE /api/v1/catalog/items/{id}` |
-| `catalog.admin` | Manage categories and VAT types; load the stock catalog. System rows (`is_system`) reject edits/deletes with 403. | `POST /api/v1/catalog/categories`, `PUT /api/v1/catalog/categories/{id}`, `DELETE /api/v1/catalog/categories/{id}`, `POST /api/v1/catalog/vat-types`, `PUT /api/v1/catalog/vat-types/{id}`, `DELETE /api/v1/catalog/vat-types/{id}`, `POST /api/v1/catalog/seed` |
+| `catalog.write` | Create, edit and (soft-)delete treatments. On system items (`is_system`) only commercial/clinical values are editable (price, cost, VAT, names, duration, sessions, `is_active`); changing `internal_code`, `category_id`, `pricing_strategy`, `treatment_scope`, `is_diagnostic` or `requires_surfaces` returns 403, as does `DELETE`. | `POST /api/v1/catalog/items`, `PUT /api/v1/catalog/items/{id}`, `DELETE /api/v1/catalog/items/{id}` |
+| `catalog.admin` | Manage categories and VAT types; load the stock catalog. System categories and VAT types (`is_system`) reject edits/deletes with 403 (VAT types: only `is_default` may change). | `POST /api/v1/catalog/categories`, `PUT /api/v1/catalog/categories/{id}`, `DELETE /api/v1/catalog/categories/{id}`, `POST /api/v1/catalog/vat-types`, `PUT /api/v1/catalog/vat-types/{id}`, `DELETE /api/v1/catalog/vat-types/{id}`, `POST /api/v1/catalog/seed` |
 
 ## Role assignment
 

--- a/docs/user-manual/en/catalog/screens/settings_catalog.md
+++ b/docs/user-manual/en/catalog/screens/settings_catalog.md
@@ -54,6 +54,9 @@ It is the price source for budgets, plans and invoices.
 - **Categories** (header button, `catalog.admin` only) — create, rename,
   reorder and deactivate/reactivate categories. System (seeded) categories
   are locked: shown with a padlock, and the server rejects edits/deletes.
+- **System treatments** (*System* badge) — price, cost, VAT, names, duration,
+  sessions and active status can be edited. Code, category, pricing strategy
+  and scope are locked, and they cannot be deleted.
 - **Load default catalog** — shown in the empty state (no treatments, no
   filters) to `catalog.admin`. Adds VAT types for the clinic country, the
   categories and the reference treatments (prices at 0 when the currency is

--- a/docs/user-manual/es/catalog/screens/settings_catalog.md
+++ b/docs/user-manual/es/catalog/screens/settings_catalog.md
@@ -55,6 +55,10 @@ categorías. Es la fuente de precios de presupuestos, planes y facturas.
   renombrar, ordenar y desactivar/reactivar categorías. Las categorías del
   sistema (semilla) están bloqueadas: se muestran con candado y el servidor
   rechaza editarlas o borrarlas.
+- **Tratamientos del sistema** (insignia *Sistema*) — se pueden editar
+  precio, coste, IVA, nombres, duración, sesiones y activar/desactivar. Código,
+  categoría, estrategia de precio y ámbito quedan bloqueados y no se pueden
+  borrar.
 - **Cargar catálogo por defecto** — aparece en el estado vacío (sin
   tratamientos, sin filtros) para `catalog.admin`. Añade tipos de IVA según el
   país de la clínica, las categorías y los tratamientos de referencia (precios

--- a/frontend/app/types/index.ts
+++ b/frontend/app/types/index.ts
@@ -672,15 +672,16 @@ export interface TreatmentCatalogCategoryUpdate {
 export interface OdontogramMapping {
   id: string
   odontogram_treatment_type: string
-  visualization_rules: string[]
+  visualization_rules: VisualizationRuleLayer[]
   visualization_config: Record<string, unknown>
   clinical_category: string
 }
 
+/** Rules/config are server-owned (layered JSONB, seeded); omit to preserve them. */
 export interface OdontogramMappingCreate {
   odontogram_treatment_type: string
-  visualization_rules: string[]
-  visualization_config: Record<string, unknown>
+  visualization_rules?: VisualizationRuleLayer[]
+  visualization_config?: Record<string, unknown>
   clinical_category: string
 }
 

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -1530,6 +1530,7 @@
     "itemUpdateFailed": "Error updating treatment",
     "itemDeleteFailed": "Error deleting treatment",
     "cannotModifySystemItem": "Cannot modify a system treatment",
+    "systemItemHint": "System treatment: code, category, pricing strategy and scope are locked; price, cost, VAT, names, duration, sessions and status can be edited.",
     "cannotDeleteSystemItem": "Cannot delete a system treatment",
     "odontogramMapping": "Odontogram Visualization",
     "odontogramMappingDescription": "Associate this treatment with an odontogram visualization type so it appears in the patient chart.",

--- a/frontend/i18n/locales/es.json
+++ b/frontend/i18n/locales/es.json
@@ -1552,6 +1552,7 @@
     "itemUpdateFailed": "Error al actualizar tratamiento",
     "itemDeleteFailed": "Error al eliminar tratamiento",
     "cannotModifySystemItem": "No se puede modificar un tratamiento del sistema",
+    "systemItemHint": "Tratamiento del sistema: código, categoría, estrategia de precio y ámbito están bloqueados; precio, coste, IVA, nombres, duración, sesiones y estado se pueden editar.",
     "cannotDeleteSystemItem": "No se puede eliminar un tratamiento del sistema",
     "odontogramMapping": "Visualización en Odontograma",
     "odontogramMappingDescription": "Asocia este tratamiento con un tipo de visualización del odontograma para que aparezca en la ficha del paciente.",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -1530,6 +1530,7 @@
     "itemUpdateFailed": "Erreur lors de la mise à jour du traitement",
     "itemDeleteFailed": "Erreur lors de la suppression du traitement",
     "cannotModifySystemItem": "Impossible de modifier un traitement système",
+    "systemItemHint": "Traitement système : code, catégorie, stratégie de prix et portée sont verrouillés ; prix, coût, TVA, noms, durée, séances et statut restent modifiables.",
     "cannotDeleteSystemItem": "Impossible de supprimer un traitement système",
     "odontogramMapping": "Visualisation odontogramme",
     "odontogramMappingDescription": "Associez ce traitement à un type de visualisation odontogramme pour qu'il apparaisse dans le dossier patient.",

--- a/frontend/i18n/locales/pt.json
+++ b/frontend/i18n/locales/pt.json
@@ -1530,6 +1530,7 @@
     "itemUpdateFailed": "Erro ao atualizar o tratamento",
     "itemDeleteFailed": "Erro ao eliminar o tratamento",
     "cannotModifySystemItem": "Não é possível modificar um tratamento de sistema",
+    "systemItemHint": "Tratamento de sistema: código, categoria, estratégia de preço e âmbito estão bloqueados; preço, custo, IVA, nomes, duração, sessões e estado podem ser editados.",
     "cannotDeleteSystemItem": "Não é possível eliminar um tratamento de sistema",
     "odontogramMapping": "Visualização no odontograma",
     "odontogramMappingDescription": "Associe este tratamento a um tipo de visualização no odontograma para que apareça na ficha do paciente.",


### PR DESCRIPTION
Closes #237

## Problem
`PUT /catalog/items/{id}` rejected **every** edit on `is_system` items with 403, while the modal only disabled the structural fields. Users could type a new base price, hit Save and get "Cannot modify system catalog item".

It is worse than the issue describes:
- Catalog rows are per-clinic; there is no shared catalog nor per-clinic price list. `default_price` **is** the clinic's price.
- Non-EUR clinics are seeded with every price at 0 and could not set any.
- The Gesdén importer links incoming treatments to system items without touching the price.
- Downstream consumers (budget, treatment_plan, billing) snapshot the price, so editing it never rewrites history. The immutability argument holds for VAT (versioned), not for price.

## Fix
- **Backend** (`router.py`): `SYSTEM_ITEM_LOCKED_FIELDS` = `internal_code`, `category_id`, `pricing_strategy`, `treatment_scope`, `is_diagnostic`, `requires_surfaces`. 403 only when one of them **changes value** (the modal resends them unchanged). Price, cost, VAT, names, duration, sessions and `is_active` are editable. `DELETE` stays 403. Seeded odontogram mapping is preserved.
- **Frontend**: `is_active` switch enabled on system items (clinics can hide stock treatments they don't offer), tooltip on the *System* badge (en/es/fr/pt), 403 toast shows the server message instead of always blaming "system item".
- **Extra bug uncovered while testing in the browser**: the modal sent `odontogram_mapping.visualization_rules` as the legacy string list; the schema is `list[dict]`. Any create/edit of a treatment with an odontogram type returned 422 — the blanket 403 was hiding it. The modal now sends only type + clinical category; rules stay server-owned.
- Tests: system item price edit → 200, locked field change → 403, delete → 403, seeded rules survive a modal-style PUT.
- Docs: `permissions.md`, user manual es/en, module CLAUDE.md + CHANGELOG.

## Verified
- `tests/test_catalog.py` 35/35, ruff, `npm run lint`, `typecheck:layers`.
- Manually in the browser on the demo clinic: edit price/cost on a System item → 200 + toast, deactivate → 200, `internal_code` via API → 403.

## Out of scope
- Per-clinic price lists (model "Phase 2").
- System categories stay locked (documented as intentional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNM7J6Yzogh5RQbFEyBr6s