### PR TITLE
fix(layout): wrap app.overlays ModuleSlot in ClientOnly (#258)

### DIFF
--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -382,11 +382,17 @@ function isActive(to: string): boolean {
         Global overlay slot for agent surfaces (the copilot drawer, and
         future voice). Registered components teleport to <body>; nothing
         renders inline here. The layout knows nothing about them.
+        ClientOnly for the same reason as app.banners above: overlay
+        registrations happen in `plugins/*.client.ts`, so the slot is
+        empty during SSR while the client renders the registered
+        components — a per-page hydration mismatch otherwise (#258).
       -->
-      <ModuleSlot
-        name="app.overlays"
-        :ctx="{}"
-      />
+      <ClientOnly>
+        <ModuleSlot
+          name="app.overlays"
+          :ctx="{}"
+        />
+      </ClientOnly>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Fixes #258.

Same root cause and same fix as `app.banners` in #210: overlay registrations live in `plugins/*.client.ts`, so the slot is empty during SSR while the client renders `CopilotMount` — a hydration mismatch logged on every page. Wrapping the layout's `app.overlays` `ModuleSlot` in `<ClientOnly>` makes server and client agree; the registered components teleport to `<body>`, so nothing visual changes and nothing is lost from the server render (this was option 1 of the two the issue listed — it keeps the fix in one place instead of inside each registered overlay).

Verification: `npm run lint` clean on the file, `npm run typecheck:layers` clean. The e2e suite exercises authenticated pages under this layout (that's what surfaced the banners variant in #210), so CI covers the regression path.