### PR TITLE
fix(reports): derive work_completed from fully invoiced quotes (#242)

### DIFF
--- a/backend/app/modules/reports/CHANGELOG.md
+++ b/backend/app/modules/reports/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#242): patient billing KPI "Trabajo completado" is no longer permanently 0. The `completed` budget status was removed in 2026-04, so `get_patient_summary` now derives `work_completed` from **fully invoiced** accepted quotes (every line's `invoiced_quantity` ≥ `quantity`), and `work_in_progress` becomes the complement (accepted, not yet fully invoiced) so the two KPIs partition the accepted total.
+
 - feat(#181): `get_patient_summary` returns `total_discount` (Σ line + global discounts on the patient's budgets).
 - fix(#184): type-check clean — sibling composable imports are relative (the `~/` form resolved to the host for vue-tsc and made half the page implicitly `any`), ISO dates via `.slice(0, 10)`, budget status badge colour is `UiColor`.
 - style(lint): first ESLint pass over this module's frontend layer —

--- a/backend/app/modules/reports/services/billing.py
+++ b/backend/app/modules/reports/services/billing.py
@@ -5,13 +5,13 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import desc, func, select
+from sqlalchemy import and_, desc, func, not_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.core.auth.models import User
 from app.modules.billing.models import Invoice, InvoiceItem, InvoicePayment, InvoiceSeries
-from app.modules.budget.models import Budget
+from app.modules.budget.models import Budget, BudgetItem
 from app.modules.catalog.models import VatType
 
 
@@ -74,15 +74,33 @@ class BillingReportService:
         Returns:
             - total_budgeted: Sum of all budgets
             - total_discount: Sum of line + global discounts on those budgets
-            - work_in_progress: Sum of accepted budgets
-            - work_completed: Sum of completed budgets
+            - work_in_progress: Sum of accepted budgets not yet fully invoiced
+            - work_completed: Sum of accepted budgets fully invoiced
             - total_invoiced: Sum of issued invoices
             - total_paid: Sum of payments
             - balance_pending: total_invoiced - total_paid
         """
         from sqlalchemy import case
 
-        # Budget aggregation
+        # Budget aggregation. The ``completed`` budget status was removed in
+        # 2026-04 (budget/CLAUDE.md): financial closure on the budget axis is
+        # "fully invoiced" — every line's derived ``invoiced_quantity`` cache
+        # has reached its ``quantity``. ``work_in_progress`` is the
+        # complement, so the two tiles partition the accepted total (#242).
+        items_state = (
+            select(
+                BudgetItem.budget_id.label("budget_id"),
+                func.bool_and(BudgetItem.invoiced_quantity >= BudgetItem.quantity).label(
+                    "fully_invoiced"
+                ),
+            )
+            .where(BudgetItem.clinic_id == clinic_id)
+            .group_by(BudgetItem.budget_id)
+            .subquery()
+        )
+        # Budgets with no items have no row in ``items_state`` → not completed.
+        fully_invoiced = func.coalesce(items_state.c.fully_invoiced, False)
+
         budget_result = await db.execute(
             select(
                 func.coalesce(func.sum(Budget.total), Decimal("0")).label("total_budgeted"),
@@ -90,14 +108,30 @@ class BillingReportService:
                     "total_discount"
                 ),
                 func.coalesce(
-                    func.sum(case((Budget.status == "accepted", Budget.total), else_=0)),
+                    func.sum(
+                        case(
+                            (
+                                and_(Budget.status == "accepted", not_(fully_invoiced)),
+                                Budget.total,
+                            ),
+                            else_=0,
+                        )
+                    ),
                     Decimal("0"),
                 ).label("work_in_progress"),
                 func.coalesce(
-                    func.sum(case((Budget.status == "completed", Budget.total), else_=0)),
+                    func.sum(
+                        case(
+                            (and_(Budget.status == "accepted", fully_invoiced), Budget.total),
+                            else_=0,
+                        )
+                    ),
                     Decimal("0"),
                 ).label("work_completed"),
-            ).where(
+            )
+            .select_from(Budget)
+            .outerjoin(items_state, items_state.c.budget_id == Budget.id)
+            .where(
                 Budget.clinic_id == clinic_id,
                 Budget.patient_id == patient_id,
                 Budget.deleted_at.is_(None),

--- a/backend/app/modules/reports/services/billing.py
+++ b/backend/app/modules/reports/services/billing.py
@@ -94,7 +94,12 @@ class BillingReportService:
                     "fully_invoiced"
                 ),
             )
-            .where(BudgetItem.clinic_id == clinic_id)
+            .join(Budget, Budget.id == BudgetItem.budget_id)
+            .where(
+                BudgetItem.clinic_id == clinic_id,
+                Budget.clinic_id == clinic_id,
+                Budget.patient_id == patient_id,
+            )
             .group_by(BudgetItem.budget_id)
             .subquery()
         )

--- a/backend/tests/modules/billing/helpers.py
+++ b/backend/tests/modules/billing/helpers.py
@@ -1,0 +1,68 @@
+"""Shared HTTP-level helpers for billing tests (quote → accept → invoice-from-budget)."""
+
+from __future__ import annotations
+
+from httpx import AsyncClient
+
+
+async def accepted_budget(
+    client: AsyncClient,
+    auth_headers: dict,
+    setup: dict,
+    *,
+    quantity: int = 1,
+    line_discount: dict | None = None,
+    global_discount: dict | None = None,
+) -> tuple[str, str]:
+    """Create → add one 100 € line → accept. Returns (budget_id, item_id)."""
+    r = await client.post(
+        "/api/v1/budget/budgets",
+        json={
+            "patient_id": setup["patient_id"],
+            "valid_from": "2024-01-01",
+            **(global_discount or {}),
+        },
+        headers=auth_headers,
+    )
+    assert r.status_code == 201, r.text
+    budget_id = r.json()["data"]["id"]
+    r = await client.post(
+        f"/api/v1/budget/budgets/{budget_id}/items",
+        json={
+            "catalog_item_id": setup["catalog_item_id"],
+            "quantity": quantity,
+            **(line_discount or {}),
+        },
+        headers=auth_headers,
+    )
+    assert r.status_code == 201, r.text
+    item_id = r.json()["data"]["id"]
+    r = await client.post(
+        f"/api/v1/budget/budgets/{budget_id}/accept",
+        headers=auth_headers,
+        json={"signature": {"signed_by_name": "Test", "relationship_to_patient": "patient"}},
+    )
+    assert r.status_code == 200, r.text
+    return budget_id, item_id
+
+
+async def invoice_from_budget(
+    client: AsyncClient,
+    auth_headers: dict,
+    budget_id: str,
+    item_id: str,
+    quantity: int | None = None,
+) -> dict:
+    spec: dict = {"budget_item_id": item_id}
+    if quantity is not None:
+        spec["quantity"] = quantity
+    r = await client.post(
+        f"/api/v1/billing/invoices/from-budget/{budget_id}",
+        json={"items": [spec]},
+        headers=auth_headers,
+    )
+    assert r.status_code == 201, r.text
+    invoice_id = r.json()["data"]["id"]
+    r = await client.get(f"/api/v1/billing/invoices/{invoice_id}", headers=auth_headers)
+    assert r.status_code == 200, r.text
+    return r.json()["data"]

--- a/backend/tests/modules/billing/test_invoice_from_budget.py
+++ b/backend/tests/modules/billing/test_invoice_from_budget.py
@@ -12,68 +12,7 @@ from decimal import Decimal
 import pytest
 from httpx import AsyncClient
 
-
-async def _accepted_budget(
-    client: AsyncClient,
-    auth_headers: dict,
-    setup: dict,
-    *,
-    quantity: int = 1,
-    line_discount: dict | None = None,
-    global_discount: dict | None = None,
-) -> tuple[str, str]:
-    """Create → add one 100 € line → accept. Returns (budget_id, item_id)."""
-    r = await client.post(
-        "/api/v1/budget/budgets",
-        json={
-            "patient_id": setup["patient_id"],
-            "valid_from": "2024-01-01",
-            **(global_discount or {}),
-        },
-        headers=auth_headers,
-    )
-    assert r.status_code == 201, r.text
-    budget_id = r.json()["data"]["id"]
-    r = await client.post(
-        f"/api/v1/budget/budgets/{budget_id}/items",
-        json={
-            "catalog_item_id": setup["catalog_item_id"],
-            "quantity": quantity,
-            **(line_discount or {}),
-        },
-        headers=auth_headers,
-    )
-    assert r.status_code == 201, r.text
-    item_id = r.json()["data"]["id"]
-    r = await client.post(
-        f"/api/v1/budget/budgets/{budget_id}/accept",
-        headers=auth_headers,
-        json={"signature": {"signed_by_name": "Test", "relationship_to_patient": "patient"}},
-    )
-    assert r.status_code == 200, r.text
-    return budget_id, item_id
-
-
-async def _invoice_from_budget(
-    client: AsyncClient,
-    auth_headers: dict,
-    budget_id: str,
-    item_id: str,
-    quantity: int | None = None,
-) -> dict:
-    spec: dict = {"budget_item_id": item_id}
-    if quantity is not None:
-        spec["quantity"] = quantity
-    r = await client.post(
-        f"/api/v1/billing/invoices/from-budget/{budget_id}",
-        json={"items": [spec]},
-        headers=auth_headers,
-    )
-    assert r.status_code == 201, r.text
-    invoice_id = r.json()["data"]["id"]
-    r = await client.get(f"/api/v1/billing/invoices/{invoice_id}", headers=auth_headers)
-    assert r.status_code == 200, r.text
-    return r.json()["data"]
+from tests.modules.billing.helpers import accepted_budget, invoice_from_budget
 
 
 @pytest.mark.asyncio
@@ -81,14 +20,14 @@ async def test_line_and_global_discounts_reach_the_invoice(
     client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
 ) -> None:
     """100 → 80 (line 20%) → 72 (global 10%): stored as one absolute line discount of 28."""
-    budget_id, item_id = await _accepted_budget(
+    budget_id, item_id = await accepted_budget(
         client,
         auth_headers,
         budget_clinic_setup,
         line_discount={"discount_type": "percentage", "discount_value": 20},
         global_discount={"global_discount_type": "percentage", "global_discount_value": 10},
     )
-    invoice = await _invoice_from_budget(client, auth_headers, budget_id, item_id)
+    invoice = await invoice_from_budget(client, auth_headers, budget_id, item_id)
     line = invoice["items"][0]
     assert line["discount_type"] == "absolute"
     assert Decimal(line["discount_value"]) == Decimal("28.00")
@@ -101,13 +40,13 @@ async def test_line_and_global_discounts_reach_the_invoice(
 async def test_percentage_only_line_discount_is_kept_as_percentage(
     client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
 ) -> None:
-    budget_id, item_id = await _accepted_budget(
+    budget_id, item_id = await accepted_budget(
         client,
         auth_headers,
         budget_clinic_setup,
         line_discount={"discount_type": "percentage", "discount_value": 20},
     )
-    invoice = await _invoice_from_budget(client, auth_headers, budget_id, item_id)
+    invoice = await invoice_from_budget(client, auth_headers, budget_id, item_id)
     line = invoice["items"][0]
     assert line["discount_type"] == "percentage"
     assert Decimal(line["discount_value"]) == Decimal("20.00")
@@ -119,17 +58,17 @@ async def test_absolute_line_discount_prorated_on_partial_invoicing(
     client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
 ) -> None:
     """Qty 2 with 30 € absolute discount, invoiced 1 unit → 15 € on that invoice, not 30."""
-    budget_id, item_id = await _accepted_budget(
+    budget_id, item_id = await accepted_budget(
         client,
         auth_headers,
         budget_clinic_setup,
         quantity=2,
         line_discount={"discount_type": "absolute", "discount_value": 30},
     )
-    first = await _invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
+    first = await invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
     assert Decimal(first["items"][0]["discount_value"]) == Decimal("15.00")
     assert Decimal(first["total"]) == Decimal("85.00")
-    second = await _invoice_from_budget(client, auth_headers, budget_id, item_id)
+    second = await invoice_from_budget(client, auth_headers, budget_id, item_id)
     assert Decimal(second["total"]) == Decimal("85.00")
 
 
@@ -138,13 +77,13 @@ async def test_absolute_global_discount_is_prorated_and_never_negative(
     client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
 ) -> None:
     """A global absolute discount larger than the quote is clamped: the line ends at 0, not below."""
-    budget_id, item_id = await _accepted_budget(
+    budget_id, item_id = await accepted_budget(
         client,
         auth_headers,
         budget_clinic_setup,
         global_discount={"global_discount_type": "absolute", "global_discount_value": 500},
     )
-    invoice = await _invoice_from_budget(client, auth_headers, budget_id, item_id)
+    invoice = await invoice_from_budget(client, auth_headers, budget_id, item_id)
     line = invoice["items"][0]
     assert Decimal(line["line_discount"]) == Decimal("100.00")
     assert Decimal(line["line_total"]) == Decimal("0.00")
@@ -155,8 +94,8 @@ async def test_absolute_global_discount_is_prorated_and_never_negative(
 async def test_no_discount_round_trips_untouched(
     client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
 ) -> None:
-    budget_id, item_id = await _accepted_budget(client, auth_headers, budget_clinic_setup)
-    invoice = await _invoice_from_budget(client, auth_headers, budget_id, item_id)
+    budget_id, item_id = await accepted_budget(client, auth_headers, budget_clinic_setup)
+    invoice = await invoice_from_budget(client, auth_headers, budget_id, item_id)
     line = invoice["items"][0]
     assert line["discount_type"] is None
     assert Decimal(invoice["total"]) == Decimal("100.00")
@@ -173,27 +112,27 @@ async def test_void_delete_and_item_edits_release_quote_lines(
     client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
 ) -> None:
     """invoiced_quantity follows the live invoice lines (issue #175)."""
-    budget_id, item_id = await _accepted_budget(
+    budget_id, item_id = await accepted_budget(
         client, auth_headers, budget_clinic_setup, quantity=3
     )
     h = auth_headers
     b = "/api/v1/billing/invoices"
 
     # Void a draft → line comes back.
-    inv = await _invoice_from_budget(client, h, budget_id, item_id, quantity=2)
+    inv = await invoice_from_budget(client, h, budget_id, item_id, quantity=2)
     assert await _invoiced_qty(client, h, budget_id) == 2
     r = await client.post(f"{b}/{inv['id']}/void", headers=h)
     assert r.status_code == 200, r.text
     assert await _invoiced_qty(client, h, budget_id) == 0
 
     # Delete a draft → line comes back.
-    inv = await _invoice_from_budget(client, h, budget_id, item_id, quantity=2)
+    inv = await invoice_from_budget(client, h, budget_id, item_id, quantity=2)
     r = await client.delete(f"{b}/{inv['id']}", headers=h)
     assert r.status_code == 204, r.text
     assert await _invoiced_qty(client, h, budget_id) == 0
 
     # Editing / deleting a draft line keeps the counter in sync.
-    inv = await _invoice_from_budget(client, h, budget_id, item_id, quantity=3)
+    inv = await invoice_from_budget(client, h, budget_id, item_id, quantity=3)
     line_id = inv["items"][0]["id"]
     r = await client.put(f"{b}/{inv['id']}/items/{line_id}", json={"quantity": 1}, headers=h)
     assert r.status_code == 200, r.text
@@ -203,7 +142,7 @@ async def test_void_delete_and_item_edits_release_quote_lines(
     assert await _invoiced_qty(client, h, budget_id) == 0
 
     # The full quantity is available again.
-    await _invoice_from_budget(client, h, budget_id, item_id, quantity=3)
+    await invoice_from_budget(client, h, budget_id, item_id, quantity=3)
     assert await _invoiced_qty(client, h, budget_id) == 3
     r = await client.post(
         f"{b}/from-budget/{budget_id}", json={"items": [{"budget_item_id": item_id}]}, headers=h
@@ -215,7 +154,7 @@ async def test_void_delete_and_item_edits_release_quote_lines(
 async def test_credit_note_releases_quote_lines(
     client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
 ) -> None:
-    budget_id, item_id = await _accepted_budget(
+    budget_id, item_id = await accepted_budget(
         client, auth_headers, budget_clinic_setup, quantity=2
     )
     h = auth_headers
@@ -235,7 +174,7 @@ async def test_credit_note_releases_quote_lines(
         )
         assert r.status_code == 201, r.text
 
-    inv = await _invoice_from_budget(client, h, budget_id, item_id)
+    inv = await invoice_from_budget(client, h, budget_id, item_id)
     r = await client.post(f"{b}/{inv['id']}/issue", json={}, headers=h)
     assert r.status_code == 200, r.text
     assert await _invoiced_qty(client, h, budget_id) == 2
@@ -257,7 +196,7 @@ async def test_partial_invoices_with_global_discount_add_up_to_the_quote(
 ) -> None:
     """qty 2 with a 20 % line discount and a 10 % global: invoicing 1 + 1 must
     reproduce the quote's discount and total exactly (issue #181)."""
-    budget_id, item_id = await _accepted_budget(
+    budget_id, item_id = await accepted_budget(
         client,
         auth_headers,
         budget_clinic_setup,
@@ -268,8 +207,8 @@ async def test_partial_invoices_with_global_discount_add_up_to_the_quote(
     quote = (await client.get(f"/api/v1/budget/budgets/{budget_id}", headers=auth_headers)).json()[
         "data"
     ]
-    first = await _invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
-    second = await _invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
+    first = await invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
+    second = await invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
 
     invoiced_discount = Decimal(first["total_discount"]) + Decimal(second["total_discount"])
     invoiced_total = Decimal(first["total"]) + Decimal(second["total"])

--- a/backend/tests/modules/billing/test_patient_summary_work_completed.py
+++ b/backend/tests/modules/billing/test_patient_summary_work_completed.py
@@ -1,0 +1,82 @@
+"""Patient billing summary derives "work completed" from fully invoiced quotes.
+
+The ``completed`` budget status was removed in 2026-04, which left the
+``work_completed`` KPI permanently at 0 (issue #242). Financial closure on
+the budget axis is now "fully invoiced": every line's ``invoiced_quantity``
+has reached its ``quantity``. ``work_in_progress`` is the complement, so the
+two KPIs partition the accepted total.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+
+from tests.modules.billing.test_invoice_from_budget import (
+    _accepted_budget,
+    _invoice_from_budget,
+)
+
+
+async def _patient_summary(client: AsyncClient, auth_headers: dict, patient_id: str) -> dict:
+    r = await client.get(f"/api/v1/billing/patients/{patient_id}/summary", headers=auth_headers)
+    assert r.status_code == 200, r.text
+    return r.json()["data"]
+
+
+@pytest.mark.asyncio
+async def test_partially_invoiced_budget_counts_as_in_progress(
+    client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
+) -> None:
+    """An accepted quote with lines still to invoice is work in progress."""
+    budget_id, item_id = await _accepted_budget(
+        client, auth_headers, budget_clinic_setup, quantity=2
+    )
+    await _invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
+
+    summary = await _patient_summary(client, auth_headers, budget_clinic_setup["patient_id"])
+    assert Decimal(summary["work_in_progress"]) == Decimal("200.00")
+    assert Decimal(summary["work_completed"]) == Decimal("0.00")
+
+
+@pytest.mark.asyncio
+async def test_fully_invoiced_budget_counts_as_completed(
+    client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
+) -> None:
+    """Once every line is fully invoiced the total moves to work completed."""
+    budget_id, item_id = await _accepted_budget(
+        client, auth_headers, budget_clinic_setup, quantity=2
+    )
+    await _invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
+    await _invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
+
+    summary = await _patient_summary(client, auth_headers, budget_clinic_setup["patient_id"])
+    assert Decimal(summary["work_in_progress"]) == Decimal("0.00")
+    assert Decimal(summary["work_completed"]) == Decimal("200.00")
+
+
+@pytest.mark.asyncio
+async def test_draft_budget_counts_in_neither_kpi(
+    client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
+) -> None:
+    """Non-accepted quotes stay out of both work KPIs."""
+    r = await client.post(
+        "/api/v1/budget/budgets",
+        json={"patient_id": budget_clinic_setup["patient_id"], "valid_from": "2024-01-01"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 201, r.text
+    budget_id = r.json()["data"]["id"]
+    r = await client.post(
+        f"/api/v1/budget/budgets/{budget_id}/items",
+        json={"catalog_item_id": budget_clinic_setup["catalog_item_id"], "quantity": 1},
+        headers=auth_headers,
+    )
+    assert r.status_code == 201, r.text
+
+    summary = await _patient_summary(client, auth_headers, budget_clinic_setup["patient_id"])
+    assert Decimal(summary["total_budgeted"]) == Decimal("100.00")
+    assert Decimal(summary["work_in_progress"]) == Decimal("0.00")
+    assert Decimal(summary["work_completed"]) == Decimal("0.00")

--- a/backend/tests/modules/billing/test_patient_summary_work_completed.py
+++ b/backend/tests/modules/billing/test_patient_summary_work_completed.py
@@ -14,10 +14,7 @@ from decimal import Decimal
 import pytest
 from httpx import AsyncClient
 
-from tests.modules.billing.test_invoice_from_budget import (
-    _accepted_budget,
-    _invoice_from_budget,
-)
+from tests.modules.billing.helpers import accepted_budget, invoice_from_budget
 
 
 async def _patient_summary(client: AsyncClient, auth_headers: dict, patient_id: str) -> dict:
@@ -31,10 +28,10 @@ async def test_partially_invoiced_budget_counts_as_in_progress(
     client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
 ) -> None:
     """An accepted quote with lines still to invoice is work in progress."""
-    budget_id, item_id = await _accepted_budget(
+    budget_id, item_id = await accepted_budget(
         client, auth_headers, budget_clinic_setup, quantity=2
     )
-    await _invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
+    await invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
 
     summary = await _patient_summary(client, auth_headers, budget_clinic_setup["patient_id"])
     assert Decimal(summary["work_in_progress"]) == Decimal("200.00")
@@ -46,11 +43,11 @@ async def test_fully_invoiced_budget_counts_as_completed(
     client: AsyncClient, auth_headers: dict, budget_clinic_setup: dict
 ) -> None:
     """Once every line is fully invoiced the total moves to work completed."""
-    budget_id, item_id = await _accepted_budget(
+    budget_id, item_id = await accepted_budget(
         client, auth_headers, budget_clinic_setup, quantity=2
     )
-    await _invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
-    await _invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
+    await invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
+    await invoice_from_budget(client, auth_headers, budget_id, item_id, quantity=1)
 
     summary = await _patient_summary(client, auth_headers, budget_clinic_setup["patient_id"])
     assert Decimal(summary["work_in_progress"]) == Decimal("0.00")


### PR DESCRIPTION
## Summary

Fixes #242 — the patient billing KPI **"Trabajo completado"** (Patient → Administración → Billing) was permanently 0 because `get_patient_summary` summed budgets with `status == 'completed'`, a status removed in 2026-04.

## Approach chosen

Of the three options listed in the issue, this PR takes **derive from fully-invoiced quotes** — it is the one `budget/CLAUDE.md` itself designates as the replacement (*"Use invoice paid / fully invoiced as the financial-closure signal instead"*), and "fully invoiced" is the only one of the two that stays on the budget axis as required.

- `work_completed` = Σ `Budget.total` of **accepted** budgets where every line's `invoiced_quantity` ≥ `quantity` (a `bool_and` aggregate over `budget_items`, outer-joined so item-less budgets are never "completed")
- `work_in_progress` = the complement (accepted, not yet fully invoiced) — previously it was *all* accepted budgets, so the two tiles would have double-counted once completed became non-zero; now they partition the accepted total

Notes:
- `BudgetItem.invoiced_quantity` is the derived cache maintained by `resync_invoiced_quantities` (credit notes subtract, voided/deleted documents don't count), so the KPI follows the same signal the from-budget wizard uses for remaining quantities.
- No schema/API shape change — `PatientBillingSummary` fields are unchanged, only their derivation.
- Off-books rule respected: budget + invoice axes only, no payment data.

## Tests

New API-level tests in `backend/tests/modules/billing/test_patient_summary_work_completed.py` (reusing the from-budget helpers from #167's tests):

- partially invoiced accepted quote → counts in `work_in_progress`, not `work_completed`
- fully invoiced accepted quote → moves to `work_completed`
- draft quote → in neither KPI

## Verification

- `ruff check app tests` and `ruff format --check` — clean
- Full pytest suite needs the Dockerized Postgres, which isn't available in my environment — relying on CI for the suite run; happy to iterate if anything is red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)