### PR TITLE
feat(agenda): order=asc|desc on GET /appointments; last-visit card fetches one row

### DIFF
--- a/backend/app/modules/agenda/CHANGELOG.md
+++ b/backend/app/modules/agenda/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: `GET /agenda/appointments` accepts `order=asc|desc` (by `start_time`, default `asc`). `LastVisitCard` now fetches the most recent completed visit with a single `order=desc&page_size=1` request instead of paging to the tail (PR #251 follow-up).
+
 - feat(#182): `LastVisitCard` on `patient.summary.cards` (order 21, next to the next-appointment card) — shows the patient's most recent completed appointment (date/time/professional/treatment) with an explicit "Sin visitas previas" empty state, so reception can tell a first-timer from a regular on the Resumen tab. Click opens the appointment on the agenda, or the agenda with the patient pre-selected when there is none.
 
 - fix(#184): type-check clean. `useAppointments`/`useHomeAgenda` expose their lists with `shallowReadonly` (the deep `readonly()` view forced `DeepReadonly<Appointment>` through every child prop); the mobile day summary/timeline called `t()` with a 3-arg (key, fallback, params) form vue-i18n does not have — the keys exist in every locale, so params only; `getCabinetColor` accepts the nullable cabinet; the modal no longer sends a `media` field `PlannedTreatmentItem` does not have.

--- a/backend/app/modules/agenda/frontend/components/summary/LastVisitCard.vue
+++ b/backend/app/modules/agenda/frontend/components/summary/LastVisitCard.vue
@@ -25,30 +25,18 @@ const patientId = computed(() => props.ctx.patient.id)
 const { data, status } = await useAsyncData(
   () => `agenda:summary-card:last-visit:${patientId.value}`,
   async () => {
-    // The list endpoint pages in ascending ``start_time``, so the most
-    // recent completed appointment sits on the *last* page. One request
-    // covers patients with ≤100 completed visits; beyond that, fetch
-    // the final page.
-    const base = `/api/v1/agenda/appointments?patient_id=${patientId.value}&status=completed&page_size=100`
     try {
-      const first = await api.get<PaginatedResponse<Appointment>>(base)
-      const total = first.total ?? first.data.length
-      if (total > first.data.length) {
-        const lastPage = Math.ceil(total / 100)
-        return await api.get<PaginatedResponse<Appointment>>(`${base}&page=${lastPage}`)
-      }
-      return first
+      return await api.get<PaginatedResponse<Appointment>>(
+        `/api/v1/agenda/appointments?patient_id=${patientId.value}&status=completed&order=desc&page_size=1`
+      )
     } catch {
-      return { data: [], total: 0, page: 1, page_size: 100 }
+      return { data: [], total: 0, page: 1, page_size: 1 }
     }
   },
   { watch: [patientId], server: false }
 )
 
-const lastVisit = computed<Appointment | null>(() => {
-  const list = data.value?.data ?? []
-  return list[list.length - 1] ?? null
-})
+const lastVisit = computed<Appointment | null>(() => data.value?.data[0] ?? null)
 
 const dayLabel = computed(() => {
   if (!lastVisit.value) return ''

--- a/backend/app/modules/agenda/router.py
+++ b/backend/app/modules/agenda/router.py
@@ -78,8 +78,14 @@ async def list_appointments(
     appointment_status: str | None = Query(default=None, alias="status"),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=100, ge=1, le=500),
+    order: str = Query(default="asc", pattern="^(asc|desc)$"),
 ) -> PaginatedApiResponse[AppointmentResponse]:
-    """List appointments with filters."""
+    """List appointments with filters.
+
+    ``order`` sorts by ``start_time`` — ``desc`` lets "most recent
+    first" consumers (e.g. the patient last-visit card) fetch one page
+    of one instead of paging to the tail.
+    """
     appointments, total = await AppointmentService.list_appointments(
         db,
         ctx.clinic_id,
@@ -91,6 +97,7 @@ async def list_appointments(
         page,
         page_size,
         patient_id=patient_id,
+        order=order,
     )
     return PaginatedApiResponse(
         data=[_localize(AppointmentResponse.model_validate(a), ctx) for a in appointments],

--- a/backend/app/modules/agenda/service.py
+++ b/backend/app/modules/agenda/service.py
@@ -160,10 +160,13 @@ class AppointmentService:
         page_size: int = 100,
         *,
         patient_id: UUID | None = None,
+        order: str = "asc",
     ) -> tuple[list[Appointment], int]:
         """List appointments with filters.
 
         Naive ``start_date``/``end_date`` are clinic-local (issue #161).
+        ``order`` sorts by ``start_time`` (``asc`` default, ``desc`` for
+        most-recent-first consumers).
         """
         if (start_date and start_date.tzinfo is None) or (end_date and end_date.tzinfo is None):
             tz = await get_clinic_tz(db, clinic_id)
@@ -225,7 +228,9 @@ class AppointmentService:
             await db.execute(select(func.count(Appointment.id)).where(*count_filters))
         ).scalar() or 0
 
-        query = query.order_by(Appointment.start_time)
+        query = query.order_by(
+            Appointment.start_time.desc() if order == "desc" else Appointment.start_time
+        )
         query = query.offset(offset).limit(page_size)
         result = await db.execute(query)
         return list(result.scalars().all()), total

--- a/backend/tests/test_appointment_list_order.py
+++ b/backend/tests/test_appointment_list_order.py
@@ -1,0 +1,82 @@
+"""``list_appointments`` honours the ``order`` parameter.
+
+``asc`` (the default, unchanged behaviour) pages oldest-first;
+``desc`` pages newest-first so most-recent-first consumers (the
+patient last-visit card) can fetch ``page_size=1`` instead of paging
+to the tail.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.agenda.service import AppointmentService
+from tests.test_appointment_transitions import _mkapt, _mkworld
+
+
+@pytest.mark.asyncio
+async def test_list_appointments_order(db_session: AsyncSession) -> None:
+    world = await _mkworld(db_session)
+    starts = [
+        datetime(2026, 5, 4, 9, 0, tzinfo=UTC),
+        datetime(2026, 5, 5, 9, 0, tzinfo=UTC),
+        datetime(2026, 5, 6, 9, 0, tzinfo=UTC),
+    ]
+    for start in starts:
+        await _mkapt(db_session, world, start=start)
+
+    ascending, total = await AppointmentService.list_appointments(
+        db_session, world["clinic_id"], patient_id=world["patient_id"]
+    )
+    assert total == 3
+    assert [a.start_time for a in ascending] == starts
+
+    descending, total = await AppointmentService.list_appointments(
+        db_session, world["clinic_id"], patient_id=world["patient_id"], order="desc"
+    )
+    assert total == 3
+    assert [a.start_time for a in descending] == list(reversed(starts))
+
+    newest, total = await AppointmentService.list_appointments(
+        db_session,
+        world["clinic_id"],
+        patient_id=world["patient_id"],
+        order="desc",
+        page_size=1,
+    )
+    assert total == 3
+    assert [a.start_time for a in newest] == [starts[-1]]
+
+
+@pytest.mark.asyncio
+async def test_list_appointments_desc_with_status_filter(db_session: AsyncSession) -> None:
+    """The last-visit card's exact query: completed only, newest first."""
+    world = await _mkworld(db_session)
+    completed_starts = [
+        datetime(2026, 5, 11, 9, 0, tzinfo=UTC),
+        datetime(2026, 5, 12, 9, 0, tzinfo=UTC),
+    ]
+    for start in completed_starts:
+        await _mkapt(db_session, world, start=start, status="completed")
+    # A later appointment that is merely scheduled must not win.
+    await _mkapt(
+        db_session, world, start=datetime(2026, 5, 13, 9, 0, tzinfo=UTC) + timedelta(hours=1)
+    )
+
+    newest, total = await AppointmentService.list_appointments(
+        db_session,
+        world["clinic_id"],
+        None,
+        None,
+        None,
+        None,
+        "completed",
+        patient_id=world["patient_id"],
+        order="desc",
+        page_size=1,
+    )
+    assert total == 2
+    assert [a.start_time for a in newest] == [completed_starts[-1]]

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -114,7 +114,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.AGENDA_VISIT_NOTE_UPDATED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:860`
+  - `agenda` — `backend/app/modules/agenda/service.py:865`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -122,14 +122,14 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_CABINET_CHANGED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:797`
+  - `agenda` — `backend/app/modules/agenda/service.py:802`
 - **Subscribers:** —
 
 ### `appointment.cancelled`
 
 - **Constant:** `EventType.APPOINTMENT_CANCELLED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:735`
+  - `agenda` — `backend/app/modules/agenda/service.py:740`
 - **Subscribers:**
   - `copilot`
   - `notifications`
@@ -141,7 +141,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_CHECKED_IN`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:732`
+  - `agenda` — `backend/app/modules/agenda/service.py:737`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -149,7 +149,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_COMPLETED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:734`
+  - `agenda` — `backend/app/modules/agenda/service.py:739`
 - **Subscribers:**
   - `integrations`
   - `patient_timeline`
@@ -160,7 +160,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_CONFIRMED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:731`
+  - `agenda` — `backend/app/modules/agenda/service.py:736`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -168,7 +168,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_IN_TREATMENT`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:733`
+  - `agenda` — `backend/app/modules/agenda/service.py:738`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -176,7 +176,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_NO_SHOW`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:736`
+  - `agenda` — `backend/app/modules/agenda/service.py:741`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -184,7 +184,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_SCHEDULED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:499`
+  - `agenda` — `backend/app/modules/agenda/service.py:504`
 - **Subscribers:**
   - `notifications`
   - `patient_timeline`
@@ -195,14 +195,14 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_STATUS_CHANGED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:726`
+  - `agenda` — `backend/app/modules/agenda/service.py:731`
 - **Subscribers:** —
 
 ### `appointment.updated`
 
 - **Constant:** `EventType.APPOINTMENT_UPDATED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:627`
+  - `agenda` — `backend/app/modules/agenda/service.py:632`
 - **Subscribers:**
   - `schedules`
 


### PR DESCRIPTION
Follow-up to #251 (review note 1).

## Summary

- `GET /agenda/appointments` accepts `order=asc|desc` (by `start_time`). `asc` is the default, so existing consumers are untouched; the value is validated by FastAPI (`pattern="^(asc|desc)$"` → 422 on anything else).
- `LastVisitCard` now sends `status=completed&order=desc&page_size=1` and takes the first row — the "follow `total` to the last page" logic is gone.

## Tests

New `backend/tests/test_appointment_list_order.py` (service level, reusing the `_mkworld`/`_mkapt` helpers from the transitions tests):

- default order is ascending (unchanged behaviour)
- `order=desc` reverses, and `page_size=1` returns exactly the newest row with the full `total`
- the card's exact query shape: completed-only + desc + `page_size=1` returns the newest **completed** visit even when a later merely-scheduled appointment exists

## Verification

- `ruff check` / `ruff format --check` clean on the touched files; `npm run typecheck:layers` clean; the card lints clean.
- Full pytest needs the Dockerized Postgres which I don't have locally — relying on CI as before.

Agenda `CHANGELOG.md` entry added under Unreleased.