### PR TITLE
fix(e2e): disable Nuxt devtools in e2e contexts via NUXT_DEVTOOLS=false (#260)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,8 @@ jobs:
           API_BASE_URL_SERVER: http://localhost:8000
           NITRO_HOST: 0.0.0.0
           NITRO_PORT: "3000"
+          # Devtools full-page reloads abort Playwright goto (#260).
+          NUXT_DEVTOOLS: "false"
         run: |
           nohup npm run dev > /tmp/nuxt.log 2>&1 &
           echo "nuxt started (pid $!)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,9 @@ services:
       NITRO_PORT: 3000
       NUXT_PUBLIC_API_BASE_URL: ${API_BASE_URL:-http://localhost:8000}
       NODE_OPTIONS: --max-old-space-size=4096
+      # Set NUXT_DEVTOOLS=false for a stable local e2e run — devtools
+      # full-page reloads abort Playwright navigation (#260).
+      NUXT_DEVTOOLS: ${NUXT_DEVTOOLS:-true}
     ports:
       - "3000:3000"
     depends_on:

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -55,7 +55,13 @@ export default defineNuxtConfig({
   ],
 
   devtools: {
-    enabled: true
+    // Vite devtools full-page reloads (optimizeDeps discovery and the
+    // devtools client itself) abort Playwright `goto` mid-navigation
+    // (#260). Pre-bundling @vue/devtools-* below is not enough on its
+    // own, so e2e contexts disable devtools with NUXT_DEVTOOLS=false
+    // (CI does; locally: NUXT_DEVTOOLS=false docker compose up -d
+    // frontend). Daily DX stays on by default.
+    enabled: process.env.NUXT_DEVTOOLS !== 'false'
   },
   app: {
     head: {

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -3,6 +3,9 @@
 #
 # Requirements:
 #   - the full stack is up (backend, frontend, db) via `docker compose up -d`
+#     — for a stable run start the frontend with devtools off, or Vite
+#     devtools full-page reloads abort Playwright navigation (#260):
+#       NUXT_DEVTOOLS=false docker compose up -d frontend
 #   - demo data is seeded (./scripts/seed-demo.sh)
 #   - Playwright browsers installed on host:
 #       (cd frontend && npx playwright install chromium)


### PR DESCRIPTION
Fixes #260.

## The evaluation the issue asked for

> evaluate whether pre-bundling the devtools deps (adding them, not removing) kills the reload instead

It doesn't — `@vue/devtools-core`/`@vue/devtools-kit` are **already** in `vite.optimizeDeps.include` on `main` (landed for the CI navigation races), and the aborts this issue describes postdate that. The devtools client injection itself can still trigger a full reload, so pre-bundling alone is insufficient.

## What lands

The reverted #210 approach, **inverted so DX stays on by default** (the issue's stated goal):

- `nuxt.config.ts`: `devtools.enabled: process.env.NUXT_DEVTOOLS !== 'false'` — on unless explicitly disabled.
- CI e2e job sets `NUXT_DEVTOOLS: "false"` on the dev-server step.
- `docker-compose.yml` passes the variable through (`NUXT_DEVTOOLS=false docker compose up -d frontend` for a stable local run) with the default preserving devtools.
- `scripts/e2e.sh` header documents the local recipe.
- The `optimizeDeps` devtools entries **stay** — they also guard the nprogress/vueuse discovery races and are harmless when devtools is off.

## Verified

- Dev server with `NUXT_DEVTOOLS=false`: the devtools client is **not** injected into the served HTML (0 markers) and the boot log has no DevTools banner.
- Default run: devtools injected as before — daily DX unchanged.
- CI's own e2e job on this PR exercises the new flag end-to-end.
- `eslint nuxt.config.ts` clean.