### PR TITLE
docs: get_tools() is optional — align checklist and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,7 +324,7 @@ class MyModule(BaseModule):
     def get_router(self) -> APIRouter: return router
     def get_permissions(self) -> list[str]: return ["resource.read", "resource.write"]
     def get_event_handlers(self) -> dict: return {"patient.created": self._on_patient_created}
-    def get_tools(self) -> list[Tool]: return []   # mandatory, even if empty
+    # get_tools() is optional — BaseModule returns []; override only when exposing tools
 ```
 
 Event bus:

--- a/docs/checklists/new-module.md
+++ b/docs/checklists/new-module.md
@@ -9,7 +9,7 @@ For deeper rationale on any line, follow the link.
 - [ ] Module class subclasses `BaseModule` (`backend/app/core/plugins/base.py`)
 - [ ] `manifest = {...}` set as class attribute (see `Manifest` in `backend/app/core/plugins/manifest.py` for the full schema)
 - [ ] Entry point registered in `backend/pyproject.toml` under `[project.entry-points."dentalpin.modules"]`
-- [ ] `get_models()`, `get_router()`, `get_tools()` implemented (the last is mandatory even if empty — see `BaseModule`)
+- [ ] `get_models()`, `get_router()` implemented (`get_tools()` is optional — `BaseModule` returns `[]`; override only when the module exposes tools, see `docs/technical/creating-modules.md`)
 
 ## Manifest fields
 


### PR DESCRIPTION
`docs/checklists/new-module.md` and root `CLAUDE.md` said `get_tools()` is mandatory even if empty; `docs/technical/creating-modules.md` (source of truth) and `BaseModule` say it's optional with a `[]` default. Align the two outliers. Spotted by @hirad121 in #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012v4M46FJV8dgoAPpfNVEjh