### PR TITLE
fix: reject weak SECRET_KEY at startup in production (GHSA-hcg9-cm67-2g8f)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,6 +1,11 @@
 """Application configuration via environment variables."""
 
+import warnings
+
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+MIN_SECRET_KEY_LENGTH = 32
 
 
 class Settings(BaseSettings):
@@ -96,6 +101,27 @@ class Settings(BaseSettings):
         if not self.ALLOWED_ORIGINS:
             return []
         return [origin.strip() for origin in self.ALLOWED_ORIGINS.split(",")]
+
+    @model_validator(mode="after")
+    def _validate_secret_key_strength(self) -> "Settings":
+        """Reject a weak SECRET_KEY in production; warn everywhere else.
+
+        SECRET_KEY signs JWTs and derives the Fernet key used to encrypt
+        SMTP passwords and Veri*Factu tax certificates at rest (see
+        GHSA-hcg9-cm67-2g8f) — a short/weak value compromises all three.
+        A model_validator (not a field_validator on SECRET_KEY) is used
+        because ENVIRONMENT is declared after SECRET_KEY, so a
+        field_validator's `info.data` would not see it yet.
+        """
+        if len(self.SECRET_KEY) < MIN_SECRET_KEY_LENGTH:
+            message = (
+                f"SECRET_KEY must be at least {MIN_SECRET_KEY_LENGTH} "
+                "characters (see .env.example: openssl rand -hex 32)."
+            )
+            if self.ENVIRONMENT == "production":
+                raise ValueError(message)
+            warnings.warn(message, stacklevel=2)
+        return self
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/backend/tests/test_secret_key_strength.py
+++ b/backend/tests/test_secret_key_strength.py
@@ -1,0 +1,67 @@
+"""Regression for GHSA-hcg9-cm67-2g8f: unvalidated weak SECRET_KEY.
+
+SECRET_KEY signs JWTs (auth/service.py) and derives the Fernet key used
+to encrypt SMTP passwords and Veri*Factu tax certificates at rest
+(core/email/encryption.py's ``_get_fernet``). Before this fix, Pydantic
+only required SECRET_KEY to be a non-empty string — a 1-character key
+booted with no error and no warning.
+
+The fix must fail hard only when ENVIRONMENT=production (an operator
+mistake in the deploy that matters), and warn everywhere else, so dev/CI
+setups using short stub keys keep working.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import MIN_SECRET_KEY_LENGTH, Settings
+
+SHORT_KEY = "a" * (MIN_SECRET_KEY_LENGTH - 1)
+STRONG_KEY = "a" * MIN_SECRET_KEY_LENGTH
+
+
+def _make_settings(**overrides):
+    kwargs = {
+        "DATABASE_URL": "postgresql://user:pass@localhost/db",
+        "SECRET_KEY": STRONG_KEY,
+        "ENVIRONMENT": "development",
+    }
+    kwargs.update(overrides)
+    return Settings(**kwargs)
+
+
+def test_short_key_in_production_raises():
+    with pytest.raises(ValueError, match="SECRET_KEY must be at least"):
+        _make_settings(SECRET_KEY=SHORT_KEY, ENVIRONMENT="production")
+
+
+def test_short_key_outside_production_warns_but_boots():
+    with pytest.warns(UserWarning, match="SECRET_KEY must be at least"):
+        settings = _make_settings(SECRET_KEY=SHORT_KEY, ENVIRONMENT="development")
+    assert settings.SECRET_KEY == SHORT_KEY
+
+
+def test_short_key_in_test_environment_warns_but_boots():
+    """CI's stub keys (e.g. ``ci-stub``) use ENVIRONMENT=test, not production."""
+    with pytest.warns(UserWarning, match="SECRET_KEY must be at least"):
+        settings = _make_settings(SECRET_KEY="ci-stub", ENVIRONMENT="test")
+    assert settings.SECRET_KEY == "ci-stub"
+
+
+def test_strong_key_in_production_boots_clean():
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        settings = _make_settings(SECRET_KEY=STRONG_KEY, ENVIRONMENT="production")
+    assert settings.SECRET_KEY == STRONG_KEY
+
+
+def test_strong_key_outside_production_boots_clean():
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        settings = _make_settings(SECRET_KEY=STRONG_KEY, ENVIRONMENT="development")
+    assert settings.SECRET_KEY == STRONG_KEY


### PR DESCRIPTION
<!--
PR template for DentalPin. The checklist enforces conventions documented
in CLAUDE.md and docs/checklists/. Tick boxes that apply; strike through
the rest. Reviewers: don't approve while a relevant box is unchecked.
-->

## Summary

- Fixes GHSA-hcg9-cm67-2g8f (advisory triage, unmerged): `SECRET_KEY` had no length/strength validator — Pydantic only required non-empty, so a weak key (e.g. 1 char) booted with no error and no warning.
- `SECRET_KEY` signs JWTs and derives the Fernet key used to encrypt SMTP passwords and Veri*Factu tax certificates at rest, so a weak value compromises all three at once.
- Adds a `model_validator(mode="after")` on `Settings`: requires ≥32 chars (matches `.env.example`'s `openssl rand -hex 32`), fails hard only when `ENVIRONMENT=production`, warns otherwise — per your go-ahead in the "Interested in contributing" email thread. Separate, decoupled from #246/#65 as requested.

## Modules touched

- none (core `app/config.py`)

## Checklist

### Always

- [x] PR title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`)
- [x] `cd backend && ruff check . && ruff format --check .` passes
- ~~`cd frontend && npm run lint` passes~~ (no frontend changes)
- [x] Tests added or updated when behaviour changed
- [x] No cross-module imports outside `manifest.depends`

### If a new module was added

~~N/A — no new module~~

### If events were added or changed

~~N/A — no events touched~~

### If permissions were added or changed

~~N/A — no permissions touched~~

### If a cross-module FK was introduced

~~N/A~~

### If an architectural decision was made

~~N/A — small, self-contained validator, not an architectural change~~

### If a new domain term was introduced

~~N/A~~

### If a touched module already exists

~~N/A — `app/config.py` isn't inside a module~~

## Test plan

- [x] `backend/tests/test_secret_key_strength.py` (new, 5 tests): weak key + `ENVIRONMENT=production` raises; weak key + `development`/`test` warns and boots; strong key + `production`/`development` boots with no warning. Confirmed to fail on pre-fix `config.py` (import error — validator doesn't exist) and pass on the fix.
- [x] Direct `Settings()` boot checks against every real value CI actually uses (`test-secret-key-for-ci`+`test`, `ci-stub`+`test`, `ci-secret-key-for-e2e`+`development`) — all warn only, none break, since none set `ENVIRONMENT=production`.
- [x] `ruff check` / `ruff format --check` clean on full `backend/`.
