### PR TITLE
fix(infra): guard frontend/modules.json against clobbering (#264)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,28 @@ jobs:
                            tests/test_module_docs.py \
                            -v --tb=short
 
+  modules-json-freshness:
+    # frontend/modules.json is generated but committed (it seeds Nuxt
+    # layer precedence for docker/local runs until the backend rewrites
+    # it) and got chronically clobbered by contributors' local install
+    # sets (#264). Same pattern as catalog-freshness: regenerate the
+    # canonical form and fail on diff. Authors fix drift locally with:
+    #   cd frontend && node scripts/modules-json.mjs \
+    #     ../backend/app/modules --prefix /module_layers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check modules.json is fresh
+        working-directory: frontend
+        run: |
+          node scripts/modules-json.mjs "$GITHUB_WORKSPACE/backend/app/modules" --prefix /module_layers
+          git diff --exit-code modules.json || {
+            echo "::error::frontend/modules.json drifted from the canonical generated form."
+            echo "Regenerate with: cd frontend && node scripts/modules-json.mjs ../backend/app/modules --prefix /module_layers"
+            exit 1
+          }
+
   catalog-freshness:
     # Verifies docs/modules-catalog.md and docs/events-catalog.md are
     # in sync with the manifests + EventType enum + event_bus.publish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ docker-compose up
 docker-compose exec backend python -m pytest -v
 cd backend && ruff check . && ruff format --check .
 cd frontend && npm run lint
-cd frontend && npm run typecheck:layers && git checkout modules.json   # vue-tsc over host + all module layers (stop the frontend container first)
+cd frontend && npm run typecheck:layers   # vue-tsc over host + all module layers (stop the frontend container first; modules.json is auto-restored, and CI guards it — see #264)
 
 # Reset DB + reseed demo data (use after tests wipe tables)
 ./scripts/reset-db.sh        # drop, dentalpin db upgrade (core + installed modules)

--- a/backend/app/core/plugins/frontend_layers.py
+++ b/backend/app/core/plugins/frontend_layers.py
@@ -116,10 +116,16 @@ def collect_layers(modules: list[BaseModule]) -> list[LayerEntry]:
 
 
 def build_payload(entries: list[LayerEntry]) -> dict[str, object]:
+    # Deterministic output: sorted by module name, matching the
+    # alphabetical order the build-time generator
+    # (frontend/scripts/modules-json.mjs) already bakes into prod and CI.
+    # Install order must never leak into layer precedence, and any two
+    # regenerations of the same module set must be byte-identical (#264).
+    ordered = sorted(entries, key=lambda e: e.module_name)
     return {
         "version": MODULES_JSON_SCHEMA_VERSION,
-        "layers": [e.path for e in entries],
-        "modules": [{"name": e.module_name, "path": e.path} for e in entries],
+        "layers": [e.path for e in ordered],
+        "modules": [{"name": e.module_name, "path": e.path} for e in ordered],
     }
 
 

--- a/backend/tests/test_frontend_layers.py
+++ b/backend/tests/test_frontend_layers.py
@@ -103,3 +103,19 @@ def test_read_modules_json_tolerates_malformed(tmp_path: Path) -> None:
     (tmp_path / "modules.json").write_text("not json {")
     payload = read_modules_json(frontend_root=tmp_path)
     assert payload["layers"] == []
+
+
+def test_build_payload_is_deterministic_and_sorted() -> None:
+    """Install order must never leak into layer precedence (#264)."""
+    scrambled = [
+        LayerEntry(module_name="zeta", path="/module_layers/zeta/frontend"),
+        LayerEntry(module_name="alpha", path="/module_layers/alpha/frontend"),
+        LayerEntry(module_name="mid", path="/module_layers/mid/frontend"),
+    ]
+    payload = build_payload(scrambled)
+    assert payload["layers"] == [
+        "/module_layers/alpha/frontend",
+        "/module_layers/mid/frontend",
+        "/module_layers/zeta/frontend",
+    ]
+    assert payload == build_payload(list(reversed(scrambled)))

--- a/frontend/modules.json
+++ b/frontend/modules.json
@@ -1,25 +1,40 @@
 {
   "layers": [
+    "/module_layers/accounting_export/frontend",
     "/module_layers/agenda/frontend",
     "/module_layers/billing/frontend",
     "/module_layers/budget/frontend",
     "/module_layers/catalog/frontend",
+    "/module_layers/clinical_notes/frontend",
+    "/module_layers/contacts/frontend",
     "/module_layers/copilot/frontend",
+    "/module_layers/expenses/frontend",
+    "/module_layers/india_gst/frontend",
+    "/module_layers/lab_orders/frontend",
     "/module_layers/media/frontend",
+    "/module_layers/medical_reference/frontend",
+    "/module_layers/migration_import/frontend",
     "/module_layers/notifications/frontend",
     "/module_layers/odontogram/frontend",
+    "/module_layers/patient_relationships/frontend",
     "/module_layers/patient_timeline/frontend",
     "/module_layers/patients/frontend",
     "/module_layers/patients_clinical/frontend",
+    "/module_layers/payments/frontend",
+    "/module_layers/periodontogram/frontend",
+    "/module_layers/recall_reminders/frontend",
     "/module_layers/recalls/frontend",
     "/module_layers/reports/frontend",
     "/module_layers/schedules/frontend",
     "/module_layers/treatment_plan/frontend",
-    "/module_layers/clinical_notes/frontend",
-    "/module_layers/medical_reference/frontend",
-    "/module_layers/payments/frontend"
+    "/module_layers/verifactu/frontend",
+    "/module_layers/whatsapp_kapso/frontend"
   ],
   "modules": [
+    {
+      "name": "accounting_export",
+      "path": "/module_layers/accounting_export/frontend"
+    },
     {
       "name": "agenda",
       "path": "/module_layers/agenda/frontend"
@@ -37,12 +52,40 @@
       "path": "/module_layers/catalog/frontend"
     },
     {
+      "name": "clinical_notes",
+      "path": "/module_layers/clinical_notes/frontend"
+    },
+    {
+      "name": "contacts",
+      "path": "/module_layers/contacts/frontend"
+    },
+    {
       "name": "copilot",
       "path": "/module_layers/copilot/frontend"
     },
     {
+      "name": "expenses",
+      "path": "/module_layers/expenses/frontend"
+    },
+    {
+      "name": "india_gst",
+      "path": "/module_layers/india_gst/frontend"
+    },
+    {
+      "name": "lab_orders",
+      "path": "/module_layers/lab_orders/frontend"
+    },
+    {
       "name": "media",
       "path": "/module_layers/media/frontend"
+    },
+    {
+      "name": "medical_reference",
+      "path": "/module_layers/medical_reference/frontend"
+    },
+    {
+      "name": "migration_import",
+      "path": "/module_layers/migration_import/frontend"
     },
     {
       "name": "notifications",
@@ -51,6 +94,10 @@
     {
       "name": "odontogram",
       "path": "/module_layers/odontogram/frontend"
+    },
+    {
+      "name": "patient_relationships",
+      "path": "/module_layers/patient_relationships/frontend"
     },
     {
       "name": "patient_timeline",
@@ -63,6 +110,18 @@
     {
       "name": "patients_clinical",
       "path": "/module_layers/patients_clinical/frontend"
+    },
+    {
+      "name": "payments",
+      "path": "/module_layers/payments/frontend"
+    },
+    {
+      "name": "periodontogram",
+      "path": "/module_layers/periodontogram/frontend"
+    },
+    {
+      "name": "recall_reminders",
+      "path": "/module_layers/recall_reminders/frontend"
     },
     {
       "name": "recalls",
@@ -81,16 +140,12 @@
       "path": "/module_layers/treatment_plan/frontend"
     },
     {
-      "name": "clinical_notes",
-      "path": "/module_layers/clinical_notes/frontend"
+      "name": "verifactu",
+      "path": "/module_layers/verifactu/frontend"
     },
     {
-      "name": "medical_reference",
-      "path": "/module_layers/medical_reference/frontend"
-    },
-    {
-      "name": "payments",
-      "path": "/module_layers/payments/frontend"
+      "name": "whatsapp_kapso",
+      "path": "/module_layers/whatsapp_kapso/frontend"
     }
   ],
   "version": 1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint . module_layers",
     "lint:fix": "eslint . module_layers --fix",
     "typecheck": "nuxt typecheck",
-    "typecheck:layers": "node scripts/modules-json.mjs ./module_layers && nuxt typecheck",
+    "typecheck:layers": "node scripts/modules-json.mjs ./module_layers && { nuxt typecheck; ret=$?; git checkout -- modules.json; exit $ret; }",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",

--- a/frontend/scripts/modules-json.mjs
+++ b/frontend/scripts/modules-json.mjs
@@ -1,23 +1,33 @@
 // Write `modules.json` listing every module layer under <layers-root>.
 //
-//   node scripts/modules-json.mjs <layers-root>
+//   node scripts/modules-json.mjs <layers-root> [--prefix <path-prefix>]
 //
 // The backend regenerates this file at runtime as modules are installed;
 // build/CI contexts have no backend, so they bake every layer instead:
 //   Dockerfile.prod  → /module_layers            (COPY of backend/app/modules)
 //   CI e2e           → $GITHUB_WORKSPACE/backend/app/modules
 //   CI typecheck     → ./module_layers           (symlink, same trick as ESLint)
+//
+// `--prefix` decouples the emitted paths from the scanned directory: the
+// modules-json-freshness CI job scans backend/app/modules on the runner
+// but emits the canonical committed form (`/module_layers/...`, the
+// Docker mount) so the snapshot can be diffed against git (#264).
 import { existsSync, readdirSync, writeFileSync } from 'node:fs'
 
-const root = process.argv[2]
-if (!root) {
-  console.error('usage: node scripts/modules-json.mjs <layers-root>')
+const args = process.argv.slice(2)
+const prefixIdx = args.indexOf('--prefix')
+const prefix = prefixIdx === -1 ? null : args[prefixIdx + 1]
+const positional = args.filter((_, i) => prefixIdx === -1 || (i !== prefixIdx && i !== prefixIdx + 1))
+const root = positional[0]
+if (!root || (prefixIdx !== -1 && !prefix)) {
+  console.error('usage: node scripts/modules-json.mjs <layers-root> [--prefix <path-prefix>]')
   process.exit(1)
 }
+const base = prefix ?? root
 const names = readdirSync(root)
   .filter(name => existsSync(`${root}/${name}/frontend/nuxt.config.ts`))
   .sort()
-const modules = names.map(name => ({ name, path: `${root}/${name}/frontend` }))
+const modules = names.map(name => ({ name, path: `${base}/${name}/frontend` }))
 writeFileSync(
   'modules.json',
   JSON.stringify({ layers: modules.map(m => m.path), modules, version: 1 }, null, 2) + '\n'


### PR DESCRIPTION
Fixes #264 with options **1 + 3** from the issue (cheapest-first), plus making the fragile convention automatic.

## Deterministic generators (option 3)

- `frontend/scripts/modules-json.mjs` gains `--prefix`: scan one directory, emit paths under another. CI scans `backend/app/modules` on the runner but emits the **canonical committed form** (`/module_layers/...`, the Docker mount — the same shape the file has on `main` today, so runtime semantics don't change). Existing invocations without `--prefix` behave exactly as before (both modes tested).
- The backend's runtime writer now **sorts entries by module name** in `build_payload` — matching the alphabetical order the build-time generator already bakes into prod (`Dockerfile.prod`) and CI, so install order never leaks into Nuxt layer precedence and any two regenerations of the same module set are byte-identical. Covered by a new test in the `frontend_layers` suite (8/8 locally).

## CI guard (option 1)

New `modules-json-freshness` job, same pattern as `catalog-freshness`: regenerate the canonical file, `git diff --exit-code`, and on drift print the exact one-liner that fixes it. Node-only, no Python setup — it's one of the cheapest jobs in the matrix.

The committed snapshot is regenerated to the canonical form in this PR — it was **stale on `main`** (11 modules missing, unsorted), which is precisely the silent drift the issue describes; from now on it fails the PR instead.

## The convention that "demonstrably failed"

`npm run typecheck:layers` now restores `modules.json` itself after `nuxt typecheck` — **even when typecheck fails** (the restore runs before the exit-code propagates). The `git checkout modules.json` step is removed from `CLAUDE.md`. POSIX-sh construct in the npm script; CI's typecheck job calls the generator directly and is unaffected.

## Verified locally

- Generator: `--prefix` and no-prefix modes both produce the expected path forms; 29 modules, sorted.
- Guard simulation: regenerate + `git diff --exit-code` → clean on the committed snapshot.
- `npm run typecheck:layers` → exit 0, **0 TS errors with the complete 29-layer canonical file**, and `modules.json` byte-identical to the committed form afterwards (auto-restore observed).
- `ruff` clean; `frontend_layers` tests 8/8.

Not taken: option 2 (`.gitignore` + `modules.default.json`) — the committed seed still matters for docker/local cold starts, and the guard + determinism get the same protection without touching the boot path. Happy to pivot if you'd rather stop committing it.