### PR TITLE
fix(reports): coerce string decimals in week-glance delta() (#201)

### DIFF
--- a/backend/app/modules/reports/CHANGELOG.md
+++ b/backend/app/modules/reports/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#201): dashboard week-glance no longer shows `↘ NaN%` on a fresh clinic — `delta()` coerces its operands (the API sends monetary fields as decimal strings, so the `!prev` guard never fired for `"0.00"`) and treats a non-finite percentage as no-delta.
+
 - feat(#181): `get_patient_summary` returns `total_discount` (Σ line + global discounts on the patient's budgets).
 - fix(#184): type-check clean — sibling composable imports are relative (the `~/` form resolved to the host for vue-tsc and made half the page implicitly `any`), ISO dates via `.slice(0, 10)`, budget status badge colour is `UiColor`.
 - style(lint): first ESLint pass over this module's frontend layer —

--- a/backend/app/modules/reports/frontend/components/home/WeekGlancePanel.vue
+++ b/backend/app/modules/reports/frontend/components/home/WeekGlancePanel.vue
@@ -48,9 +48,14 @@ onActivated(load)
 
 const { format: formatMoney } = useCurrency()
 
-function delta(cur: number, prev: number): { pct: number | null, dir: 'up' | 'down' | 'flat' } {
-  if (!prev) return { pct: null, dir: 'flat' }
-  const pct = ((cur - prev) / prev) * 100
+function delta(cur: number | string, prev: number | string): { pct: number | null, dir: 'up' | 'down' | 'flat' } {
+  // Monetary fields arrive as decimal strings ("0.00"), which are truthy —
+  // coerce before guarding, or a fresh clinic renders NaN% (#201).
+  const curNum = Number(cur)
+  const prevNum = Number(prev)
+  if (!prevNum) return { pct: null, dir: 'flat' }
+  const pct = ((curNum - prevNum) / prevNum) * 100
+  if (!Number.isFinite(pct)) return { pct: null, dir: 'flat' }
   if (Math.abs(pct) < 0.5) return { pct: 0, dir: 'flat' }
   return { pct, dir: pct > 0 ? 'up' : 'down' }
 }


### PR DESCRIPTION
## Summary

Fixes #201 — on a fresh clinic the dashboard panel **"La semana en un vistazo"** showed `↘ NaN%` in red under "Facturado".

## Cause

`total_invoiced` arrives from the API as a decimal **string** (`"0.00"`), which is truthy, so the `!prev` guard in `delta()` was skipped and `(0 - "0.00") / "0.00"` yielded `NaN`. `NaN > 0` is false → `dir: 'down'` → red arrow with `NaN%`.

## Fix

In `WeekGlancePanel.vue` `delta()` (as suggested in the issue):

- widens the signature to `number | string` to match what the API actually sends, and coerces both operands with `Number()` **before** the `!prev` guard — so `"0.00"` (and `NaN` from malformed input, since `NaN` is falsy) short-circuits to `{ pct: null, dir: 'flat' }` and no delta line renders;
- additionally treats a non-finite `pct` as `null` as a belt-and-braces guard, so `NaN%`/`Infinity%` can never reach the template.

Also adds the entry to the reports module `CHANGELOG.md` under `## Unreleased` per the repo checklist.

## Verification

- `npm run lint` — 0 errors (4 pre-existing `vue/no-v-html` warnings in odontogram, untouched)
- `npm run typecheck:layers` — exit 0, no TS errors (`modules.json` restored afterwards per CLAUDE.md)
- Logic check on the repro values: `delta(0, "0.00")` → `{ pct: null, dir: 'flat' }` → the delta row is not rendered (`v-if="k.delta && k.delta.pct !== null"`), which matches the intended fresh-clinic behaviour.