### PR TITLE
fix(i18n): persist locale in a cookie so SSR renders the user's language (#235, #202)

### DIFF
--- a/frontend/app/plugins/locale.client.ts
+++ b/frontend/app/plugins/locale.client.ts
@@ -8,6 +8,11 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
   const savedLocale = localStorage.getItem(STORAGE_KEYS.LOCALE) as CodeLang
 
+  // The `dentalpin_locale` cookie (written by setLocale, read during SSR —
+  // see the i18n block in nuxt.config.ts) is the authoritative store since
+  // #235. localStorage is kept as a fallback: pre-cookie users get their
+  // saved language restored here, and setLocale then writes the cookie so
+  // the next server render already uses it.
   if (savedLocale && SUPPORTED_LOCALES.includes(savedLocale) && savedLocale !== i18n.locale.value) {
     await i18n.setLocale(savedLocale)
   }

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -146,7 +146,18 @@ export default defineNuxtConfig({
     lazy: true,
     langDir: 'locales',
     strategy: 'no_prefix',
-    detectBrowserLanguage: false
+    // Persist the chosen locale in a cookie the server can read, so SSR
+    // renders in the user's language. Locale-dependent DOM *attributes*
+    // (placeholder, title, aria-label) are not patched during hydration,
+    // so an English server render used to survive until the next
+    // client-side navigation (#235, #202). First visit without the
+    // cookie falls back to Accept-Language, then to `en`.
+    detectBrowserLanguage: {
+      useCookie: true,
+      cookieKey: 'dentalpin_locale',
+      redirectOn: 'root',
+      fallbackLocale: 'en'
+    }
   },
 
   // Pre-bundle every `i-lucide-*` icon referenced in source into the client


### PR DESCRIPTION
## Summary

Fixes #235 and fixes #202 — both share one root cause: the locale lives only in `localStorage`, so **SSR always renders English**. For text content, hydration papers over it (with warnings); for **attributes** (`placeholder`, `title`, `aria-label`) Vue does not patch mismatches, so the English server value survives until a client-side navigation re-creates the component (#235's symptom). #202's hydration warnings, mixed-language aria-labels and flash-of-English come from the same place.

## Fix

Exactly the cookie approach proposed in both issues, using `@nuxtjs/i18n`'s built-in mechanism instead of hand-rolled cookie code:

- **`nuxt.config.ts`**: `detectBrowserLanguage: { useCookie: true, cookieKey: 'dentalpin_locale', redirectOn: 'root', fallbackLocale: 'en' }` (cookie names can't contain `:`, hence not `dentalpin:locale`). With `strategy: 'no_prefix'` there is no redirect involved — the module simply reads the cookie during SSR and applies the locale, and every `setLocale()` call (i.e. `useLocale().changeLocale`, used by /setup and Settings → Account) now writes the cookie automatically. First visit without a cookie falls back to **Accept-Language**, then `en`, and the server sets the cookie on that response.
- **`app/plugins/locale.client.ts`**: unchanged behaviour, now documented as the **migration path** — pre-cookie users get their `localStorage` language restored on first load, and that `setLocale` writes the cookie, so from the second load SSR is correct. localStorage keeps being written as a fallback store.

Bonus: `<html lang>` now matches the user's language during SSR (it was always `en`), which fixes the document-level a11y language signal too.

## Verification (dev server, curl + browser)

| Scenario | Result |
|---|---|
| `GET /login` no cookie | English placeholders, `Set-Cookie: dentalpin_locale=en` |
| `GET /login` with `dentalpin_locale=es` | SSR HTML has `placeholder="Correo electrónico"` / `"Contraseña"`, `<html lang="es">` |
| `GET /login` no cookie, `Accept-Language: es-ES` | Spanish SSR + `Set-Cookie: dentalpin_locale=es` (1-year, SameSite=Lax) |
| Browser: `setLocale('es')` then re-fetch `/login` | next SSR response is Spanish — the client write is picked up server-side |
| Browser: cookie cleared + `localStorage['dentalpin:locale']='fr'` + reload | client locale becomes `fr` and the **next** SSR renders `lang="fr"` (migration path) |

Also ran `npm run lint` (0 errors, 4 pre-existing warnings) and `npm run typecheck:layers` (clean, `modules.json` restored per CLAUDE.md).

Detection was verified on a non-root path (`/login`), so deep links get the right locale too, not just `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)