### PR TITLE
fix(billing): void/delete/credit note release the quote lines they consumed (#175)

### DIFF
--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix(#175): voiding or deleting a draft invoice, editing/removing one of its lines, or issuing a credit note now releases the quote lines it consumed. `BudgetItem.invoiced_quantity` is recomputed from the live invoice lines (`resync_invoiced_quantities`) instead of incremented on create; `create_from_budget` takes the budget row lock so two wizards can't over-invoice the same line.
 - fix(#206): issue snapshot reads `Patient.effective_billing_*` (no duplicated name fallback). "Faltan datos" now shows on the from-budget wizard and turns the draft's *Emitir* action into *Completar datos*; every "edit patient billing" link opens the billing modal and returns to the invoice. Payment terms are hidden (form) and omitted (PDF, #204 §4) when the budget is fully collected / the invoice has no balance due.
 - docs(#91): `BillingHookRegistry` docstring shows the real hook (`BaseModule.on_activate`) instead of the never-implemented `on_load/on_unload`.
 - refactor(#184): the invoice edit page no longer casts the embedded patient brief to `Patient`; a `displayedPatient` computed falls back from the user's pick to the invoice brief, and `patient_id` is only sent when a different patient was actually chosen.

--- a/backend/app/modules/billing/CLAUDE.md
+++ b/backend/app/modules/billing/CLAUDE.md
@@ -54,6 +54,12 @@ that event was never published.
 
 ## Gotchas
 
+- **`BudgetItem.invoiced_quantity` is a derived cache, never a
+  counter.** `service.resync_invoiced_quantities` recomputes it from the
+  live `invoice_items` (credit-note lines subtract, deleted/voided
+  documents don't count). Call it after any mutation of a line carrying
+  `budget_item_id` — `create_from_budget`, void/delete, item edits and
+  credit notes already do. Never `+=`/`-=` it by hand (issue #175).
 - **Compliance hooks live in compliance modules**, not here. The
   `verifactu` module attaches via `BillingComplianceHook` on
   `invoice.issued` to chain into AEAT. Don't import verifactu from

--- a/backend/app/modules/billing/service.py
+++ b/backend/app/modules/billing/service.py
@@ -1,10 +1,11 @@
 """Billing module service layer - business logic."""
 
+from collections.abc import Iterable
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from uuid import UUID
 
-from sqlalchemy import and_, desc, func, or_, select
+from sqlalchemy import and_, case, desc, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
@@ -544,6 +545,7 @@ class InvoiceItemService:
 
         # Recalculate invoice totals
         await InvoiceService.recalculate_totals(db, invoice)
+        await resync_invoiced_quantities(db, clinic_id, [item.budget_item_id])
 
         return item
 
@@ -554,11 +556,13 @@ class InvoiceItemService:
         invoice: Invoice,
     ) -> None:
         """Delete an invoice item."""
+        budget_item_id = item.budget_item_id
         await db.delete(item)
         await db.flush()
 
         # Recalculate invoice totals
         await InvoiceService.recalculate_totals(db, invoice)
+        await resync_invoiced_quantities(db, invoice.clinic_id, [budget_item_id])
 
 
 class InvoiceService:
@@ -985,6 +989,7 @@ class InvoiceService:
         )
 
         await db.flush()
+        await resync_invoiced_quantities_for_invoice(db, invoice)
 
     @staticmethod
     async def create_from_budget(
@@ -1015,6 +1020,11 @@ class InvoiceService:
         """
         from app.modules.budget.models import Budget, BudgetItem
         from app.modules.budget.pricing import allocate_global_discount
+
+        from .payment_bridge import lock_budget
+
+        # Serialize concurrent wizards on the same quote (available-qty check below).
+        await lock_budget(db, clinic_id, budget_id)
 
         # Get budget
         result = await db.execute(
@@ -1074,8 +1084,7 @@ class InvoiceService:
                 raise ValueError(f"Budget item {budget_item_id} not found")
 
             # Calculate available quantity
-            invoiced_qty = getattr(budget_item, "invoiced_quantity", 0) or 0
-            available_qty = budget_item.quantity - invoiced_qty
+            available_qty = budget_item.quantity - budget_item.invoiced_quantity
 
             if available_qty <= 0:
                 raise ValueError(f"Budget item {budget_item_id} is fully invoiced")
@@ -1140,17 +1149,65 @@ class InvoiceService:
             # Calculate line totals
             await InvoiceService.calculate_item_totals(invoice_item)
 
-            # Update budget item invoiced quantity
-            budget_item.invoiced_quantity = invoiced_qty + quantity
-
         await db.flush()
 
         # Recalculate invoice totals
         await InvoiceService.recalculate_totals(db, invoice)
 
         await db.flush()
+        await resync_invoiced_quantities_for_invoice(db, invoice)
 
         return invoice
+
+
+async def resync_invoiced_quantities(
+    db: AsyncSession, clinic_id: UUID, budget_item_ids: Iterable[UUID | None]
+) -> None:
+    """Recompute ``BudgetItem.invoiced_quantity`` from the live invoice lines.
+
+    The column is a derived cache, never incremented by hand (issue #175):
+    a line counts while its document is not deleted/voided, and credit-note
+    lines subtract. Idempotent — call after any mutation of an ``InvoiceItem``
+    that carries a ``budget_item_id``.
+    """
+    from app.modules.budget.models import BudgetItem
+
+    ids = {i for i in budget_item_ids if i is not None}
+    if not ids:
+        return
+
+    signed_qty = case(
+        (Invoice.credit_note_for_id.is_not(None), -InvoiceItem.quantity),
+        else_=InvoiceItem.quantity,
+    )
+    rows = await db.execute(
+        select(InvoiceItem.budget_item_id, func.sum(signed_qty))
+        .join(Invoice, Invoice.id == InvoiceItem.invoice_id)
+        .where(
+            Invoice.clinic_id == clinic_id,
+            Invoice.deleted_at.is_(None),
+            InvoiceItem.budget_item_id.in_(ids),
+        )
+        .group_by(InvoiceItem.budget_item_id)
+    )
+    totals = dict(rows.all())
+
+    items = await db.execute(
+        select(BudgetItem).where(BudgetItem.id.in_(ids), BudgetItem.clinic_id == clinic_id)
+    )
+    for item in items.scalars():
+        item.invoiced_quantity = max(0, totals.get(item.id, 0))
+    await db.flush()
+
+
+async def resync_invoiced_quantities_for_invoice(db: AsyncSession, invoice: Invoice) -> None:
+    """``resync_invoiced_quantities`` for every budget line the invoice touches."""
+    rows = await db.execute(
+        select(InvoiceItem.budget_item_id).where(
+            InvoiceItem.invoice_id == invoice.id, InvoiceItem.budget_item_id.is_not(None)
+        )
+    )
+    await resync_invoiced_quantities(db, invoice.clinic_id, rows.scalars().all())
 
 
 async def compute_paid_summaries_for_invoices(

--- a/backend/app/modules/billing/workflow.py
+++ b/backend/app/modules/billing/workflow.py
@@ -397,7 +397,7 @@ class InvoiceWorkflowService:
         invoice.deleted_at = datetime.now(UTC)
 
         # Add history
-        from .service import InvoiceHistoryService
+        from .service import InvoiceHistoryService, resync_invoiced_quantities_for_invoice
 
         await InvoiceHistoryService.add_entry(
             db,
@@ -410,6 +410,7 @@ class InvoiceWorkflowService:
         )
 
         await db.flush()
+        await resync_invoiced_quantities_for_invoice(db, invoice)
 
         return invoice
 
@@ -523,7 +524,7 @@ class InvoiceWorkflowService:
                 f"Cannot create credit note for invoice with status '{original_invoice.status}'"
             )
 
-        from .service import InvoiceService
+        from .service import InvoiceService, resync_invoiced_quantities_for_invoice
 
         # Create credit note in draft status WITHOUT assigning number
         # Number will be assigned when the credit note is issued via issue_invoice()
@@ -633,5 +634,6 @@ class InvoiceWorkflowService:
         )
 
         await db.flush()
+        await resync_invoiced_quantities_for_invoice(db, credit_note)
 
         return credit_note

--- a/backend/tests/modules/billing/test_invoice_from_budget.py
+++ b/backend/tests/modules/billing/test_invoice_from_budget.py
@@ -160,3 +160,92 @@ async def test_no_discount_round_trips_untouched(
     line = invoice["items"][0]
     assert line["discount_type"] is None
     assert Decimal(invoice["total"]) == Decimal("100.00")
+
+
+async def _invoiced_qty(client: AsyncClient, auth_headers: dict, budget_id: str) -> int:
+    r = await client.get(f"/api/v1/budget/budgets/{budget_id}", headers=auth_headers)
+    assert r.status_code == 200, r.text
+    return r.json()["data"]["items"][0]["invoiced_quantity"]
+
+
+@pytest.mark.asyncio
+async def test_void_delete_and_item_edits_release_quote_lines(
+    client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
+) -> None:
+    """invoiced_quantity follows the live invoice lines (issue #175)."""
+    budget_id, item_id = await _accepted_budget(
+        client, auth_headers, budget_clinic_setup, quantity=3
+    )
+    h = auth_headers
+    b = "/api/v1/billing/invoices"
+
+    # Void a draft → line comes back.
+    inv = await _invoice_from_budget(client, h, budget_id, item_id, quantity=2)
+    assert await _invoiced_qty(client, h, budget_id) == 2
+    r = await client.post(f"{b}/{inv['id']}/void", headers=h)
+    assert r.status_code == 200, r.text
+    assert await _invoiced_qty(client, h, budget_id) == 0
+
+    # Delete a draft → line comes back.
+    inv = await _invoice_from_budget(client, h, budget_id, item_id, quantity=2)
+    r = await client.delete(f"{b}/{inv['id']}", headers=h)
+    assert r.status_code == 204, r.text
+    assert await _invoiced_qty(client, h, budget_id) == 0
+
+    # Editing / deleting a draft line keeps the counter in sync.
+    inv = await _invoice_from_budget(client, h, budget_id, item_id, quantity=3)
+    line_id = inv["items"][0]["id"]
+    r = await client.put(f"{b}/{inv['id']}/items/{line_id}", json={"quantity": 1}, headers=h)
+    assert r.status_code == 200, r.text
+    assert await _invoiced_qty(client, h, budget_id) == 1
+    r = await client.delete(f"{b}/{inv['id']}/items/{line_id}", headers=h)
+    assert r.status_code == 204, r.text
+    assert await _invoiced_qty(client, h, budget_id) == 0
+
+    # The full quantity is available again.
+    await _invoice_from_budget(client, h, budget_id, item_id, quantity=3)
+    assert await _invoiced_qty(client, h, budget_id) == 3
+    r = await client.post(
+        f"{b}/from-budget/{budget_id}", json={"items": [{"budget_item_id": item_id}]}, headers=h
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_credit_note_releases_quote_lines(
+    client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
+) -> None:
+    budget_id, item_id = await _accepted_budget(
+        client, auth_headers, budget_clinic_setup, quantity=2
+    )
+    h = auth_headers
+    b = "/api/v1/billing/invoices"
+
+    r = await client.put(
+        f"/api/v1/patients/{budget_clinic_setup['patient_id']}",
+        json={"billing_tax_id": "12345678Z"},
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    for prefix, series_type in (("FAC", "invoice"), ("RECT", "credit_note")):
+        r = await client.post(
+            "/api/v1/billing/series",
+            json={"prefix": prefix, "series_type": series_type, "is_default": True},
+            headers=h,
+        )
+        assert r.status_code == 201, r.text
+
+    inv = await _invoice_from_budget(client, h, budget_id, item_id)
+    r = await client.post(f"{b}/{inv['id']}/issue", json={}, headers=h)
+    assert r.status_code == 200, r.text
+    assert await _invoiced_qty(client, h, budget_id) == 2
+
+    r = await client.post(f"{b}/{inv['id']}/credit-note", json={"reason": "error"}, headers=h)
+    assert r.status_code == 201, r.text
+    cn_id = r.json()["data"]["id"]
+    assert await _invoiced_qty(client, h, budget_id) == 0
+
+    # Dropping the draft credit note consumes the lines again.
+    r = await client.delete(f"{b}/{cn_id}", headers=h)
+    assert r.status_code == 204, r.text
+    assert await _invoiced_qty(client, h, budget_id) == 2

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -445,7 +445,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.INVOICE_PAID`
 - **Publishers:**
-  - `billing` — `backend/app/modules/billing/workflow.py:466`
+  - `billing` — `backend/app/modules/billing/workflow.py:467`
 - **Subscribers:**
   - `patient_timeline`
   - `verifactu`

--- a/docs/user-manual/en/billing/screens/invoices_from-budget_budgetId.md
+++ b/docs/user-manual/en/billing/screens/invoices_from-budget_budgetId.md
@@ -15,7 +15,7 @@ related_permissions:
 related_paths:
   - backend/app/modules/billing/frontend/pages/invoices/from-budget/[budgetId].vue
   - backend/app/modules/billing/router.py
-last_verified_commit: 0f30803
+last_verified_commit: 3212255
 ---
 
 # Invoice from budget

--- a/docs/user-manual/en/billing/screens/invoices_from-budget_budgetId.md
+++ b/docs/user-manual/en/billing/screens/invoices_from-budget_budgetId.md
@@ -84,5 +84,6 @@ include.
 - **Backend returns 400 on create.** You picked more quantity than
   pending. Check `invoiced_quantity` vs `quantity` per line.
 - **A budget line is missing.** It is already 100% invoiced
-  (`invoiced_quantity == quantity`). To revert, void the previous
-  invoice and re-enter this wizard.
+  (`invoiced_quantity == quantity`). To revert, void or delete the
+  draft invoice (or issue a credit note for an issued one) and re-enter
+  this wizard — the lines come back as soon as the document is voided.

--- a/docs/user-manual/es/billing/screens/invoices_from-budget_budgetId.md
+++ b/docs/user-manual/es/billing/screens/invoices_from-budget_budgetId.md
@@ -15,7 +15,7 @@ related_permissions:
 related_paths:
   - backend/app/modules/billing/frontend/pages/invoices/from-budget/[budgetId].vue
   - backend/app/modules/billing/router.py
-last_verified_commit: 0f30803
+last_verified_commit: 3212255
 ---
 
 # Factura desde presupuesto

--- a/docs/user-manual/es/billing/screens/invoices_from-budget_budgetId.md
+++ b/docs/user-manual/es/billing/screens/invoices_from-budget_budgetId.md
@@ -87,4 +87,5 @@ y qué cantidades incluir.
   ítem.
 - **Falta una línea del presupuesto.** Está marcada como ya
   facturada al 100% (`invoiced_quantity == quantity`). Para revertir,
-  anula la factura previa y vuelve a entrar aquí.
+  anula o borra el borrador (o emite una rectificativa si ya está
+  emitida) y vuelve a entrar aquí: las líneas se liberan al instante.


### PR DESCRIPTION
Closes #175

## Problem
`BudgetItem.invoiced_quantity` was a hand-maintained counter that only went up in `create_from_budget`. Voiding or deleting a draft, editing/removing one of its lines, or issuing a credit note never gave the quote lines back, so the from-budget wizard kept them locked (`Budget item … is fully invoiced`) — contradicting the user manual.

## Fix
- `invoiced_quantity` is now a **derived cache**: `resync_invoiced_quantities()` recomputes it from the live `invoice_items` (deleted/voided documents don't count, credit-note lines subtract). Called from `create_from_budget`, `delete_invoice`, `void_invoice`, `create_credit_note`, `InvoiceItemService.update_item`/`delete_item`. No more `+=`.
- `create_from_budget` takes `lock_budget` (existing helper from `payment_bridge.py`) so two concurrent wizards can't over-invoice the same line.
- No migration, no new events, no frontend change.

## Tests
- `test_void_delete_and_item_edits_release_quote_lines` — void, delete, line quantity edit, line delete, and the 400 on over-invoicing.
- `test_credit_note_releases_quote_lines` — issued invoice + full credit note releases; deleting the draft credit note consumes again.
- Billing/budget/lifecycle suites: 71 passed. `ruff check` / `ruff format --check` clean.

## Docs
- billing `CHANGELOG.md` + `CLAUDE.md` gotcha (never increment the counter by hand).
- User manual EN/ES for the from-budget wizard, `last_verified_commit` bumped.

## Not done (deliberate)
- No one-off data resync for counters already drifted in production; `resync_invoiced_quantities` can be run from a shell if a clinic reports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNM7J6Yzogh5RQbFEyBr6s