### PR TITLE
feat(agenda): export an appointment as .ics (#129)

### DIFF
--- a/backend/app/modules/agenda/CHANGELOG.md
+++ b/backend/app/modules/agenda/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat(#129): `GET /agenda/appointments/{id}.ics` — export one appointment as an RFC 5545 iCalendar file (UTC timestamps, CRLF + 75-octet folding, escaped text values, stable `UID` of `<appointment-uuid>@dentalpin.com`, `text/calendar` attachment). Hand-rolled builder in `ics.py`, no new dependency. Registered before the plain `/{id}` route so the `.ics` suffix isn't swallowed by the UUID param.
+
 - fix(#203): the kanban card menu trigger carried `aria-label="Marcar llegada"` in every column; now the neutral `appointments.actionsMenu` ("Acciones de la cita"), added to all five locales.
 
 - feat: `GET /agenda/appointments` accepts `order=asc|desc` (by `start_time`, default `asc`). `LastVisitCard` now fetches the most recent completed visit with a single `order=desc&page_size=1` request instead of paging to the tail (PR #251 follow-up).

--- a/backend/app/modules/agenda/ics.py
+++ b/backend/app/modules/agenda/ics.py
@@ -1,0 +1,126 @@
+"""RFC 5545 export of a single appointment (issue #129).
+
+Hand-rolled on purpose: one ``VEVENT`` is ~25 lines of string building
+and does not justify an ``icalendar`` dependency. The RFC details that
+actually bite are handled here — CRLF line endings, 75-octet line
+folding, escaping of ``, ; \\`` and newlines in text values, UTC
+``...Z`` timestamps, and a stable ``UID``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.core.auth.models import Clinic
+
+    from .models import Appointment
+
+PRODID = "-//DentalPin//Agenda//EN"
+UID_DOMAIN = "dentalpin.com"
+
+# Appointment statuses that map to a cancelled VEVENT; everything else
+# ships as CONFIRMED (calendar clients have no richer vocabulary).
+_CANCELLED_STATUSES = {"cancelled", "no_show"}
+
+
+def _escape(value: str) -> str:
+    """Escape a TEXT value per RFC 5545 §3.3.11."""
+    return (
+        value.replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace("\r\n", "\\n")
+        .replace("\n", "\\n")
+    )
+
+
+def _fold(line: str) -> list[str]:
+    """Fold a content line at 75 octets (continuation lines start with a space)."""
+    encoded = line.encode("utf-8")
+    if len(encoded) <= 75:
+        return [line]
+    out: list[str] = []
+    rest = encoded
+    first = True
+    while rest:
+        limit = 75 if first else 74  # continuation lines lose one octet to the space
+        chunk = rest[:limit]
+        # Never split inside a UTF-8 multi-byte sequence.
+        while chunk and (chunk[-1] & 0xC0) == 0x80:
+            chunk = chunk[:-1]
+        out.append(("" if first else " ") + chunk.decode("utf-8"))
+        rest = rest[len(chunk) :]
+        first = False
+    return out
+
+
+def _utc(dt: datetime) -> str:
+    """Render an aware datetime as an RFC 5545 UTC timestamp (``...Z``)."""
+    return dt.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _location(clinic: Clinic) -> str:
+    address = clinic.address or {}
+    parts = [clinic.name]
+    for key in ("street", "city", "postal_code"):
+        value = address.get(key)
+        if value:
+            parts.append(str(value))
+    return ", ".join(parts)
+
+
+def build_appointment_ics(
+    appointment: Appointment,
+    clinic: Clinic,
+    *,
+    now: datetime | None = None,
+) -> str:
+    """A complete single-``VEVENT`` iCalendar document, CRLF-terminated.
+
+    ``SUMMARY``/``DESCRIPTION`` carry no clinical detail beyond what the
+    appointment already shows: treatment type and the people involved.
+    ``now`` is injectable for deterministic tests.
+    """
+    stamp = _utc(now if now is not None else datetime.now(UTC))
+
+    summary = appointment.treatment_type or "Dental appointment"
+
+    description_parts: list[str] = []
+    if appointment.patient is not None:
+        description_parts.append(
+            f"Patient: {appointment.patient.first_name} {appointment.patient.last_name}"
+        )
+    if appointment.professional is not None:
+        description_parts.append(
+            f"Professional: {appointment.professional.first_name} "
+            f"{appointment.professional.last_name}"
+        )
+
+    status = "CANCELLED" if appointment.status in _CANCELLED_STATUSES else "CONFIRMED"
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        f"PRODID:{PRODID}",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+        "BEGIN:VEVENT",
+        f"UID:{appointment.id}@{UID_DOMAIN}",
+        f"DTSTAMP:{stamp}",
+        f"DTSTART:{_utc(appointment.start_time)}",
+        f"DTEND:{_utc(appointment.end_time)}",
+        f"SUMMARY:{_escape(summary)}",
+    ]
+    if description_parts:
+        lines.append(f"DESCRIPTION:{_escape(chr(10).join(description_parts))}")
+    lines.append(f"LOCATION:{_escape(_location(clinic))}")
+    lines.append(f"STATUS:{status}")
+    lines.append("END:VEVENT")
+    lines.append("END:VCALENDAR")
+
+    folded: list[str] = []
+    for line in lines:
+        folded.extend(_fold(line))
+    return "\r\n".join(folded) + "\r\n"

--- a/backend/app/modules/agenda/router.py
+++ b/backend/app/modules/agenda/router.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -153,6 +153,36 @@ async def create_appointment(
         ) from e
 
     return ApiResponse(data=_localize(AppointmentResponse.model_validate(appointment), ctx))
+
+
+@router.get("/appointments/{appointment_id}.ics")
+async def export_appointment_ics(
+    appointment_id: UUID,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("agenda.appointments.read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Response:
+    """Export one appointment as an RFC 5545 ``.ics`` file (#129).
+
+    Lets a patient or professional drop the appointment into Google
+    Calendar / Apple Calendar / Outlook. Timestamps go out in UTC.
+    Registered before the plain ``/{appointment_id}`` route: starlette
+    matches routes in order and ``{appointment_id}`` (``[^/]+``) would
+    swallow the ``.ics`` suffix into the UUID and 422.
+    """
+    from .ics import build_appointment_ics
+
+    appointment = await AppointmentService.get_appointment(db, ctx.clinic_id, appointment_id)
+    if not appointment:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Appointment not found",
+        )
+    return Response(
+        content=build_appointment_ics(appointment, ctx.clinic),
+        media_type="text/calendar; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="appointment-{appointment.id}.ics"'},
+    )
 
 
 @router.get("/appointments/{appointment_id}", response_model=ApiResponse[AppointmentResponse])

--- a/backend/tests/test_appointment_ics.py
+++ b/backend/tests/test_appointment_ics.py
@@ -1,0 +1,169 @@
+"""RFC 5545 export of an appointment (#129).
+
+Unit tests exercise the pure builder (CRLF, escaping, UTC, folding,
+stable UID) on transient ORM objects — no DB. API tests cover the
+endpoint: happy path returns a parseable VEVENT, a wrong-clinic
+appointment is a 404, and a SUMMARY containing a comma is escaped.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.models import Clinic, ClinicMembership
+from app.modules.agenda.ics import build_appointment_ics
+from app.modules.agenda.models import Appointment
+from tests.test_appointment_transitions import _mkapt, _mkworld
+
+# ---------------------------------------------------------------------------
+# Unit — pure builder
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+
+
+def _clinic(**overrides) -> Clinic:
+    values = dict(
+        id=uuid4(),
+        name="Clínica Demo",
+        tax_id="B1",
+        address={"street": "Calle Gran Vía 123", "city": "Madrid"},
+        settings={},
+    )
+    values.update(overrides)
+    return Clinic(**values)
+
+
+def _appointment(**overrides) -> Appointment:
+    values = dict(
+        id=uuid4(),
+        clinic_id=uuid4(),
+        professional_id=uuid4(),
+        start_time=datetime(2026, 9, 1, 10, 0, tzinfo=UTC),
+        end_time=datetime(2026, 9, 1, 10, 30, tzinfo=UTC),
+        treatment_type="Limpieza dental",
+        status="scheduled",
+    )
+    values.update(overrides)
+    return Appointment(**values)
+
+
+def test_crlf_endings_and_envelope() -> None:
+    ics = build_appointment_ics(_appointment(), _clinic(), now=_NOW)
+    assert ics.startswith("BEGIN:VCALENDAR\r\n")
+    assert ics.endswith("END:VCALENDAR\r\n")
+    # Every line break is CRLF — no bare \n anywhere.
+    assert "\n" not in ics.replace("\r\n", "")
+
+
+def test_timestamps_are_utc_z() -> None:
+    # A clinic-local aware time one hour ahead of UTC must convert, not
+    # be reinterpreted.
+    madrid = timezone(timedelta(hours=2))
+    apt = _appointment(
+        start_time=datetime(2026, 9, 1, 12, 0, tzinfo=madrid),
+        end_time=datetime(2026, 9, 1, 12, 30, tzinfo=madrid),
+    )
+    ics = build_appointment_ics(apt, _clinic(), now=_NOW)
+    assert "DTSTART:20260901T100000Z" in ics
+    assert "DTEND:20260901T103000Z" in ics
+    assert f"DTSTAMP:{_NOW.strftime('%Y%m%dT%H%M%SZ')}" in ics
+
+
+def test_uid_is_stable_and_domain_qualified() -> None:
+    apt = _appointment()
+    first = build_appointment_ics(apt, _clinic(), now=_NOW)
+    second = build_appointment_ics(apt, _clinic(), now=_NOW)
+    assert f"UID:{apt.id}@dentalpin.com\r\n" in first
+    assert first == second
+
+
+def test_text_values_are_escaped() -> None:
+    apt = _appointment(treatment_type="Cleaning, deep; with\nnotes\\here")
+    ics = build_appointment_ics(apt, _clinic(name="Acme, S.L."), now=_NOW)
+    assert "SUMMARY:Cleaning\\, deep\\; with\\nnotes\\\\here" in ics
+    assert "LOCATION:Acme\\, S.L." in ics
+
+
+def test_long_lines_fold_at_75_octets() -> None:
+    apt = _appointment(treatment_type="Rehabilitación oral completa " * 6)
+    ics = build_appointment_ics(apt, _clinic(), now=_NOW)
+    for line in ics.split("\r\n"):
+        assert len(line.encode("utf-8")) <= 75
+    # Folded continuations start with a single space.
+    assert "\r\n " in ics
+
+
+def test_cancelled_status_maps_to_cancelled_vevent() -> None:
+    ics = build_appointment_ics(_appointment(status="cancelled"), _clinic(), now=_NOW)
+    assert "STATUS:CANCELLED" in ics
+    ics = build_appointment_ics(_appointment(status="confirmed"), _clinic(), now=_NOW)
+    assert "STATUS:CONFIRMED" in ics
+
+
+# ---------------------------------------------------------------------------
+# API — endpoint behaviour
+# ---------------------------------------------------------------------------
+
+
+async def _join_authed_user_to(db: AsyncSession, client: AsyncClient, auth_headers, clinic_id):
+    me = await client.get("/api/v1/auth/me", headers=auth_headers)
+    user_id = UUID(me.json()["data"]["user"]["id"])
+    db.add(ClinicMembership(id=uuid4(), user_id=user_id, clinic_id=clinic_id, role="admin"))
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_export_returns_parseable_vevent(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+) -> None:
+    world = await _mkworld(db_session)
+    await _join_authed_user_to(db_session, client, auth_headers, world["clinic_id"])
+    apt = await _mkapt(db_session, world, start=datetime(2026, 9, 2, 9, 0, tzinfo=UTC))
+
+    r = await client.get(f"/api/v1/agenda/appointments/{apt.id}.ics", headers=auth_headers)
+    assert r.status_code == 200, r.text
+    assert r.headers["content-type"].startswith("text/calendar")
+    assert f'filename="appointment-{apt.id}.ics"' in r.headers["content-disposition"]
+    body = r.text
+    assert "BEGIN:VEVENT" in body and "END:VEVENT" in body
+    assert f"UID:{apt.id}@dentalpin.com" in body
+    assert "DTSTART:20260902T090000Z" in body
+
+
+@pytest.mark.asyncio
+async def test_export_escapes_comma_in_summary(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+) -> None:
+    world = await _mkworld(db_session)
+    await _join_authed_user_to(db_session, client, auth_headers, world["clinic_id"])
+    apt = await _mkapt(db_session, world, start=datetime(2026, 9, 3, 9, 0, tzinfo=UTC))
+    row = (
+        await db_session.execute(select(Appointment).where(Appointment.id == apt.id))
+    ).scalar_one()
+    row.treatment_type = "Limpieza, revisión"
+    await db_session.commit()
+
+    r = await client.get(f"/api/v1/agenda/appointments/{apt.id}.ics", headers=auth_headers)
+    assert r.status_code == 200, r.text
+    assert "SUMMARY:Limpieza\\, revisión" in r.text
+
+
+@pytest.mark.asyncio
+async def test_export_is_clinic_scoped(
+    client: AsyncClient, auth_headers: dict, db_session: AsyncSession
+) -> None:
+    """An appointment of a clinic the user does not belong to is a 404."""
+    mine = await _mkworld(db_session)
+    await _join_authed_user_to(db_session, client, auth_headers, mine["clinic_id"])
+    other = await _mkworld(db_session)
+    foreign_apt = await _mkapt(db_session, other, start=datetime(2026, 9, 4, 9, 0, tzinfo=UTC))
+
+    r = await client.get(f"/api/v1/agenda/appointments/{foreign_apt.id}.ics", headers=auth_headers)
+    assert r.status_code == 404

--- a/docs/technical/agenda/permissions.md
+++ b/docs/technical/agenda/permissions.md
@@ -1,6 +1,6 @@
 ---
 module: agenda
-last_verified_commit: 0000000
+last_verified_commit: 76b1273
 ---
 
 # Agenda — permissions
@@ -12,7 +12,7 @@ Returned by `AgendaModule.get_permissions()`
 
 | Permission | Allows | Required by |
 |------------|--------|-------------|
-| `agenda.appointments.read` | _Describe what this allows._ | _List the endpoints._ |
+| `agenda.appointments.read` | View appointments and export them. | `GET /agenda/appointments`, `GET /agenda/appointments/{appointment_id}`, `GET /agenda/appointments/{appointment_id}.ics` (RFC 5545 export, #129) |
 | `agenda.appointments.write` | _Describe what this allows._ | _List the endpoints._ |
 | `agenda.cabinets.read` | _Describe what this allows._ | _List the endpoints._ |
 | `agenda.cabinets.write` | _Describe what this allows._ | _List the endpoints._ |


### PR DESCRIPTION
Fixes #129 — the backend endpoint exactly as scoped in the issue (the UI download button stays a follow-up, per the maintainer's comment; if @BabuBahir still wants to take that part, it's all theirs).

## What's in

- `GET /agenda/appointments/{appointment_id}.ics` — single-`VEVENT` RFC 5545 document, `text/calendar; charset=utf-8`, `Content-Disposition: attachment; filename="appointment-<id>.ics"`.
- Hand-rolled ~120-line builder in `agenda/ics.py` — **no new dependency**, as requested. Handled RFC details:
  - **CRLF** line endings throughout (asserted: no bare `\n` anywhere)
  - **75-octet line folding**, UTF-8-safe (never splits a multi-byte sequence), continuation lines with a leading space
  - **escaping** of `, ; \\` and newlines in `SUMMARY`/`DESCRIPTION`/`LOCATION`
  - **UTC `...Z` timestamps** — aware datetimes converted with `astimezone(UTC)`, never reinterpreted (test feeds a +02:00 time and asserts the shifted `Z` form)
  - **stable `UID`**: `<appointment-uuid>@dentalpin.com`
  - injectable `now` for a deterministic `DTSTAMP`
- `cancelled`/`no_show` → `STATUS:CANCELLED`; everything else `CONFIRMED`. `SUMMARY` = treatment type, `DESCRIPTION` = patient + professional names only, `LOCATION` = clinic name + address — no clinical detail beyond what the appointment already shows.
- **Multi-tenancy**: loads via `AppointmentService.get_appointment(db, ctx.clinic_id, …)`; wrong-clinic → 404 (tested).
- **Route-order gotcha**: registered *before* `GET /appointments/{appointment_id}` — starlette matches in order, and the `[^/]+` param would otherwise swallow `<uuid>.ics` and 422. Noted in the docstring.

## Acceptance criteria

- ✅ Tests in `backend/tests/test_appointment_ics.py`: happy path returns a parseable VEVENT, wrong-clinic 404, comma-in-SUMMARY escaping — plus six no-DB unit tests over the builder (**6/6 ran locally**; API tests via CI, no local Postgres).
- ⚠️ *Which client I tested with*: I can't drive a real Google Calendar import from this environment, so instead the generated file **round-trips through the `icalendar` Python parser** (the strictest offline check I have): SUMMARY with comma/semicolon/newline round-trips exactly, DTSTART comes back tz-aware UTC, folding is transparent. If you can do a quick manual GCal import on review, that would close the last gap.
- ✅ `ruff check` + `ruff format --check` clean.
- ✅ Endpoint row under `agenda.appointments.read` in `docs/technical/agenda/permissions.md` (placeholder row filled with the real read-endpoints list) and `## Unreleased` entry in the agenda `CHANGELOG.md`.
- Events catalog: regenerated, no drift (agenda's publishers live in `service.py`, untouched).