### PR TITLE
feat(i18n): ship Polish (pl) and Italian (it) — core app, 2422 keys each

### DIFF
--- a/frontend/app/constants/languages.ts
+++ b/frontend/app/constants/languages.ts
@@ -5,5 +5,7 @@ export const SUPPORTED_LOCALES = [
   'pt',
   'ta',
   'de',
-  'hu'
+  'hu',
+  'pl',
+  'it'
 ] as const

--- a/frontend/i18n/i18n.config.ts
+++ b/frontend/i18n/i18n.config.ts
@@ -7,5 +7,18 @@
 export default defineI18nConfig(() => ({
   fallbackLocale: 'en',
   missingWarn: false,
-  fallbackWarn: false
+  fallbackWarn: false,
+  pluralRules: {
+    // Polish needs three plural forms — [one, few, many]: 1 klient,
+    // 2-4 klienci (except 12-14), 0/5+ klientów. vue-i18n's default
+    // two-way rule cannot express this; pl.json messages carry three
+    // pipe-separated forms in that order (#144).
+    pl: (choice: number, choicesLength: number) => {
+      if (choice === 1) return 0
+      const teen = choice % 100 >= 12 && choice % 100 <= 14
+      const few = choice % 10 >= 2 && choice % 10 <= 4 && !teen
+      if (choicesLength === 2) return 1
+      return few ? 1 : 2
+    }
+  }
 }))

--- a/frontend/i18n/locales/it.json
+++ b/frontend/i18n/locales/it.json
@@ -1,0 +1,3052 @@
+{
+  "app": {
+    "name": "DentalPin",
+    "tagline": "Gestione dello studio dentistico"
+  },
+  "demo": {
+    "bannerMessage": "Demo pubblica — non inserire dati reali dei pazienti. Il database viene azzerato periodicamente.",
+    "bannerDismiss": "Nascondi",
+    "credentialsTitle": "Credenziali demo",
+    "credentialsNote": "Solo per la valutazione — visibile perché questa è un'istanza demo pubblica.",
+    "copyEmail": "Copia e-mail",
+    "copyPassword": "Copia password",
+    "copied": "Copiato negli appunti"
+  },
+  "nav": {
+    "dashboard": "Home",
+    "patients": "Pazienti",
+    "appointments": "Agenda",
+    "recalls": "Richiami",
+    "treatmentPlans": "Piani di cura",
+    "budgets": "Preventivi",
+    "invoices": "Fatture",
+    "reports": "Report",
+    "settings": "Impostazioni",
+    "defaultClinicName": "Studio",
+    "catalog": "Listino prestazioni",
+    "contacts": "Contatti",
+    "expenses": "Spese",
+    "labOrdersForm": "Nuovo ordine di laboratorio",
+    "labOrdersStatus": "Ordini di laboratorio",
+    "menu": "Menu",
+    "openMenu": "Apri menu",
+    "close": "Chiudi",
+    "toggleSidebar": "Mostra/nascondi barra laterale"
+  },
+  "auth": {
+    "login": "Accedi",
+    "logout": "Esci",
+    "email": "E-mail",
+    "password": "Password",
+    "loginButton": "Accedi",
+    "loginSuccess": "Accesso effettuato",
+    "invalidCredentials": "E-mail o password errati",
+    "emailRequired": "Inserisci la tua e-mail",
+    "passwordRequired": "Inserisci la tua password",
+    "emailInvalid": "Indirizzo e-mail non valido",
+    "accountInactive": "Il tuo account non è attivo. Contatta l'amministratore",
+    "tooManyAttempts": "Troppi tentativi. Riprova tra qualche minuto",
+    "sessionExpired": "La tua sessione è scaduta",
+    "networkError": "Impossibile connettersi al server",
+    "serverError": "Il server non è disponibile. Riprova tra qualche minuto",
+    "unknownError": "Errore imprevisto. Riprova"
+  },
+  "setup": {
+    "title": "Prima configurazione",
+    "subtitle": "Crea il tuo account e il tuo studio. Sarai operativo in due minuti.",
+    "stepAccount": "Account amministratore",
+    "stepClinic": "Dati dello studio",
+    "firstName": "Nome",
+    "lastName": "Cognome",
+    "email": "E-mail",
+    "password": "Password",
+    "passwordConfirm": "Conferma password",
+    "passwordHint": "Almeno 8 caratteri, con lettere e numeri",
+    "clinicName": "Nome dello studio",
+    "taxId": "Partita IVA",
+    "next": "Avanti",
+    "back": "Indietro",
+    "submit": "Crea il mio studio",
+    "success": "Fatto! Benvenuto in DentalPin",
+    "firstNameRequired": "Inserisci il nome",
+    "lastNameRequired": "Inserisci il cognome",
+    "emailRequired": "Inserisci l'e-mail",
+    "emailInvalid": "L'e-mail non è valida",
+    "passwordRequired": "Inserisci una password",
+    "passwordTooShort": "La password deve avere almeno 8 caratteri",
+    "passwordWeak": "La password deve contenere lettere e numeri",
+    "passwordMismatch": "Le password non coincidono",
+    "clinicNameRequired": "Inserisci il nome dello studio",
+    "taxIdRequired": "Inserisci la partita IVA",
+    "alreadyInitialized": "Il sistema è già configurato. Accedi.",
+    "error": "Impossibile completare la configurazione. Riprova",
+    "stepOf": "Passo {current} di {total}",
+    "country": "Paese",
+    "countryHelp": "Imposta per te tasse, valuta e fuso orario",
+    "countryRequired": "Seleziona un paese",
+    "taxIdGeneric": "Codice fiscale / partita IVA",
+    "taxIdLooksInvalid": "Non sembra un identificativo fiscale valido. Verificalo prima di fatturare.",
+    "taxIdFormat": "Formato non valido (esempio: {example})",
+    "timezoneRequired": "Seleziona un fuso orario",
+    "currencyRequired": "Seleziona una valuta",
+    "derivedSettings": "Fuso orario e valuta",
+    "willSeed": "Creeremo per te il listino prestazioni, le aliquote IVA, una serie di fatturazione, un riunito e un orario dal lunedì al venerdì. Tutto è modificabile in seguito.",
+    "willSuggestVerifactu": "In seguito ti proporremo di attivare VeriFactu.",
+    "invalidData": "Controlla i dati: un campo non è valido."
+  },
+  "onboarding": {
+    "title": "Primi passi",
+    "progress": "{done} di {total} passi completati",
+    "configure": "Configura",
+    "skip": "Salta",
+    "unskip": "Annulla",
+    "dismiss": "Nascondi",
+    "guidedMode": "Modalità guidata",
+    "optional": "Facoltativi ({count})",
+    "stepOf": "Passo {current} di {total}",
+    "next": "Avanti",
+    "finish": "Termina",
+    "exit": "Esci",
+    "completedTitle": "Il tuo studio è pronto!",
+    "completedDescription": "La configurazione è completata. Ora puoi lavorare normalmente.",
+    "guidedDoneTitle": "Tour completato",
+    "guidedDoneDescription": "Nessun passo in sospeso.",
+    "items": {
+      "team": {
+        "label": "Il tuo team",
+        "description": "Aggiungi i professionisti che visitano i pazienti, oppure contrassegnati come professionista se lavori da solo."
+      },
+      "verifactu": {
+        "label": "Attiva VeriFactu",
+        "description": "Richiesto in Spagna per emettere fatture valide per l'agenzia delle entrate (AEAT)."
+      }
+    }
+  },
+  "actions": {
+    "edit": "Modifica",
+    "cancel": "Annulla",
+    "save": "Salva",
+    "create": "Crea",
+    "delete": "Elimina",
+    "close": "Chiudi",
+    "remove": "Rimuovi"
+  },
+  "patients": {
+    "title": "Pazienti",
+    "create": "Nuovo paziente",
+    "edit": "Modifica paziente",
+    "search": "Cerca paziente...",
+    "searchPlaceholder": "Nome o telefono",
+    "noResults": "Nessun paziente trovato",
+    "empty": "Nessun paziente registrato",
+    "emptyAction": "Crea il primo paziente",
+    "name": "Nome",
+    "firstName": "Nome",
+    "lastName": "Cognome",
+    "phone": "Telefono",
+    "email": "E-mail",
+    "dateOfBirth": "Data di nascita",
+    "notes": "Note",
+    "created": "Paziente creato",
+    "updated": "Paziente aggiornato",
+    "archived": "Paziente archiviato",
+    "notFound": "Paziente non trovato",
+    "archiveConfirm": "Archiviare il paziente {name}?",
+    "archiveDescription": "Il paziente verrà nascosto dalle ricerche. Gli appuntamenti esistenti non saranno eliminati.",
+    "cancel": "Annulla",
+    "archive": "Archivia",
+    "dangerZone": {
+      "title": "Zona di rischio",
+      "archiveHelp": "Archivia il paziente per nasconderlo dalle ricerche. Appuntamenti e storico vengono conservati."
+    },
+    "billingSection": "Dati di fatturazione",
+    "billingSectionHint": "Questi dati verranno usati automaticamente nella creazione delle fatture per questo paziente.",
+    "editingBillingForInvoice": "Modifica dei dati di fatturazione. Le modifiche appariranno in fattura.",
+    "returnToInvoice": "Torna alla fattura",
+    "billingName": "Intestazione fattura",
+    "billingNamePlaceholder": "Nome o ragione sociale per le fatture",
+    "billingTaxId": "Codice fiscale / P. IVA",
+    "billingEmail": "E-mail di fatturazione",
+    "billingAddress": "Indirizzo di fatturazione",
+    "billingComplete": "Completi",
+    "billingIncomplete": "Incompleti",
+    "demographics": "Dati anagrafici",
+    "nationalId": "Documento d'identità",
+    "nationalIdType": "Tipo di documento",
+    "passport": "Passaporto",
+    "profession": "Professione",
+    "workplace": "Luogo di lavoro",
+    "years": "anni",
+    "status": {
+      "active": "Attivo",
+      "archived": "Archiviato"
+    },
+    "filters": {
+      "status": "Stato",
+      "city": "Città",
+      "withDebt": "Con debito",
+      "doNotContact": "Non contattare",
+      "doNotContactOnly": "Solo da non contattare",
+      "doNotContactOnlyContactable": "Solo contattabili"
+    },
+    "columns": {
+      "city": "Città",
+      "contact": "Contatto",
+      "debt": "Debito"
+    },
+    "sort": {
+      "lastVisit": "Ultima visita",
+      "lastName": "Cognome",
+      "firstName": "Nome",
+      "createdAt": "Registrato",
+      "updatedAt": "Modificati di recente"
+    },
+    "doNotContact": {
+      "label": "Non contattare",
+      "hint": "Il paziente sarà escluso dalla lista chiamate e dalle comunicazioni automatiche",
+      "badge": "Non contattare"
+    },
+    "gender": {
+      "label": "Sesso",
+      "select": "Seleziona il sesso",
+      "male": "Maschio",
+      "female": "Femmina",
+      "other": "Altro",
+      "preferNotSay": "Preferisco non dirlo"
+    },
+    "emergencyContact": {
+      "title": "Contatto di emergenza",
+      "hasContact": "Ha un contatto di emergenza",
+      "noContact": "Nessun contatto di emergenza registrato",
+      "name": "Nome completo",
+      "namePlaceholder": "Nome del contatto",
+      "relationship": "Relazione",
+      "relationshipPlaceholder": "Seleziona la relazione",
+      "phone": "Telefono",
+      "phonePlaceholder": "Telefono del contatto",
+      "email": "E-mail",
+      "emailPlaceholder": "E-mail del contatto",
+      "isLegalGuardian": "È il tutore legale",
+      "remove": "Rimuovi contatto",
+      "relationships": {
+        "spouse": "Coniuge",
+        "parent": "Genitore",
+        "child": "Figlio/a",
+        "sibling": "Fratello/sorella",
+        "friend": "Amico/a",
+        "other": "Altro"
+      }
+    },
+    "medicalHistory": {
+      "title": "Anamnesi",
+      "save": "Salva anamnesi",
+      "fetchError": "Errore nel caricamento dell'anamnesi",
+      "saveSuccess": "Anamnesi salvata",
+      "saveError": "Errore nel salvataggio dell'anamnesi",
+      "allergies": "Allergie",
+      "allergiesCount": "{n} allergia | {n} allergie",
+      "onAnticoagulants": "In terapia anticoagulante",
+      "allergyName": "Nome dell'allergia",
+      "type": "Tipo",
+      "allergyTypes": {
+        "drug": "Farmaco",
+        "food": "Alimento",
+        "material": "Materiale",
+        "environmental": "Ambientale"
+      },
+      "severity": {
+        "low": "Lieve",
+        "medium": "Media",
+        "high": "Grave",
+        "critical": "Critica"
+      },
+      "medications": "Farmaci",
+      "medicationName": "Nome del farmaco",
+      "dosage": "Posologia",
+      "frequency": "Frequenza",
+      "systemicDiseases": "Malattie sistemiche",
+      "diseaseName": "Nome della malattia",
+      "diseaseTypes": {
+        "cardiovascular": "Cardiovascolare",
+        "respiratory": "Respiratoria",
+        "endocrine": "Endocrina",
+        "neurological": "Neurologica",
+        "autoimmune": "Autoimmune",
+        "other": "Altra"
+      },
+      "critical": "Critica",
+      "controlled": "Compensata",
+      "notControlled": "Non compensata",
+      "specialConditions": "Condizioni particolari",
+      "pregnant": "In gravidanza",
+      "pregnancyWeek": "Settimana di gravidanza",
+      "lactating": "In allattamento",
+      "anticoagulants": "Anticoagulanti",
+      "anticoagulantMedication": "Farmaco anticoagulante",
+      "inrValue": "Valore INR",
+      "anesthesiaReaction": "Reazione all'anestesia",
+      "anesthesiaReactionDetails": "Dettagli della reazione",
+      "bruxism": "Bruxismo",
+      "lifestyle": "Stile di vita",
+      "smoker": "Fumatore",
+      "smokingFrequency": "Sigarette al giorno",
+      "alcoholConsumption": "Consumo di alcol",
+      "alcohol": {
+        "none": "Nessuno",
+        "occasional": "Occasionale",
+        "moderate": "Moderato",
+        "heavy": "Elevato"
+      },
+      "surgicalHistory": "Interventi pregressi",
+      "procedure": "Intervento"
+    },
+    "timeline": {
+      "empty": "Nessuna attività registrata",
+      "emptyFiltered": "Nessun evento in questa categoria",
+      "clearFilter": "Mostra tutta l'attività",
+      "endOfTimeline": "Fine della cronologia",
+      "totalEntries": "{count} voce | {count} voci",
+      "groups": {
+        "today": "Oggi",
+        "yesterday": "Ieri",
+        "thisWeek": "Questa settimana",
+        "thisMonth": "Questo mese",
+        "earlier": "In precedenza"
+      },
+      "author": "di {name}",
+      "meta": {
+        "cabinet": "Riunito {name}",
+        "teeth": "Denti: {list}",
+        "total": "Totale: {amount}",
+        "number": "N. {value}",
+        "via": "Tramite {channel}",
+        "template": "Modello: {key}",
+        "docType": "Tipo: {type}"
+      },
+      "categories": {
+        "all": "Tutte",
+        "visit": "Visite",
+        "treatment": "Trattamenti",
+        "financial": "Finanze",
+        "communication": "Comunicazioni",
+        "medical": "Anamnesi",
+        "document": "Documenti",
+        "note": "Note cliniche"
+      }
+    },
+    "alerts": {
+      "title": "{count} avviso | {count} avvisi",
+      "label": "Avvisi clinici"
+    },
+    "editDemographics": "Modifica dati anagrafici",
+    "editEmergencyContact": "Modifica contatto di emergenza",
+    "editBilling": "Modifica dati di fatturazione",
+    "editMedicalHistory": "Modifica anamnesi",
+    "medicalSnapshot": {
+      "title": "Informazioni mediche",
+      "allergiesLabel": "Allergie",
+      "allergiesEmpty": "Nessuna allergia nota",
+      "allergiesNotReviewed": "Anamnesi non registrata",
+      "completeHistory": "Completa l'anamnesi",
+      "reviewedOn": "Verificata il {date}",
+      "conditions": {
+        "pregnantWeek": "In gravidanza · sett. {week}",
+        "anticoagulantInr": "Anticoagulante · INR {inr}",
+        "smokerFreq": "Fumatore · {freq}/giorno"
+      }
+    },
+    "personalInfo": {
+      "title": "Dati personali",
+      "ageLabel": "{age} anni",
+      "birthWithAge": "{date} ({age} anni)"
+    },
+    "contactInfo": {
+      "title": "Contatto",
+      "copyPhone": "Copia telefono",
+      "copyEmail": "Copia e-mail",
+      "address": "Indirizzo",
+      "addEmergency": "Aggiungi contatto di emergenza",
+      "addGuardian": "Aggiungi tutore legale",
+      "guardianRequired": "Tutore legale obbligatorio"
+    },
+    "administrative": {
+      "title": "Amministrazione"
+    },
+    "header": {
+      "ariaLabel": "Intestazione del paziente"
+    },
+    "quickActions": {
+      "ariaLabel": "Azioni rapide del paziente"
+    },
+    "onboarding": {
+      "label": "Crea il tuo primo paziente",
+      "description": "Il modo più rapido per vedere in azione cartella, agenda e preventivi."
+    }
+  },
+  "patientDetail": {
+    "tabs": {
+      "summary": "Riepilogo",
+      "info": "Dati",
+      "clinical": "Clinica",
+      "odontogram": "Odontogramma",
+      "administration": "Amministrazione",
+      "history": "Storico",
+      "timeline": "Attività",
+      "appointments": "Appuntamenti",
+      "budgets": "Preventivi",
+      "billing": "Fatturazione",
+      "payments": "Pagamenti",
+      "documents": "Documenti",
+      "gallery": "Galleria"
+    },
+    "historyPlaceholder": "Note cliniche disponibili in una versione futura",
+    "noAppointments": "Questo paziente non ha appuntamenti",
+    "scheduleAppointment": "Fissa un appuntamento",
+    "noBudgets": "Questo paziente non ha preventivi",
+    "createBudget": "Crea preventivo",
+    "viewAllBudgets": "Vedi tutti i preventivi",
+    "activePlan": "Piano attivo",
+    "noActivePlan": "Nessun piano attivo",
+    "viewPlan": "Apri piano",
+    "createPlan": "Crea piano",
+    "nextAppointment": "Prossimo appuntamento",
+    "noUpcomingAppointments": "Nessun appuntamento in programma",
+    "openAppointment": "Apri appuntamento",
+    "lastVisit": "Ultima visita",
+    "neverVisited": "Mai venuto",
+    "reschedule": "Riprogramma",
+    "balance": "Saldo",
+    "collect": "Incassa",
+    "viewLedger": "Apri estratto conto",
+    "noPayments": "Nessun movimento",
+    "diagnoses": "Diagnosi",
+    "pending": "non trattate",
+    "noDiagnoses": "Nessun reperto in sospeso",
+    "openOdontogram": "Apri odontogramma",
+    "medicalHistory": "Anamnesi",
+    "completeMedicalHistory": "Anamnesi assente. Completala per registrare allergie, patologie e farmaci.",
+    "editMedicalHistory": "Modifica anamnesi",
+    "quickActions": "Azioni rapide",
+    "edit": "Modifica",
+    "editPatient": "Modifica paziente",
+    "noSummaryCards": "Nessun modulo registrato nel riepilogo.",
+    "actions": {
+      "label": "Azioni",
+      "newAppointment": "Appuntamento",
+      "collect": "Incassa",
+      "newNote": "Nota",
+      "newBudget": "Preventivo",
+      "uploadDocument": "Documento"
+    }
+  },
+  "patientBilling": {
+    "totalBudgeted": "Totale preventivato",
+    "workInProgress": "Lavori in corso",
+    "workCompleted": "Lavori completati",
+    "totalInvoiced": "Totale fatturato",
+    "totalPaid": "Totale incassato",
+    "balancePending": "Saldo in sospeso",
+    "invoices": "Fatture",
+    "createInvoice": "Crea fattura",
+    "noInvoices": "Questo paziente non ha fatture",
+    "pending": "In sospeso",
+    "totalDiscount": "di sconti"
+  },
+  "odontogram": {
+    "title": "Odontogramma",
+    "tooth": "Dente",
+    "globals": {
+      "category": "Bocca intera",
+      "applied": "{name} aggiunto al piano",
+      "archPickerTitle": "Quale arcata per \"{name}\"?",
+      "upperArch": "Arcata superiore",
+      "lowerArch": "Arcata inferiore",
+      "searchPlaceholder": "Cerca trattamento…"
+    },
+    "selectCondition": "Seleziona condizione",
+    "readOnly": "Sola lettura",
+    "legend": "Legenda",
+    "statusLegend": "Stato del trattamento",
+    "toothPosition": "Posizione del dente",
+    "displaced": "Dislocato",
+    "rotated": "Ruotato",
+    "dentition": {
+      "permanent": "Permanente",
+      "deciduous": "Decidua",
+      "toggle": "Cambia dentizione"
+    },
+    "quadrants": {
+      "upper": "Arcata superiore",
+      "lower": "Arcata inferiore",
+      "upperRight": "Superiore destro",
+      "upperLeft": "Superiore sinistro",
+      "lowerRight": "Inferiore destro",
+      "lowerLeft": "Inferiore sinistro"
+    },
+    "surfaces": {
+      "M": "Mesiale",
+      "D": "Distale",
+      "O": "Occlusale",
+      "V": "Vestibolare",
+      "L": "Linguale"
+    },
+    "conditions": {
+      "healthy": "Sano",
+      "caries": "Carie",
+      "filling": "Otturazione",
+      "crown": "Corona",
+      "missing": "Mancante",
+      "root_canal": "Devitalizzazione",
+      "implant": "Impianto",
+      "bridge_pontic": "Elemento intermedio",
+      "bridge_abutment": "Pilastro di ponte",
+      "extraction_indicated": "Estrazione indicata",
+      "sealant": "Sigillatura",
+      "fracture": "Frattura"
+    },
+    "history": {
+      "title": "Cronologia modifiche",
+      "noChanges": "Nessuna modifica registrata",
+      "changedBy": "Modificato da",
+      "changeTypes": {
+        "created": "Creato",
+        "general_condition": "Condizione generale",
+        "surface_update": "Aggiornamento superficie",
+        "note": "Nota"
+      }
+    },
+    "messages": {
+      "updated": "Odontogramma aggiornato",
+      "error": "Errore nell'aggiornamento dell'odontogramma",
+      "loadError": "Impossibile caricare l'odontogramma"
+    },
+    "actions": {
+      "save": "Salva",
+      "reset": "Ripristina",
+      "print": "Stampa"
+    },
+    "status": {
+      "existing": "Esistente",
+      "planned": "Pianificato"
+    },
+    "treatments": {
+      "title": "Trattamenti",
+      "addTreatment": "Aggiungi trattamento",
+      "selectStatus": "Seleziona stato",
+      "noTreatments": "Nessun trattamento registrato",
+      "markPerformed": "Segna come eseguito",
+      "categories": {
+        "common": "Frequenti",
+        "restorative": "Conservativa",
+        "diagnostic": "Diagnostica",
+        "orthodontic": "Ortodonzia",
+        "periodontic": "Parodontologia",
+        "position": "Posizione",
+        "other": "Altro",
+        "diagnostico": "Diagnostica",
+        "restauradora": "Conservativa",
+        "cirugia": "Chirurgia",
+        "endodoncia": "Endodonzia",
+        "ortodoncia": "Ortodonzia"
+      },
+      "types": {
+        "pulpitis": "Pulpite",
+        "caries": "Carie",
+        "incipient_caries": "Carie iniziale",
+        "pigmentation": "Pigmentazione",
+        "fracture": "Frattura",
+        "missing": "Mancante",
+        "periapical_small": "Periapicale <2mm",
+        "periapical_medium": "Periapicale 2-4mm",
+        "periapical_large": "Periapicale >4mm",
+        "rotated": "Ruotato",
+        "displaced": "Dislocato",
+        "unerupted": "Non erotto",
+        "filling": "Otturazione",
+        "filling_composite": "Otturazione in composito",
+        "filling_amalgam": "Otturazione in amalgama",
+        "filling_temporary": "Otturazione provvisoria",
+        "sealant": "Sigillatura",
+        "veneer": "Faccetta",
+        "inlay": "Inlay",
+        "overlay": "Overlay",
+        "crown": "Corona",
+        "crown_on_implant": "Corona su impianto",
+        "provisional_crown_on_implant": "Corona provvisoria su impianto",
+        "pontic": "Elemento intermedio",
+        "bridge_pontic": "Elemento intermedio",
+        "bridge_abutment": "Pilastro di ponte",
+        "extraction": "Estrazione",
+        "implant": "Impianto",
+        "apicoectomy": "Apicectomia",
+        "root_canal": "Devitalizzazione",
+        "root_canal_full": "Otturazione canalare completa",
+        "root_canal_two_thirds": "Otturazione canalare 2/3",
+        "root_canal_half": "Otturazione canalare 1/2",
+        "root_canal_overfill": "Otturazione canalare in eccesso",
+        "post": "Perno",
+        "bracket": "Bracket",
+        "tube": "Tubo",
+        "band": "Banda",
+        "attachment": "Attachment",
+        "retainer": "Retainer",
+        "rotate": "Ruotato",
+        "displace": "Dislocato",
+        "splint": "Splintaggio",
+        "migrated": "Trattamento generale",
+        "other": "Altro trattamento"
+      },
+      "treatmentAdded": "Trattamento aggiunto",
+      "treatmentPerformed": "Trattamento segnato come eseguito",
+      "treatmentDeleted": "Trattamento eliminato",
+      "status": {
+        "existing": "Esistente",
+        "planned": "Pianificato"
+      }
+    },
+    "position": {
+      "displaced": "Dislocato",
+      "rotated": "Ruotato",
+      "normal": "Normale"
+    },
+    "views": {
+      "occlusal": "Vista occlusale",
+      "lateral": "Vista laterale",
+      "dual": "Vista doppia"
+    },
+    "selectSurfaces": "Seleziona superfici",
+    "selectedSurfaces": "Superfici selezionate",
+    "surfacesSelected": "superfici selezionate",
+    "instructions": {
+      "selectTreatment": "Seleziona un trattamento da applicare",
+      "clickTooth": "Fai clic sul dente per applicarlo"
+    },
+    "addToPlan": "Aggiungi al piano",
+    "noPlan": "Nessun piano",
+    "createNewPlan": "Crea nuovo piano...",
+    "applyTo": "Applica a",
+    "oneTooth": "1 dente",
+    "multipleTeeth": "Più denti",
+    "surfacePricingHint": "Prezzo per superficie: {range}",
+    "toothNames": {
+      "centralIncisor": "Incisivo centrale",
+      "lateralIncisor": "Incisivo laterale",
+      "canine": "Canino",
+      "firstPremolar": "Primo premolare",
+      "secondPremolar": "Secondo premolare",
+      "firstMolar": "Primo molare",
+      "secondMolar": "Secondo molare",
+      "thirdMolar": "Terzo molare (dente del giudizio)"
+    },
+    "positions": {
+      "upper": "superiore",
+      "lower": "inferiore",
+      "left": "sinistro",
+      "right": "destro"
+    },
+    "tooltip": {
+      "clickToEdit": "Fai clic per modificare"
+    },
+    "planning": "Pianificazione",
+    "diagnosisMode": "Diagnosi",
+    "treatmentList": {
+      "title": "Elenco trattamenti",
+      "noTreatments": "Nessun trattamento registrato"
+    },
+    "changeHistory": {
+      "title": "Cronologia modifiche",
+      "noChanges": "Nessuna modifica registrata",
+      "treatmentAdded": "Trattamento"
+    },
+    "timeline": {
+      "title": "Linea temporale",
+      "viewingDate": "Visualizzazione: {date}",
+      "viewingHistory": "Stai visualizzando lo stato storico dell'odontogramma",
+      "returnToNow": "Torna allo stato attuale",
+      "noHistory": "Nessuna cronologia precedente"
+    },
+    "multiTooth": {
+      "bridge": {
+        "label": "Ponte fisso"
+      },
+      "splint": {
+        "label": "Splintaggio"
+      },
+      "veneers": {
+        "label": "Più faccette"
+      },
+      "crowns": {
+        "label": "Più corone"
+      },
+      "pillar": "pilastro",
+      "pontic": "elemento intermedio",
+      "roleHint": "Fai clic su un dente per alternare pilastro / elemento intermedio.",
+      "needPillar": "Il ponte richiede almeno un dente pilastro.",
+      "confirmHint": "Stai per creare un gruppo di trattamenti con {n} denti.",
+      "willBePlanned": "Il gruppo sarà contrassegnato come pianificato.",
+      "willBeExisting": "Il gruppo sarà registrato come esistente.",
+      "hints": {
+        "range": "Fai clic sul primo dente, poi sull'ultimo",
+        "free": "Fai clic per aggiungere o rimuovere denti"
+      },
+      "errors": {
+        "tooFew": "Servono almeno {n} denti",
+        "tooMany": "Sono ammessi al massimo {n} denti",
+        "sameArchRequired": "I denti devono trovarsi nella stessa arcata"
+      },
+      "sectionLabel": "Trattamenti su più denti"
+    }
+  },
+  "clinical": {
+    "modes": {
+      "history": "Storico",
+      "diagnosis": "Diagnosi",
+      "plans": "Piani di cura",
+      "appointments": "Appuntamenti"
+    },
+    "history": {
+      "stateAt": "Stato al",
+      "changesOnDate": "Modifiche in questa data",
+      "noChanges": "Nessuna modifica registrata"
+    },
+    "diagnosis": {
+      "registeredConditions": "Condizioni diagnosticate",
+      "registerConditions": "Registra condizioni",
+      "noConditions": "Nessuna condizione registrata",
+      "startDiagnosis": "Seleziona un dente e aggiungi le condizioni esistenti",
+      "generalConditions": "Condizioni generali",
+      "readyToCreatePlan": "Diagnosi completata?",
+      "createPlan": "Crea piano di cura",
+      "continuePlan": "Continua il piano \"{name}\"",
+      "selectPlan": "Seleziona piano",
+      "continue": "Continua",
+      "odontogramTab": "Odontogramma"
+    },
+    "plans": {
+      "title": "Piani di cura",
+      "create": "Nuovo piano",
+      "backToList": "Torna ai piani",
+      "treatments": "Trattamenti del piano",
+      "addTreatment": "Aggiungi trattamento",
+      "total": "Totale",
+      "activate": "Attiva piano",
+      "generateBudget": "Genera preventivo",
+      "empty": "Nessun piano di cura",
+      "emptyDescription": "Crea un piano per organizzare i trattamenti del paziente",
+      "createFirst": "Crea il primo piano",
+      "active": "Piani attivi",
+      "drafts": "Bozze",
+      "completed": "Completati",
+      "closed": "Chiusi",
+      "other": "Altri",
+      "noItems": "Nessun trattamento nel piano",
+      "markComplete": "Segna come completato",
+      "removeItem": "Rimuovi dal piano",
+      "sessions": {
+        "progress": "{done}/{total} sedute",
+        "markDone": "Segna la seduta come eseguita",
+        "cancel": "Annulla seduta",
+        "markedDone": "Seduta segnata come eseguita",
+        "cancelled": "Seduta annullata",
+        "untitled": "Seduta {n}"
+      },
+      "unknownTreatment": "Trattamento",
+      "odontogram": "Odontogramma",
+      "pending": "in sospeso",
+      "dragToReorder": "Trascina per riordinare",
+      "reorderHint": "Sposta con Alt + frecce",
+      "emptyDraft": {
+        "title": "Pianifica i trattamenti",
+        "step1": "Scegli un trattamento dalla barra qui sotto",
+        "step2": "Fai clic su un dente nell'odontogramma",
+        "step3": "Conferma il piano per generare preventivo e appuntamenti"
+      },
+      "steps": {
+        "plan": "Pianifica",
+        "confirm": "Conferma",
+        "inProgress": "In corso"
+      },
+      "confirmCta": {
+        "titleWithItems": "Conferma il piano",
+        "subtitleWithItems": "La conferma sblocca la generazione del preventivo e la programmazione degli appuntamenti.",
+        "empty": "Aggiungi almeno un trattamento per confermare il piano"
+      },
+      "ghostHint": "Disponibile dopo la conferma del piano",
+      "addedToPlan": "Aggiunto al piano",
+      "addingToPlan": "Aggiunta a questo piano",
+      "cancelPlan": "Annulla piano",
+      "locked": {
+        "title": "Piano bloccato",
+        "subtitle": "Il preventivo {number} è stato emesso. Per modificare i trattamenti usa Riapri (se in sospeso) o rinegozia il preventivo.",
+        "viewBudget": "Vedi preventivo"
+      }
+    },
+    "tooth": "Dente"
+  },
+  "appointments": {
+    "title": "Agenda",
+    "create": "Nuovo appuntamento",
+    "edit": "Modifica appuntamento",
+    "today": "Oggi",
+    "tomorrow": "Domani",
+    "yesterday": "Ieri",
+    "week": "Settimana",
+    "prevWeek": "Settimana precedente",
+    "nextWeek": "Settimana successiva",
+    "selectPatient": "Seleziona paziente",
+    "selectProfessional": "Seleziona professionista",
+    "openPatientFile": "Apri cartella del paziente",
+    "patient": "Paziente",
+    "professional": "Professionista",
+    "cabinet": "Riunito",
+    "date": "Data",
+    "time": "Ora",
+    "startTime": "Inizio",
+    "duration": "Durata",
+    "treatmentType": "Tipo di trattamento",
+    "treatments": "Trattamenti",
+    "addTreatment": "Aggiungi trattamento",
+    "selectTreatment": "Seleziona trattamento",
+    "estimatedDuration": "Durata stimata",
+    "notes": "Note",
+    "hasNotes": "Ha note",
+    "actionsMenu": "Azioni dell'appuntamento",
+    "status": {
+      "label": "Stato",
+      "scheduled": "Programmato",
+      "confirmed": "Confermato",
+      "checked_in": "In sala d'attesa",
+      "in_treatment": "Al riunito",
+      "completed": "Completato",
+      "cancelled": "Annullato",
+      "no_show": "Assente"
+    },
+    "scheduled": "Programmato",
+    "confirmed": "Confermato",
+    "inProgress": "In corso",
+    "in_progress": "In corso",
+    "completed": "Completato",
+    "cancelled": "Annullato",
+    "noShow": "Assente",
+    "no_show": "Assente",
+    "transitions": {
+      "confirmed": "Segna come confermato",
+      "checked_in": "Registra l'arrivo",
+      "in_treatment": "Porta al riunito",
+      "completed": "Concludi appuntamento",
+      "cancelled": "Annulla appuntamento",
+      "no_show": "Segna come assente"
+    },
+    "timer": {
+      "startsIn": "inizia tra {minutes} min",
+      "startsInOverdue": "{minutes} min di ritardo",
+      "waiting": "in attesa da {minutes} min",
+      "inTreatment": "{elapsed}/{planned} min",
+      "completedAt": "terminato {time}",
+      "cancelledAt": "annullato",
+      "noShowAt": "assente"
+    },
+    "confirmTransitionTitle": "Conferma il cambio di stato",
+    "confirmCancelMessage": "Annullare questo appuntamento? La modifica sarà registrata.",
+    "confirmNoShowMessage": "Segnare questo paziente come assente? La modifica sarà registrata.",
+    "noteLabel": "Nota (facoltativa)",
+    "transitionFailed": "Impossibile cambiare lo stato dell'appuntamento",
+    "when": "Quando",
+    "whereWho": "Riunito e professionista",
+    "followup": {
+      "title": "Azioni post-appuntamento"
+    },
+    "created": "Appuntamento creato",
+    "saved": "Appuntamento salvato",
+    "updated": "Appuntamento aggiornato",
+    "conflict": "Questa fascia oraria è già occupata",
+    "cancel": "Annulla appuntamento",
+    "markCompleted": "Segna come completato",
+    "markNoShow": "Assente",
+    "dailyView": "Giorno",
+    "weeklyView": "Settimana",
+    "kanbanView": "Kanban",
+    "kanban": {
+      "upcoming": "In arrivo",
+      "waiting": "Sala d'attesa",
+      "inChair": "Al riunito",
+      "done": "Completati",
+      "missed": "Assenti / Annullati",
+      "free": "Libero",
+      "inactive": "Inattivo",
+      "empty": "Nessun appuntamento",
+      "nextIn": "Prossimo alle {time}",
+      "subtitleCount": "{count} appuntamenti",
+      "subtitleEmpty": "Nessun appuntamento",
+      "subtitleWaiting": "{count} in attesa · media {avg} min",
+      "subtitleInChair": "{busy} occupati · {free} liberi"
+    },
+    "cabinetAssignment": {
+      "assignLater": "Assegna più tardi",
+      "unassigned": "Non assegnato",
+      "assign": "Assegna riunito",
+      "reassign": "Riassegna riunito",
+      "unassign": "Rimuovi assegnazione",
+      "requiredForTreatment": "Assegna un riunito prima di passare al trattamento"
+    },
+    "professionals": {
+      "strip": "Professionisti",
+      "state": {
+        "free": "Libero",
+        "in_treatment": "Al riunito",
+        "on_break": "In pausa",
+        "off": "Non in servizio"
+      }
+    },
+    "noProfessionals": "Nessun professionista configurato",
+    "overlapWarning": "Sovrapposizioni rilevate",
+    "overlapProfessional": "Il professionista ha {count} appuntamenti in questo orario",
+    "overlapCabinet": "Il riunito ha {count} appuntamenti in questo orario",
+    "selectDuration": "Seleziona la durata...",
+    "sendEmail": "Invia e-mail",
+    "sendConfirmationEmail": "Invia conferma",
+    "resendConfirmation": "Reinvia conferma",
+    "sendReminderEmail": "Invia promemoria",
+    "emailSent": "E-mail inviata con successo",
+    "automatic": "automatico",
+    "selectPatientFirst": "Seleziona un paziente per vedere i trattamenti in sospeso",
+    "noPendingTreatments": "Nessun trattamento in sospeso",
+    "createPlanFirst": "Crea un piano di cura per questo paziente",
+    "addTreatmentFromPlan": "Aggiungi trattamento dal piano",
+    "selectPendingTreatment": "Seleziona trattamento in sospeso",
+    "emptyDay": "Nessun appuntamento in questo giorno",
+    "noPatient": "Nessun paziente",
+    "freeSlots": {
+      "byProfessional": "Professionista",
+      "byCabinet": "Riunito",
+      "freeSuffix": "liberi",
+      "freeShort": "liberi",
+      "noFreeTime": "Nessuna disponibilità",
+      "tapToBook": "Tocca per prenotare",
+      "tapToBookAria": "Fascia libera di {duration} alle {time}",
+      "nextFreeAt": "Prossima alle {time}",
+      "gapsAtLeast": "{count} spazi ≥ {min} min",
+      "minDuration": "Minimo",
+      "noFreeSlots": "Nessuna fascia libera oggi",
+      "clinicClosed": "Studio chiuso",
+      "professionalOff": "Fuori servizio",
+      "onBreak": "In pausa"
+    }
+  },
+  "dashboard": {
+    "greetings": {
+      "morning": "Buongiorno",
+      "afternoon": "Buon pomeriggio",
+      "evening": "Buonasera"
+    },
+    "welcome": "Benvenuto in DentalPin",
+    "welcomeMessage": "Inizia creando il tuo primo paziente.",
+    "quickActions": {
+      "newAppointment": "Nuovo appuntamento",
+      "newPatient": "Nuovo paziente",
+      "search": "Cerca paziente",
+      "searchPlaceholder": "Cerca per nome, telefono o e-mail"
+    },
+    "timeline": {
+      "title": "Oggi",
+      "empty": "Nessun appuntamento in programma per oggi",
+      "now": "Adesso",
+      "openSchedule": "Apri agenda"
+    },
+    "todayKpi": {
+      "title": "Appuntamenti di oggi",
+      "completed": "completati",
+      "inProgress": "in corso",
+      "upcoming": "in arrivo",
+      "cancelled": "annullati",
+      "noShow": "assenze",
+      "empty": "Nessun appuntamento oggi"
+    },
+    "inClinic": {
+      "title": "Ora in studio",
+      "inTreatment": "{n} al riunito",
+      "waiting": "{n} in attesa",
+      "empty": "Nessuno in studio"
+    },
+    "unconfirmed": {
+      "title": "Non confermati per domani",
+      "empty": "Tutti gli appuntamenti di domani sono confermati",
+      "confirm": "Conferma",
+      "confirmError": "Impossibile confermare"
+    },
+    "overdue": {
+      "title": "Pagamenti scaduti",
+      "daysOverdue": "{n} giorno di ritardo | {n} giorni di ritardo",
+      "viewAll": "Vedi tutti",
+      "empty": "Nessuna fattura scaduta"
+    },
+    "recent": {
+      "title": "Pazienti recenti",
+      "empty": "Ancora nessun paziente"
+    },
+    "weekGlance": {
+      "title": "La settimana a colpo d'occhio",
+      "subtitle": "Ultimi 7 giorni vs 7 precedenti",
+      "appointments": "Appuntamenti",
+      "completed": "Completati",
+      "invoiced": "Fatturato",
+      "empty": "Nessun dato questa settimana"
+    }
+  },
+  "settings": {
+    "title": "Impostazioni",
+    "subtitle": "Gestisci il tuo studio, il team e i moduli.",
+    "allCategories": "Tutte le categorie",
+    "navLabel": "Categorie di impostazioni",
+    "attentionRequired": "Richiede attenzione",
+    "categories": {
+      "general": {
+        "label": "Generale",
+        "description": "Profilo dello studio, immagine e fuso orario."
+      },
+      "workspace": {
+        "label": "Spazio di lavoro",
+        "description": "Riuniti, orari di apertura e disponibilità."
+      },
+      "people": {
+        "label": "Persone",
+        "description": "Utenti, ruoli e inviti."
+      },
+      "clinical": {
+        "label": "Clinica",
+        "description": "Listino, impostazioni dei trattamenti e modelli."
+      },
+      "billing": {
+        "label": "Fatturazione e fisco",
+        "description": "Serie di fatturazione, IVA e adempimenti fiscali."
+      },
+      "communications": {
+        "label": "Comunicazioni",
+        "description": "Notifiche, SMTP e modelli."
+      },
+      "integrations": {
+        "label": "Integrazioni",
+        "description": "Servizi e fornitori esterni."
+      },
+      "modules": {
+        "label": "Moduli",
+        "description": "Installa, aggiorna e disinstalla moduli."
+      },
+      "account": {
+        "label": "Account",
+        "description": "Il tuo profilo, la password e la lingua."
+      }
+    },
+    "search": {
+      "placeholder": "Cerca nelle impostazioni…",
+      "empty": "Nessun risultato per questa ricerca.",
+      "navigate": "naviga",
+      "open": "apri"
+    },
+    "locked": {
+      "title": "Non hai accesso a questa sezione",
+      "description": "Chiedi a un amministratore dello studio di concederti i permessi necessari."
+    },
+    "emptyCategory": {
+      "title": "Nessuna opzione disponibile",
+      "description": "Quando saranno attivi moduli compatibili, le loro impostazioni appariranno qui."
+    },
+    "loadError": {
+      "description": "Impossibile caricare questo editor. Riprova tra qualche secondo."
+    },
+    "comingSoon": {
+      "title": "In arrivo",
+      "subtitle": "Stiamo lavorando a questa sezione. Nel frattempo puoi gestirla tramite l'API."
+    },
+    "onboarding": {
+      "title": "Completa la configurazione dello studio",
+      "subtitle": "Mancano {count} passi per completare la configurazione iniziale.",
+      "dismiss": "Nascondi",
+      "items": {
+        "clinicInfo": {
+          "label": "Completa il profilo dello studio",
+          "description": "Nome, partita IVA e indirizzo compaiono su preventivi e fatture."
+        },
+        "cabinets": {
+          "label": "Crea almeno un riunito",
+          "description": "Senza riuniti non è possibile fissare appuntamenti."
+        }
+      }
+    },
+    "cabinetsDescription": "Sale o postazioni in cui vengono trattati i pazienti.",
+    "usersDescription": "Account con accesso a questo studio e i loro ruoli.",
+    "profileDescription": "Le tue informazioni personali in questo studio.",
+    "clinic": "Studio",
+    "profile": "Profilo",
+    "clinicName": "Nome dello studio",
+    "clinicInfo": "Dati dello studio",
+    "clinicInfoDescription": "Questi dati appariranno su preventivi e documenti",
+    "taxId": "Partita IVA",
+    "legalName": "Ragione sociale",
+    "legalNameHelp": "Denominazione legale dell'entità per la fatturazione. Lascia vuoto per usare il nome dello studio.",
+    "street": "Indirizzo",
+    "city": "Città",
+    "postalCode": "CAP",
+    "country": "Paese",
+    "countryPlaceholder": "Seleziona un paese",
+    "countrySearchPlaceholder": "Cerca paese…",
+    "phone": "Telefono",
+    "timezone": "Fuso orario",
+    "timezoneHelp": "Tutti gli orari e gli appuntamenti sono interpretati in questo fuso orario.",
+    "currency": "Valuta",
+    "currencyHelp": "Valuta dello studio usata in preventivi, fatture e listino.",
+    "editClinicInfo": "Modifica dati",
+    "clinicUpdated": "Dati dello studio aggiornati",
+    "clinicUpdateError": "Errore nell'aggiornamento dei dati",
+    "cabinets": "Riuniti",
+    "language": "Lingua",
+    "languageDescription": "Seleziona la lingua preferita",
+    "users": "Utenti dello studio",
+    "newUser": "Nuovo utente",
+    "createUser": "Crea utente",
+    "editUser": "Modifica utente",
+    "deleteUser": "Elimina utente",
+    "deleteUserConfirm": "Vuoi davvero rimuovere",
+    "deleteUserNote": "L'utente perderà l'accesso a questo studio, ma il suo account non sarà eliminato.",
+    "noUsers": "Nessun utente registrato",
+    "youTag": "(tu)",
+    "userActive": "Utente attivo",
+    "isProfessional": "Esercita come professionista",
+    "isProfessionalHelp": "Appare in agenda, ha orari di lavoro e può ricevere trattamenti assegnati. Anche un amministratore può esercitare.",
+    "userInactiveNote": "(Non può accedere)",
+    "saveChanges": "Salva modifiche",
+    "noCabinets": "Nessun riunito configurato",
+    "addCabinet": "Aggiungi",
+    "newCabinet": "Nuovo riunito",
+    "editCabinet": "Modifica riunito",
+    "deleteCabinet": "Elimina riunito",
+    "deleteCabinetConfirm": "Vuoi davvero eliminare il riunito",
+    "deleteCabinetNote": "Gli appuntamenti esistenti in questo riunito non saranno toccati.",
+    "createCabinet": "Crea riunito",
+    "roles": {
+      "admin": "Amministratore",
+      "dentist": "Odontoiatra",
+      "hygienist": "Igienista",
+      "assistant": "Assistente",
+      "receptionist": "Receptionist"
+    },
+    "errors": {
+      "loadUsers": "Errore nel caricamento degli utenti",
+      "createUser": "Errore nella creazione dell'utente",
+      "updateUser": "Errore nell'aggiornamento dell'utente",
+      "deleteUser": "Errore nella rimozione dell'utente",
+      "emailExists": "E-mail già esistente",
+      "userNotFound": "Utente non trovato",
+      "operationNotAllowed": "Operazione non consentita",
+      "invalidData": "Dati non validi",
+      "inviteLink": "Impossibile generare il link di accesso"
+    },
+    "messages": {
+      "userCreated": "Utente creato con successo",
+      "userUpdated": "Utente aggiornato con successo",
+      "userDeleted": "Utente rimosso dallo studio"
+    },
+    "modules": {
+      "title": "Moduli",
+      "subtitle": "Installa, disinstalla e aggiorna i moduli dello studio.",
+      "description": "Gestisci quali moduli sono attivi nel tuo studio.",
+      "deps": "Dipendenze",
+      "noDeps": "Nessuna dipendenza",
+      "state": {
+        "installed": "Installato",
+        "uninstalled": "Non installato",
+        "toInstall": "In attesa di installazione",
+        "toUpgrade": "In attesa di aggiornamento",
+        "toRemove": "In attesa di rimozione",
+        "disabled": "Disattivato",
+        "error": "Errore"
+      },
+      "category": {
+        "official": "Ufficiale",
+        "community": "Community"
+      },
+      "actions": {
+        "install": "Installa",
+        "uninstall": "Disinstalla",
+        "upgrade": "Aggiorna",
+        "apply": "Applica modifiche",
+        "viewDetails": "Dettagli",
+        "force": "Forza disinstallazione"
+      },
+      "confirmInstall": {
+        "title": "Installare {name}?",
+        "message": "Il modulo sarà programmato per l'installazione e diventerà attivo dopo l'applicazione delle modifiche.",
+        "scheduled": "Verranno installate anche queste dipendenze:"
+      },
+      "confirmUninstall": {
+        "title": "Disinstallare {name}?",
+        "warning": "Le tabelle del modulo saranno rimosse. Prima viene creato un backup pg_dump per poter recuperare i dati.",
+        "forceHint": "Ignora i moduli dipendenti. Usalo solo se sai cosa stai facendo."
+      },
+      "confirmUpgrade": {
+        "title": "Aggiornare {name}?",
+        "message": "Il modulo sarà aggiornato alla versione del manifest su disco quando le modifiche verranno applicate."
+      },
+      "confirmApply": {
+        "title": "Applica modifiche",
+        "message": "Il backend verrà riavviato. La sessione potrebbe interrompersi brevemente durante le operazioni in sospeso."
+      },
+      "pending": {
+        "banner": "Modifiche in sospeso:",
+        "apply": "Applica modifiche"
+      },
+      "doctor": {
+        "banner": "Rilevati problemi nel sistema dei moduli.",
+        "orphans": "moduli orfani",
+        "missingDeps": "dipendenze mancanti",
+        "manifestErrors": "errori di manifest",
+        "errored": "moduli in errore"
+      },
+      "detail": {
+        "state": "Stato",
+        "category": "Categoria",
+        "installedAt": "Installato il",
+        "lastChange": "Ultima modifica",
+        "baseRevision": "Revisione base",
+        "appliedRevision": "Revisione applicata",
+        "manifest": "Manifest completo",
+        "errorMessage": "Messaggio di errore",
+        "operationLog": "Registro operazioni",
+        "noOperations": "Nessuna operazione registrata."
+      },
+      "restart": {
+        "inProgress": "Riavvio del backend…",
+        "done": "Modifiche applicate",
+        "failed": "Impossibile applicare le modifiche",
+        "timeout": "Timeout in attesa del backend"
+      },
+      "toasts": {
+        "scheduled": "Operazione programmata. Applica le modifiche per completarla.",
+        "applied": "Modifiche applicate con successo."
+      }
+    },
+    "invite": {
+      "linkTitle": "Link di accesso",
+      "linkHelp": "Invia questo link a {name} perché scelga la sua password. Scade il {date} e funziona una sola volta.",
+      "copy": "Copia link",
+      "copied": "Link copiato",
+      "whatsapp": "Invia via WhatsApp",
+      "shareText": "Ciao {name}, ecco il tuo accesso a DentalPin. Aprilo e scegli la tua password: {url}",
+      "secretNote": "Trattalo come una password: chiunque abbia il link può accedere a questo account.",
+      "passwordOptionalHelp": "Lascia vuoto per generare un link di accesso da inviare via WhatsApp o e-mail.",
+      "passwordOptionalPlaceholder": "Facoltativa",
+      "createAndLink": "Crea e genera link",
+      "rowAction": "Link di accesso",
+      "setPasswordTitle": "Scegli la tua password",
+      "setPasswordSubtitle": "Sei stato invitato su DentalPin. Crea la tua password per accedere.",
+      "setPasswordSubmit": "Salva e accedi",
+      "invalidToken": "Questo link non è valido o è già stato usato. Chiedi un nuovo link all'amministratore dello studio."
+    }
+  },
+  "selector": {
+    "recentPatients": "Pazienti recenti",
+    "commonTreatments": "Trattamenti frequenti",
+    "noRecentPatients": "Nessun paziente recente",
+    "noCommonTreatments": "Nessun trattamento frequente",
+    "noMatches": "Nessuna corrispondenza",
+    "typeToSearch": "Digita per cercare..."
+  },
+  "density": {
+    "switchToCompact": "Vista compatta",
+    "switchToComfortable": "Vista comoda"
+  },
+  "patientSelector": {
+    "createOption": "Crea paziente \"{query}\"",
+    "createOptionEmpty": "Crea nuovo paziente",
+    "newBadge": "Nuovo",
+    "duplicateWarning": "{name} esiste già con questo telefono",
+    "useExisting": "Usa questo paziente",
+    "createForm": {
+      "title": "Nuovo paziente",
+      "back": "Torna alla ricerca",
+      "firstName": "Nome",
+      "lastName": "Cognome",
+      "phone": "Telefono",
+      "phoneHint": "Puoi aggiungerlo più tardi nella scheda del paziente.",
+      "submit": "Crea e seleziona",
+      "cancel": "Annulla",
+      "errorGeneric": "Impossibile creare il paziente. Riprova."
+    }
+  },
+  "common": {
+    "save": "Salva",
+    "add": "Aggiungi",
+    "cancel": "Annulla",
+    "clear": "Svuota",
+    "close": "Chiudi",
+    "delete": "Elimina",
+    "comingSoon": "In arrivo",
+    "edit": "Modifica",
+    "change": "modifica | modifiche",
+    "back": "Indietro",
+    "loading": "Caricamento...",
+    "error": "Errore",
+    "success": "Operazione riuscita",
+    "completed": "Completato",
+    "retry": "Riprova",
+    "refresh": "Aggiorna",
+    "hide": "Nascondi",
+    "forbidden": "Accesso negato",
+    "confirm": "Conferma",
+    "yes": "Sì",
+    "no": "No",
+    "actions": "Azioni",
+    "viewDetails": "Vedi dettagli",
+    "previous": "Precedente",
+    "next": "Successivo",
+    "previousYear": "Anno precedente",
+    "nextYear": "Anno successivo",
+    "undo": "Annulla",
+    "undone": "Annullato",
+    "added": "Aggiunto",
+    "removed": "Rimosso",
+    "page": "Pagina {current} di {total}",
+    "noData": "Nessun dato",
+    "noValue": "nessun valore",
+    "noResults": "Nessun risultato",
+    "search": "Cerca...",
+    "selectAll": "Tutti",
+    "deselectAll": "Nessuno",
+    "all": "Tutti",
+    "required": "Questo campo è obbligatorio",
+    "invalidEmail": "E-mail non valida",
+    "networkError": "Errore di connessione",
+    "serverError": "Errore del server",
+    "notFound": "Non trovato",
+    "offline": "Offline — i dati potrebbero non essere aggiornati",
+    "inactive": "Inattivo",
+    "name": "Nome",
+    "color": "Colore",
+    "firstName": "Nome",
+    "lastName": "Cognome",
+    "email": "E-mail",
+    "password": "Password",
+    "passwordPlaceholder": "Minimo 8 caratteri",
+    "role": "Ruolo",
+    "readOnly": "Sola lettura",
+    "createdBy": "Creato da",
+    "date": "Data",
+    "upload": "Carica",
+    "uploading": "Caricamento…",
+    "maxFileSize": "fino a 10 MB",
+    "durationMinutes": "{value} min",
+    "days": {
+      "sunday": "Domenica",
+      "monday": "Lunedì",
+      "tuesday": "Martedì",
+      "wednesday": "Mercoledì",
+      "thursday": "Giovedì",
+      "friday": "Venerdì",
+      "saturday": "Sabato"
+    },
+    "now": "Adesso",
+    "today": "Oggi",
+    "tomorrow": "Domani",
+    "yesterday": "Ieri",
+    "copied": "Copiato negli appunti",
+    "copy": "Copia",
+    "copyFailed": "Impossibile copiare"
+  },
+  "cabinet": {
+    "toast": {
+      "created": "Riunito creato",
+      "updated": "Riunito aggiornato",
+      "deleted": "Riunito eliminato",
+      "duplicateName": "Esiste già un riunito con questo nome",
+      "notFound": "Riunito non trovato",
+      "createFailed": "Impossibile creare il riunito",
+      "updateFailed": "Impossibile aggiornare il riunito",
+      "deleteFailed": "Impossibile eliminare il riunito"
+    }
+  },
+  "professionals": {
+    "toast": {
+      "loadFailed": "Impossibile caricare i professionisti"
+    }
+  },
+  "lists": {
+    "empty": {
+      "title": "Nessun risultato",
+      "description": "Modifica i filtri o cancellali per vedere tutti i record."
+    },
+    "resultCount": "{shown} di {total}",
+    "filter": {
+      "title": "Filtri",
+      "more": "Filtri",
+      "moreCount": "Filtri ({count})",
+      "clear": "Cancella",
+      "apply": "Applica",
+      "date": "Date",
+      "dateFrom": "Dal",
+      "dateTo": "Al",
+      "searchPlaceholder": "Cerca...",
+      "noResults": "Nessuna corrispondenza",
+      "all": "Tutti"
+    },
+    "sort": {
+      "label": "Ordina",
+      "asc": "Crescente",
+      "desc": "Decrescente"
+    },
+    "datePreset": {
+      "today": "Oggi",
+      "last7": "Ultimi 7 giorni",
+      "last30": "Ultimi 30 giorni",
+      "thisMonth": "Questo mese",
+      "thisQuarter": "Trimestre",
+      "thisYear": "Anno",
+      "custom": "Personalizzato"
+    },
+    "truncatedWarning": "Risultati troncati (>1000). Affina i filtri."
+  },
+  "shared": {
+    "totals": "Totali",
+    "info": "Dettagli",
+    "moreActions": "Altre azioni",
+    "criticalBanner": {
+      "dismiss": "Nascondi avviso"
+    },
+    "collect": {
+      "amountLabel": "Importo da incassare",
+      "methodLabel": "Metodo di pagamento",
+      "dateLabel": "Data del pagamento",
+      "today": "Oggi",
+      "quickFull": "Totale",
+      "optionalDetails": "Aggiungi riferimento o note (facoltativo)",
+      "referenceLabel": "Riferimento",
+      "referencePlaceholder": "es. numero transazione POS",
+      "notesLabel": "Note interne",
+      "submit": "Incassa",
+      "cancel": "Annulla"
+    }
+  },
+  "validation": {
+    "required": "Questo campo è obbligatorio",
+    "email": "Inserisci un'e-mail valida",
+    "minLength": "Minimo {min} caratteri",
+    "maxLength": "Massimo {max} caratteri",
+    "phone": "Inserisci un numero di telefono valido"
+  },
+  "time": {
+    "minutes": "{n} min",
+    "hours": "{n} ora | {n} ore"
+  },
+  "calendar": {
+    "today": "Oggi",
+    "prevWeek": "Settimana precedente",
+    "nextWeek": "Settimana successiva",
+    "monday": "Lunedì",
+    "tuesday": "Martedì",
+    "wednesday": "Mercoledì",
+    "thursday": "Giovedì",
+    "friday": "Venerdì",
+    "saturday": "Sabato",
+    "sunday": "Domenica"
+  },
+  "catalog": {
+    "title": "Listino prestazioni",
+    "description": "Gestisci trattamenti, prezzi e configurazione fiscale",
+    "items": "Trattamenti",
+    "categories": "Categorie",
+    "noItems": "Nessun trattamento nel listino",
+    "searchPlaceholder": "Cerca per codice o nome...",
+    "code": "Codice",
+    "name": "Nome",
+    "category": "Categoria",
+    "price": "Prezzo",
+    "defaultPrice": "Prezzo base",
+    "costPrice": "Prezzo di costo",
+    "currency": "Valuta",
+    "vatType": "Aliquota IVA",
+    "vatRate": "IVA %",
+    "duration": "Durata",
+    "system": "Di sistema",
+    "newItem": "Nuovo trattamento",
+    "editItem": "Modifica trattamento",
+    "deleteItem": "Elimina trattamento",
+    "deleteItemConfirm": "Vuoi davvero eliminare il trattamento \"{name}\"?",
+    "deleteItemNote": "Questa azione non può essere annullata.",
+    "pricing": "Prezzi",
+    "scheduling": "Programmazione",
+    "characteristics": "Caratteristiche",
+    "scope": "Ambito",
+    "requiresAppointment": "Richiede appuntamento",
+    "isDiagnostic": "È diagnostico",
+    "requiresSurfaces": "Richiede superfici",
+    "materialNotes": "Note sui materiali",
+    "materialNotesPlaceholder": "Materiali o forniture necessari...",
+    "active": "Attivo",
+    "vatTypes": {
+      "exempt": "Esente",
+      "reduced": "Ridotta",
+      "standard": "Ordinaria"
+    },
+    "scopeTypes": {
+      "tooth": "Dente",
+      "multi_tooth": "Più denti",
+      "global_mouth": "Bocca intera",
+      "global_arch": "Per arcata"
+    },
+    "pricingStrategy": {
+      "label": "Strategia di prezzo",
+      "help": "Come viene calcolato il prezzo del trattamento all'applicazione",
+      "flat": "Fisso (prezzo unico)",
+      "per_tooth": "Per dente (× numero di denti)",
+      "per_surface": "Per superficie (a scaglioni)",
+      "per_role": "Per ruolo (ponte: pilastro/intermedio)"
+    },
+    "surfacePrices": {
+      "title": "Prezzi per numero di superfici",
+      "help": "Definisci il prezzo per 1–5 superfici. Quando si selezionano le superfici su un dente si applica lo scaglione corrispondente. Gli scaglioni mancanti ricadono sul più vicino inferiore compilato.",
+      "tier": "{n} sup."
+    },
+    "sessions": {
+      "title": "Sedute (fatturazione frazionata)",
+      "help": "Definisci le fasi con cui il trattamento viene eseguito e fatturato (es. corona: 'Impronte' + 'Cementazione'). La somma deve essere pari al prezzo base.",
+      "label": "Etichetta",
+      "labelPlaceholder": "es. Impronte",
+      "price": "Importo",
+      "add": "Aggiungi seduta",
+      "sumStatus": "Somma {sum} € · Totale {total} €"
+    },
+    "categoryCreated": "Categoria creata",
+    "categoryUpdated": "Categoria aggiornata",
+    "categoryDeleted": "Categoria eliminata",
+    "categoryKeyExists": "Esiste già una categoria con questa chiave",
+    "categoryCreateFailed": "Errore nella creazione della categoria",
+    "categoryUpdateFailed": "Errore nell'aggiornamento della categoria",
+    "categoryDeleteFailed": "Errore nell'eliminazione della categoria",
+    "cannotModifySystemCategory": "Le categorie di sistema non sono modificabili",
+    "cannotDeleteSystemCategory": "Le categorie di sistema non sono eliminabili",
+    "itemCreated": "Trattamento creato",
+    "itemUpdated": "Trattamento aggiornato",
+    "itemDeleted": "Trattamento eliminato",
+    "itemCodeExists": "Esiste già un trattamento con questo codice",
+    "categoryNotFound": "Categoria non trovata",
+    "itemCreateFailed": "Errore nella creazione del trattamento",
+    "itemUpdateFailed": "Errore nell'aggiornamento del trattamento",
+    "itemDeleteFailed": "Errore nell'eliminazione del trattamento",
+    "cannotModifySystemItem": "I trattamenti di sistema non sono modificabili",
+    "systemItemHint": "Trattamento di sistema: codice, categoria, strategia di prezzo e ambito sono bloccati; prezzo, costo, IVA, nomi, durata, sedute e stato sono modificabili.",
+    "cannotDeleteSystemItem": "I trattamenti di sistema non sono eliminabili",
+    "odontogramMapping": "Visualizzazione nell'odontogramma",
+    "odontogramMappingDescription": "Associa questo trattamento a un tipo di visualizzazione dell'odontogramma perché compaia nella scheda del paziente.",
+    "odontogramType": "Tipo di trattamento",
+    "clinicalCategory": "Categoria clinica",
+    "noOdontogramMapping": "Nessuna associazione",
+    "odontogramMappingHint": "Le caratteristiche del trattamento saranno adeguate automaticamente al tipo selezionato.",
+    "selectCategory": "Seleziona categoria...",
+    "selectVatType": "Seleziona aliquota IVA...",
+    "selectScope": "Seleziona ambito...",
+    "selectOdontogramType": "Seleziona tipo...",
+    "selectClinicalCategory": "Seleziona categoria...",
+    "expandAll": "Espandi tutto",
+    "collapseAll": "Comprimi tutto",
+    "unnamed": "Senza titolo",
+    "activeHint": "Disponibile per preventivi e piani",
+    "tabs": {
+      "general": "Generale",
+      "pricing": "Prezzi",
+      "scheduling": "Programmazione",
+      "clinical": "Clinica"
+    },
+    "onboarding": {
+      "label": "Listino prestazioni",
+      "description": "Senza trattamenti non ci sono preventivi né piani. Carica il listino predefinito o creane uno tuo.",
+      "createOwn": "Creerò il mio"
+    },
+    "manageCategories": "Gestisci categorie",
+    "newCategory": "Nuova categoria",
+    "categoryName": "Nome",
+    "categoryNamePlaceholder": "es. Ortodonzia",
+    "categoryOrder": "Ordine",
+    "noCategories": "Nessuna categoria. Creane una o carica il listino predefinito.",
+    "inactiveCategories": "Categorie inattive",
+    "reactivate": "Riattiva",
+    "deleteCategoryConfirm": "La categoria sarà disattivata; i suoi trattamenti restano. Continuare?",
+    "systemCategoryNote": "Le categorie di sistema non possono essere modificate o eliminate.",
+    "loadDefaults": "Carica listino predefinito",
+    "loadDefaultsHint": "Aliquote IVA, categorie e trattamenti di riferimento per il paese dello studio. Vengono aggiunte solo le righe mancanti.",
+    "defaultsLoaded": "Listino caricato: {categories} categorie, {items} trattamenti, {vat_types} aliquote IVA",
+    "defaultsFailed": "Impossibile caricare il listino predefinito"
+  },
+  "placeholders": {
+    "selectRole": "Seleziona ruolo..."
+  },
+  "vatTypes": {
+    "title": "Aliquote IVA",
+    "description": "Gestisci le aliquote IVA disponibili per i trattamenti",
+    "name": "Nome",
+    "rate": "Aliquota",
+    "default": "Predefinita",
+    "system": "Di sistema",
+    "active": "Attiva",
+    "new": "Nuova aliquota IVA",
+    "edit": "Modifica aliquota IVA",
+    "delete": "Elimina aliquota IVA",
+    "setAsDefault": "Imposta come predefinita",
+    "showInactive": "Mostra inattive",
+    "noItems": "Nessuna aliquota IVA configurata",
+    "namePlaceholder": "Es.: Ridotta (10%)",
+    "systemNote": "Delle aliquote di sistema si può cambiare solo lo stato predefinito.",
+    "deleteConfirm": "Vuoi davvero eliminare l'aliquota IVA",
+    "deleteNote": "I trattamenti che usano questa aliquota non saranno toccati.",
+    "created": "Aliquota IVA creata",
+    "updated": "Aliquota IVA aggiornata",
+    "deleted": "Aliquota IVA eliminata",
+    "loadError": "Errore nel caricamento delle aliquote IVA",
+    "createError": "Errore nella creazione dell'aliquota IVA",
+    "updateError": "Errore nell'aggiornamento dell'aliquota IVA",
+    "deleteError": "Errore nell'eliminazione dell'aliquota IVA"
+  },
+  "treatmentPlans": {
+    "title": "Piani di cura",
+    "description": "Gestisci i piani di cura dei pazienti",
+    "new": "Nuovo piano",
+    "create": "Crea piano di cura",
+    "edit": "Modifica piano",
+    "view": "Vedi piano",
+    "delete": "Elimina piano",
+    "noItems": "Questo piano non ha trattamenti",
+    "noPlans": "Questo paziente non ha piani di cura",
+    "noPlansHint": "Segna i trattamenti sull'odontogramma e crea un piano per organizzarli",
+    "createFirst": "Crea il primo piano",
+    "empty": "Nessun piano di cura registrato",
+    "emptyAction": "Crea il primo piano",
+    "searchPlaceholder": "Cerca per numero, paziente o titolo...",
+    "planNumber": "Numero",
+    "patient": "Paziente",
+    "untitled": "Senza titolo",
+    "untitledPlan": "Piano senza titolo",
+    "itemCount": "{count} trattamento | {count} trattamenti",
+    "treatments": "trattamenti",
+    "progress": "Avanzamento",
+    "pendingTreatments": "Trattamenti in sospeso",
+    "completedTreatments": "Trattamenti completati",
+    "linkedBudget": "Preventivo collegato",
+    "unknownTreatment": "Trattamento sconosciuto",
+    "globalTreatment": "Trattamento generale",
+    "activePlan": "Piano attivo",
+    "otherPlans": "Altri piani",
+    "viewAllPlans": "Vedi cronologia dei piani",
+    "activate": "Attiva",
+    "generateBudget": "Genera preventivo",
+    "scheduleAppointment": "Fissa appuntamento",
+    "status": {
+      "draft": "Bozza",
+      "pending": "In attesa",
+      "active": "Attivo",
+      "completed": "Completato",
+      "closed": "Chiuso",
+      "archived": "Archiviato"
+    },
+    "fields": {
+      "title": "Titolo",
+      "titlePlaceholder": "Es.: Riabilitazione orale completa",
+      "assignedProfessional": "Professionista assegnato",
+      "selectProfessional": "Seleziona professionista",
+      "diagnosisNotes": "Note diagnostiche",
+      "diagnosisNotesPlaceholder": "Diagnosi e osservazioni cliniche...",
+      "internalNotes": "Note interne",
+      "internalNotesPlaceholder": "Note visibili solo allo staff..."
+    },
+    "modal": {
+      "subtitle": "Organizza i trattamenti del paziente",
+      "titleHint": "Facoltativo - aiuta a identificare il piano",
+      "additionalNotes": "Note aggiuntive",
+      "quickTip": "Dopo aver creato il piano potrai aggiungere trattamenti dall'odontogramma o dal listino.",
+      "createButton": "Crea piano"
+    },
+    "actions": {
+      "activate": "Attiva piano",
+      "confirm": "Conferma piano",
+      "complete": "Segna come completato",
+      "generateBudget": "Genera preventivo",
+      "linkBudget": "Collega preventivo",
+      "syncBudget": "Sincronizza preventivo",
+      "cancelPlan": "Annulla piano",
+      "reopen": "Riapri",
+      "close": "Chiudi piano",
+      "reactivate": "Riattiva piano",
+      "logContact": "Registra contatto"
+    },
+    "items": {
+      "title": "Trattamenti",
+      "add": "Aggiungi trattamento",
+      "addSelected": "Aggiungi {count} trattamento | Aggiungi {count} trattamenti",
+      "remove": "Rimuovi trattamento",
+      "empty": "Nessun trattamento in questo piano",
+      "assignedProfessional": "Odontoiatra assegnato",
+      "assignedProfessionalAriaLabel": "Cambia l'odontoiatra assegnato a questo trattamento",
+      "useUsersPlanDoctor": "Usa l'odontoiatra del piano",
+      "noProfessional": "Nessun odontoiatra assegnato",
+      "inactiveProfessional": "Professionista inattivo",
+      "cascadeReassign": {
+        "title": "Riassegnare i trattamenti in sospeso?",
+        "body": "Hai cambiato l'odontoiatra del piano. {count} trattamenti in sospeso erano assegnati a {previousName}. Riassegnarli al nuovo odontoiatra?",
+        "confirm": "Sì, riassegna i sospesi",
+        "cancel": "No, lasciali così"
+      }
+    },
+    "filters": {
+      "allStatuses": "Tutti gli stati"
+    },
+    "confirmations": {
+      "delete": "Eliminare questo piano di cura?",
+      "completeItem": "Segnare il trattamento come completato?",
+      "completeItemDescription": "Questa azione non può essere annullata.",
+      "activateTitle": "Confermare il piano di cura?",
+      "activateDescription": "La conferma sblocca la generazione del preventivo e la programmazione degli appuntamenti. Potrai comunque aggiungere o completare trattamenti.",
+      "unlockTitle": "Modificare il piano?",
+      "unlockIntro": "Per questo piano è già stato emesso il preventivo {number}. Per modificarlo, il preventivo attuale deve essere annullato.",
+      "unlockConsequence1": "Il preventivo {number} sarà annullato e non sarà più valido per il paziente.",
+      "unlockConsequence2": "Potrai aggiungere, modificare o rimuovere trattamenti dal piano.",
+      "unlockConsequence3": "Al termine delle modifiche dovrai generare un nuovo preventivo.",
+      "unlockConsequence4": "Il preventivo annullato resta nello storico per tracciabilità.",
+      "cancelTitle": "Annullare il piano di cura?",
+      "cancelDescription": "Il piano passerà allo stato annullato e i trattamenti pianificati non eseguiti saranno rimossi dall'odontogramma. Lo storico del piano viene conservato."
+    },
+    "messages": {
+      "created": "Piano di cura creato",
+      "updated": "Piano di cura aggiornato",
+      "deleted": "Piano di cura eliminato",
+      "itemsAdded": "Trattamenti aggiunti al piano"
+    },
+    "itemCompleted": "Trattamento completato",
+    "budgetGenerated": "Preventivo generato",
+    "created": "Piano di cura creato",
+    "updated": "Piano di cura aggiornato",
+    "statusUpdated": "Stato del piano aggiornato",
+    "deleted": "Piano di cura eliminato",
+    "budgetLinked": "Preventivo collegato al piano",
+    "budgetSynced": "Preventivo sincronizzato",
+    "errors": {
+      "load": "Errore nel caricamento dei piani di cura",
+      "create": "Errore nella creazione del piano di cura",
+      "update": "Errore nell'aggiornamento del piano di cura",
+      "delete": "Errore nell'eliminazione del piano di cura"
+    },
+    "notes": {
+      "title": "Note cliniche",
+      "empty": "Ancora nessuna nota clinica",
+      "addNote": "Aggiungi nota",
+      "edit": "Modifica nota",
+      "delete": "Elimina nota",
+      "attachments": "Allegati",
+      "author": "Autore",
+      "createdAt": "Creata",
+      "templatePicker": "Modelli",
+      "bodyPlaceholder": "Scrivi la nota clinica…",
+      "saved": "Nota salvata",
+      "deleted": "Nota eliminata"
+    },
+    "completionNudge": {
+      "title": "Completa il trattamento",
+      "description": "Aggiungi una nota clinica su quanto avvenuto nella seduta prima di segnarlo come completato.",
+      "completeWithNote": "Completa con nota",
+      "skip": "Salta la nota",
+      "skipConfirm": "Completare senza nota clinica?"
+    },
+    "visitNote": {
+      "title": "Nota clinica della seduta",
+      "save": "Salva nota",
+      "empty": "Nessuna nota della seduta",
+      "saved": "Nota salvata"
+    },
+    "clinicalNotesTab": "Note cliniche",
+    "filterBy": {
+      "plan": "Piano",
+      "item": "Trattamento",
+      "visit": "Seduta",
+      "all": "Tutte"
+    },
+    "byPlan": {
+      "empty": "Questo paziente non ha note cliniche in nessun piano di cura",
+      "planNotesLabel": "Note del piano",
+      "noNotesForTreatment": "Nessuna nota per questo trattamento",
+      "noNotesForPlan": "Nessuna nota in questo piano"
+    },
+    "noteTemplates": {
+      "endo": {
+        "singleVisit": "Endodonzia — seduta unica",
+        "multiVisit": "Endodonzia — più sedute"
+      },
+      "perio": {
+        "scaling": "Detartrasi / levigatura radicolare"
+      },
+      "implant": {
+        "placement": "Inserimento implantare"
+      },
+      "general": {
+        "followUp": "Controllo generale"
+      }
+    },
+    "closureReason": {
+      "rejected_by_patient": "Rifiutato dal paziente",
+      "expired": "Scaduto",
+      "cancelled_by_clinic": "Annullato dallo studio",
+      "patient_abandoned": "Paziente rinunciatario",
+      "other": "Altro motivo"
+    },
+    "confirmed": "Piano confermato",
+    "reopened": "Piano riaperto",
+    "closed": "Piano chiuso",
+    "reactivated": "Piano riattivato",
+    "contactLogged": "Contatto registrato",
+    "modals": {
+      "confirm": {
+        "title": "Conferma il piano",
+        "description": "Il piano passerà a In attesa e verrà creata automaticamente una bozza di preventivo. Dopo la conferma i trattamenti sono di sola lettura.",
+        "submit": "Conferma il piano"
+      },
+      "reopen": {
+        "title": "Riapri il piano per la modifica",
+        "description": "Questo annullerà il preventivo attuale. Il piano torna in Bozza così puoi modificare i trattamenti.",
+        "submit": "Riapri"
+      },
+      "close": {
+        "title": "Chiudi il piano",
+        "description": "Scegli il motivo di chiusura. I trattamenti in sospeso saranno archiviati.",
+        "reasonLabel": "Motivo",
+        "noteLabel": "Nota (facoltativa)",
+        "submit": "Chiudi il piano"
+      },
+      "reactivate": {
+        "title": "Riattiva il piano chiuso",
+        "description": "Riattiverai un piano chiuso il {date} come «{reason}». Continuare?",
+        "submit": "Riattiva"
+      },
+      "contactLog": {
+        "title": "Registra contatto",
+        "description": "Registra il contatto senza cambiare lo stato del piano.",
+        "channelLabel": "Canale",
+        "noteLabel": "Nota (facoltativa)",
+        "submit": "Registra"
+      }
+    },
+    "newBudgetHint": {
+      "text": "Questo paziente ha il piano {plan} senza preventivo. Genera il preventivo dal piano così restano collegati.",
+      "cta": "Apri il piano"
+    }
+  },
+  "pipeline": {
+    "title": "Pipeline dei piani",
+    "description": "Gestisci il flusso dei trattamenti.",
+    "tabs": {
+      "por_presupuestar": "Da preventivare",
+      "esperando_paciente": "In attesa del paziente",
+      "sin_cita": "Senza appuntamento",
+      "sin_proxima_cita": "Senza prossimo appuntamento",
+      "cerrados": "Chiusi",
+      "listado": "Elenco"
+    },
+    "row": {
+      "patient": "Paziente",
+      "plan": "Piano",
+      "budget": "Preventivo",
+      "items": "Trattamenti",
+      "daysIn": "{n} giorni in questo stato",
+      "nextAppt": "Prossimo app.",
+      "noNextAppt": "Nessun appuntamento",
+      "noBudget": "Nessun preventivo"
+    },
+    "actions": {
+      "open": "Apri",
+      "send": "Invia",
+      "remind": "Reinvia",
+      "schedule": "Fissa appuntamento",
+      "scheduleNext": "Fissa il prossimo",
+      "reactivate": "Riattiva",
+      "call": "Chiama",
+      "whatsapp": "WhatsApp",
+      "markContacted": "Segna come contattato",
+      "acceptInClinic": "Accetta in studio"
+    },
+    "search": "Cerca per nome o numero…",
+    "empty": "Nessuna riga in questa scheda.",
+    "loading": "Caricamento…"
+  },
+  "budget": {
+    "title": "Preventivi",
+    "description": "Gestisci i preventivi di cura dei pazienti",
+    "new": "Nuovo preventivo",
+    "edit": "Modifica preventivo",
+    "view": "Vedi preventivo",
+    "delete": "Elimina preventivo",
+    "duplicate": "Crea nuova versione",
+    "noItems": "Nessun preventivo",
+    "empty": "Nessun preventivo registrato",
+    "emptyAction": "Crea il primo preventivo",
+    "linkedToPlan": "Collegato al piano",
+    "searchPlaceholder": "Cerca per numero o paziente...",
+    "budgetNumber": "Numero",
+    "version": "Versione",
+    "treatmentPlan": "Piano di cura",
+    "patient": "Paziente",
+    "selectPatient": "Seleziona paziente",
+    "selectPatientHint": "Cerca e seleziona il paziente per questo preventivo",
+    "professional": "Professionista",
+    "validFrom": "Valido dal",
+    "validUntil": "Valido fino al",
+    "validUntilHint": "Lascia vuoto per un preventivo senza scadenza",
+    "noExpiry": "Senza scadenza",
+    "createAndAddItems": "Crea e aggiungi trattamenti",
+    "subtotal": "Subtotale",
+    "totalDiscount": "Sconto totale",
+    "totalTax": "IVA totale",
+    "total": "Totale",
+    "globalDiscount": "Sconto globale",
+    "discountType": "Tipo di sconto",
+    "discountValue": "Valore dello sconto",
+    "percentage": "Percentuale",
+    "absolute": "Assoluto",
+    "internalNotes": "Note interne",
+    "internalNotesPlaceholder": "Note visibili solo allo staff...",
+    "patientNotes": "Note per il paziente",
+    "patientNotesPlaceholder": "Note visibili sul preventivo...",
+    "status": {
+      "title": "Stato",
+      "draft": "Bozza",
+      "sent": "Inviato",
+      "partially_accepted": "Parzialmente accettato",
+      "accepted": "Accettato",
+      "in_progress": "In corso",
+      "completed": "Completato",
+      "invoiced": "Fatturato",
+      "rejected": "Rifiutato",
+      "expired": "Scaduto",
+      "cancelled": "Annullato"
+    },
+    "itemStatus": {
+      "pending": "In sospeso",
+      "accepted": "Accettato",
+      "rejected": "Rifiutato",
+      "in_progress": "In corso",
+      "completed": "Completato"
+    },
+    "actions": {
+      "send": "Invia al paziente",
+      "accept": "Accetta preventivo",
+      "acceptPartial": "Accetta selezionati",
+      "reject": "Rifiuta",
+      "cancel": "Annulla preventivo",
+      "duplicate": "Crea nuova versione",
+      "downloadPdf": "Scarica PDF",
+      "previewPdf": "Anteprima PDF",
+      "startTreatment": "Inizia il trattamento",
+      "completeTreatment": "Completa il trattamento",
+      "renegotiate": "Rinegozia",
+      "acceptInClinic": "Accetta in studio",
+      "resend": "Reinvia",
+      "sendReminder": "Invia promemoria",
+      "setPublicCode": "Imposta codice di accesso",
+      "unlockPublic": "Sblocca l'accesso"
+    },
+    "items": {
+      "title": "Trattamenti",
+      "add": "Aggiungi trattamento",
+      "remove": "Rimuovi trattamento",
+      "edit": "Modifica trattamento",
+      "empty": "Nessun trattamento in questo preventivo",
+      "singular": "trattamento",
+      "plural": "trattamenti",
+      "addFromCatalog": "Aggiungi dal listino",
+      "addFromOdontogram": "Aggiungi dall'odontogramma",
+      "treatment": "Trattamento",
+      "searchCatalog": "Cerca nel listino prestazioni...",
+      "unitPrice": "Prezzo unitario",
+      "quantity": "Quantità",
+      "discount": "Sconto",
+      "lineTotal": "Totale riga",
+      "tooth": "Dente",
+      "toothNumber": "Numero del dente",
+      "toothNumberPlaceholder": "Es.: 11, 21, 36...",
+      "surfaces": "Superfici",
+      "notes": "Note",
+      "notesPlaceholder": "Note su questo trattamento...",
+      "managedByPlan": "Le voci di questo preventivo sono gestite dal piano di cura {plan}."
+    },
+    "signature": {
+      "title": "Firma digitale",
+      "viewAction": "Vedi firma",
+      "signedBy": "Firmato da",
+      "signedAt": "Firmato il",
+      "methodLabel": "Metodo",
+      "relationshipLabel": "Relazione",
+      "documentHash": "Hash del documento (SHA-256)",
+      "hashHint": "Hash {short} — vincola la firma a questo preciso PDF. Qualsiasi modifica la invaliderebbe.",
+      "downloadSignedPdf": "Scarica il PDF firmato",
+      "downloadError": "Impossibile scaricare il PDF firmato.",
+      "notSigned": "Per questo preventivo non è ancora stata acquisita una firma.",
+      "method": {
+        "drawn": "Firma autografa",
+        "clickAccept": "Accettazione con clic",
+        "external": "Fornitore esterno"
+      },
+      "email": "E-mail",
+      "relationship": "Relazione con il paziente",
+      "patient": "Paziente",
+      "guardian": "Tutore legale",
+      "representative": "Rappresentante",
+      "accept": "Accetto le condizioni del preventivo",
+      "signHere": "Firma qui",
+      "clear": "Cancella firma"
+    },
+    "history": {
+      "title": "Cronologia modifiche",
+      "noChanges": "Nessuna modifica registrata",
+      "actions": {
+        "created": "Preventivo creato",
+        "updated": "Preventivo aggiornato",
+        "status_changed": "Stato modificato",
+        "item_added": "Trattamento aggiunto",
+        "item_removed": "Trattamento rimosso",
+        "signed": "Preventivo firmato",
+        "sent": "Preventivo inviato",
+        "duplicated": "Nuova versione creata",
+        "deleted": "Preventivo eliminato",
+        "item_treatment_started": "Trattamento iniziato",
+        "item_treatment_completed": "Trattamento completato"
+      }
+    },
+    "versions": {
+      "title": "Versioni",
+      "current": "Attuale",
+      "viewVersion": "Vedi versione"
+    },
+    "confirmations": {
+      "send": "Inviare il preventivo al paziente?",
+      "sendDescription": "Il preventivo sarà contrassegnato come inviato.",
+      "reject": "Rifiutare il preventivo?",
+      "rejectDescription": "Questa azione non può essere annullata.",
+      "cancel": "Annullare il preventivo?",
+      "cancelDescription": "Questa azione non può essere annullata.",
+      "resend": "Creare una nuova versione di questo preventivo? Il piano di cura collegato seguirà la nuova versione.",
+      "delete": "Eliminare il preventivo?",
+      "deleteDescription": "Questa azione non può essere annullata."
+    },
+    "send": {
+      "description": "Puoi inviare il preventivo via e-mail o contrassegnarlo come consegnato manualmente (stampato o consegnato a mano).",
+      "sendByEmail": "Invia via e-mail",
+      "willSendTo": "Sarà inviato a",
+      "noPatientEmail": "Il paziente non ha un'e-mail registrata",
+      "customMessage": "Messaggio personalizzato (facoltativo)",
+      "customMessagePlaceholder": "Aggiungi un messaggio per il paziente...",
+      "manualNote": "Il preventivo sarà contrassegnato come inviato senza inviare alcuna e-mail.",
+      "sendEmail": "Invia e-mail",
+      "markAsSent": "Segna come inviato"
+    },
+    "messages": {
+      "created": "Preventivo creato",
+      "updated": "Preventivo aggiornato",
+      "deleted": "Preventivo eliminato",
+      "sent": "Preventivo inviato",
+      "sentByEmail": "Preventivo inviato via e-mail",
+      "sentManually": "Preventivo contrassegnato come inviato",
+      "accepted": "Preventivo accettato",
+      "rejected": "Preventivo rifiutato",
+      "cancelled": "Preventivo annullato",
+      "duplicated": "Nuova versione creata",
+      "resent": "Nuova versione creata dal preventivo precedente",
+      "itemAdded": "Trattamento aggiunto",
+      "itemUpdated": "Trattamento aggiornato",
+      "itemRemoved": "Trattamento rimosso",
+      "treatmentStarted": "Trattamento iniziato",
+      "treatmentCompleted": "Trattamento completato"
+    },
+    "errors": {
+      "load": "Errore nel caricamento dei preventivi",
+      "create": "Errore nella creazione del preventivo",
+      "update": "Errore nell'aggiornamento del preventivo",
+      "delete": "Errore nell'eliminazione del preventivo",
+      "send": "Errore nell'invio del preventivo",
+      "accept": "Errore nell'accettazione del preventivo",
+      "reject": "Errore nel rifiuto del preventivo",
+      "notFound": "Preventivo non trovato",
+      "onlyDraft": "Solo i preventivi in bozza sono modificabili"
+    },
+    "filters": {
+      "allStatuses": "Tutti gli stati",
+      "status": "Stato",
+      "paymentStatus": "Stato",
+      "professional": "Professionista",
+      "validity": "Validità",
+      "validityValid": "Valido",
+      "validityExpiringSoon": "Scade tra 7 giorni",
+      "validityExpired": "Scaduto",
+      "dateFrom": "Dal",
+      "dateTo": "Al",
+      "showExpired": "Mostra scaduti",
+      "advanced": "Filtri avanzati",
+      "clear": "Cancella filtri"
+    },
+    "sortFields": {
+      "createdAt": "Creato",
+      "validUntil": "Valido fino al",
+      "total": "Totale",
+      "status": "Stato",
+      "budgetNumber": "Numero"
+    },
+    "validity": {
+      "expired": "Scaduto",
+      "expiresIn": "Scade tra {days} g"
+    },
+    "pdf": {
+      "generating": "Generazione del PDF...",
+      "downloadError": "Errore nello scaricamento del PDF"
+    },
+    "modals": {
+      "renegotiate": {
+        "title": "Rinegozia il preventivo",
+        "description": "Il preventivo attuale sarà annullato e il piano tornerà in Bozza per poter modificare i trattamenti.",
+        "submit": "Rinegozia"
+      },
+      "acceptInClinic": {
+        "title": "Accetta il preventivo in studio",
+        "description": "Registra l'accettazione del paziente. Puoi acquisire una firma su tablet (facoltativo).",
+        "signerLabel": "Nome completo del firmatario",
+        "captureSignature": "Acquisisci firma",
+        "submit": "Segna come accettato"
+      },
+      "setPublicCode": {
+        "title": "Imposta codice di accesso",
+        "description": "Questo paziente non ha né telefono né data di nascita in scheda. Imposta un codice di 4-6 cifre e comunicaglielo a voce. NON includere il codice nell'e-mail.",
+        "codeLabel": "Codice (4-6 cifre)",
+        "submit": "Salva codice"
+      }
+    },
+    "publicLink": {
+      "action": "Condividi link",
+      "title": "Link per il paziente",
+      "help": "Copia questo link e condividilo con il paziente via WhatsApp, SMS o e-mail. Prima di vedere il preventivo gli sarà chiesto un dato di verifica.",
+      "copy": "Copia link",
+      "copied": "Copiato!",
+      "whatsapp": "Invia via WhatsApp",
+      "whatsappNoPhone": "Il paziente non ha un telefono in scheda",
+      "whatsappGreeting": "Ciao {name}, ecco il tuo preventivo:",
+      "whatsappGreetingFallback": "Salve, ecco il suo preventivo:",
+      "preview": "Anteprima",
+      "statusSent": "Inviato",
+      "statusAccepted": "Accettato",
+      "statusRejected": "Rifiutato",
+      "statusExpired": "Scaduto"
+    },
+    "public": {
+      "title": "Il tuo preventivo",
+      "intro": "{clinic} ti ha inviato questo preventivo. Esamina i trattamenti e scegli un'opzione.",
+      "greeting": "Ciao, {name}",
+      "subtitle": "Il tuo piano di cura personalizzato",
+      "budgetNumber": "Preventivo",
+      "issuedOn": "Emesso il {date}",
+      "items": "Trattamenti inclusi",
+      "tooth": "Dente {number}",
+      "subtotal": "Subtotale",
+      "discount": "Sconto",
+      "tax": "IVA",
+      "total": "Totale",
+      "validUntil": "Valido fino al {date}",
+      "trustSecure": "Connessione sicura",
+      "trustEncrypted": "Dati crittografati",
+      "trustSignature": "Firma legalmente vincolante",
+      "needHelp": "Ti serve aiuto? Chiama lo studio",
+      "noteFromClinic": "Messaggio dello studio",
+      "callClinic": "Chiama lo studio",
+      "emailClinic": "Invia e-mail",
+      "cta_accept": "Accetta e firma",
+      "cta_reject": "Non mi interessa",
+      "expired": "Questo preventivo è scaduto. Contatta lo studio.",
+      "locked": "Accesso bloccato per troppi tentativi. Chiama lo studio.",
+      "already_accepted": "Hai già accettato questo preventivo. Lo studio ti contatterà per fissare il primo appuntamento.",
+      "already_rejected": "Hai rifiutato questo preventivo. Se cambi idea, chiama lo studio.",
+      "download": {
+        "signedPdf": "Scarica il PDF firmato",
+        "notSigned": "Questo preventivo non ha ancora una firma allegata.",
+        "error": "Impossibile scaricare il PDF. Riprova.",
+        "reauthIntro": "Per sicurezza, verifica di nuovo la tua identità per scaricare il PDF firmato."
+      },
+      "verify": {
+        "title": "Verifica la tua identità",
+        "intro": "Per proteggere le tue informazioni, conferma un dato prima di vedere il preventivo.",
+        "phone_last4_label": "Le ultime 4 cifre del tuo telefono",
+        "dob_label": "La tua data di nascita",
+        "manual_code_label": "Il codice fornito dallo studio",
+        "submit": "Continua",
+        "invalid": "Dato errato. Riprova.",
+        "locked": "Accesso bloccato per troppi tentativi. Chiama lo studio.",
+        "rate_limited": "Troppi tentativi. Attendi 15 minuti."
+      },
+      "accept": {
+        "title": "Accetta e firma",
+        "signerLabel": "Il tuo nome completo",
+        "signatureLabel": "Firma qui (facoltativo)",
+        "signatureClear": "Cancella",
+        "consent": "Accetto questo preventivo e autorizzo il trattamento descritto.",
+        "submit": "Conferma l'accettazione",
+        "success": "Fatto! Lo studio ti contatterà per fissare il primo appuntamento."
+      },
+      "reject": {
+        "title": "Non mi interessa",
+        "intro": "Perché questo preventivo non fa per te?",
+        "reasonLabel": "Motivo",
+        "noteLabel": "Commento (facoltativo)",
+        "submit": "Conferma il rifiuto",
+        "success": "Abbiamo avvisato lo studio.",
+        "reasons": {
+          "price": "Prezzo",
+          "time": "Mancanza di tempo",
+          "second_opinion": "Secondo parere",
+          "other": "Altro motivo"
+        }
+      }
+    },
+    "settings": {
+      "title": "Impostazioni dei preventivi",
+      "description": "Configura scadenza, promemoria e verifica del link pubblico.",
+      "cards": {
+        "expiry": {
+          "title": "Scadenza e chiusura automatica",
+          "description": "Quanto resta valido un preventivo e quando chiudere automaticamente i piani in sospeso."
+        },
+        "reminders": {
+          "title": "Promemoria automatici",
+          "description": "Attiva o disattiva i promemoria e-mail a 7 e 14 giorni per i pazienti senza risposta."
+        },
+        "publicLink": {
+          "title": "Link pubblico e verifica",
+          "description": "Configura la protezione del link del preventivo rivolto al paziente."
+        }
+      },
+      "expiry": {
+        "validityDays": "Validità del preventivo (giorni)",
+        "validityHelp": "Dopo questo numero di giorni senza risposta il preventivo passa a Scaduto (intervallo 7-180).",
+        "autoCloseDays": "Giorni prima della chiusura automatica del piano",
+        "autoCloseHelp": "I piani con preventivo scaduto e senza attività per questo numero di giorni passano a Chiuso (intervallo 7-180).",
+        "save": "Salva"
+      },
+      "reminders": {
+        "enabled": "Invia promemoria automatici a 7 e 14 giorni",
+        "enabledHelp": "Se attivo, il sistema invia e-mail al paziente sui preventivi in sospeso. Se disattivo, la reception segue manualmente.",
+        "save": "Salva"
+      },
+      "publicLink": {
+        "authDisabled": "Disattiva la verifica del link pubblico",
+        "authDisabledHelp": "Se attivo, il paziente vede il preventivo con il solo link — senza verifica di telefono o data di nascita. Accetta il rischio se il link viene condiviso.",
+        "save": "Salva"
+      },
+      "saved": "Impostazioni salvate"
+    }
+  },
+  "notifications": {
+    "communications": {
+      "language": {
+        "cardTitle": "Lingua delle comunicazioni",
+        "cardDescription": "Lingua della vista preventivo per il paziente, delle e-mail e degli SMS.",
+        "title": "Lingua delle comunicazioni ai pazienti",
+        "label": "Lingua",
+        "help": "Si applica alla vista preventivo per il paziente e ai modelli automatici e-mail/SMS. L'interfaccia dello staff mantiene la lingua di ogni utente.",
+        "save": "Salva",
+        "saved": "Lingua salvata"
+      }
+    },
+    "title": "Notifiche",
+    "description": "Configura le notifiche e-mail dello studio",
+    "pageDescription": "Configura quali notifiche vengono inviate automaticamente e quali richiedono l'invio manuale.",
+    "autoVsManual": "Notifiche automatiche e manuali",
+    "autoVsManualDescription": "Definisci quali notifiche partono automaticamente al verificarsi di un evento e quali l'utente deve inviare manualmente.",
+    "notificationType": "Tipo di notifica",
+    "enabled": "Attiva",
+    "autoSend": "Invio automatico",
+    "options": "Opzioni",
+    "hoursBefore": "h prima",
+    "testConnection": "Prova connessione",
+    "testEmailTitle": "Invia e-mail di prova",
+    "testEmailDescription": "Invieremo un'e-mail di prova per verificare che la configurazione funzioni correttamente.",
+    "sendTestEmail": "Invia prova",
+    "test_email_sent": "E-mail di prova inviata con successo",
+    "settings_saved": "Impostazioni salvate",
+    "emailProvider": "Provider e-mail",
+    "providerConfigured": "Provider e-mail configurato",
+    "providerNote": "La configurazione del server e-mail avviene nelle variabili d'ambiente del server.",
+    "infoTitle": "Informazioni",
+    "infoAutoSend": "Invio automatico: la notifica parte al verificarsi dell'evento (es. alla creazione di un appuntamento).",
+    "infoManualSend": "Invio manuale: apparirà un pulsante per inviare la notifica quando desiderato.",
+    "infoDisabled": "Disattivata: la notifica non sarà inviata e l'opzione di invio non apparirà.",
+    "types": {
+      "appointment_confirmation": "Conferma appuntamento",
+      "appointment_confirmation_desc": "E-mail di conferma alla creazione di un appuntamento",
+      "appointment_cancelled": "Annullamento appuntamento",
+      "appointment_cancelled_desc": "E-mail di notifica all'annullamento di un appuntamento",
+      "appointment_reminder": "Promemoria appuntamento",
+      "appointment_reminder_desc": "E-mail di promemoria prima dell'appuntamento",
+      "budget_sent": "Invio del preventivo",
+      "budget_sent_desc": "E-mail con i dettagli del preventivo",
+      "budget_accepted": "Preventivo accettato",
+      "budget_accepted_desc": "E-mail di conferma all'accettazione di un preventivo",
+      "welcome": "Benvenuto",
+      "welcome_desc": "E-mail di benvenuto per i nuovi pazienti"
+    },
+    "sendConfirmation": "Invia conferma",
+    "sendReminder": "Invia promemoria",
+    "sendCancellation": "Invia annullamento",
+    "sendBudget": "Invia via e-mail",
+    "sendAcceptance": "Invia conferma",
+    "sendWelcome": "Invia benvenuto",
+    "sendEmail": "Invia e-mail",
+    "errors": {
+      "fetch_failed": "Errore nel caricamento delle impostazioni",
+      "save_failed": "Errore nel salvataggio delle impostazioni",
+      "test_failed": "Errore nell'invio dell'e-mail di prova",
+      "send_failed": "Errore nell'invio della notifica"
+    },
+    "smtp": {
+      "title": "Configurazione del server e-mail",
+      "description": "Configura il server SMTP per inviare e-mail dal tuo studio. Ogni studio può avere la propria configurazione.",
+      "configure": "Configura",
+      "provider": "Provider",
+      "host": "Server",
+      "port": "Porta",
+      "username": "Nome utente",
+      "password": "Password",
+      "passwordHint": "Lascia vuoto per mantenere la password attuale",
+      "useTls": "Usa TLS",
+      "useSsl": "Usa SSL",
+      "fromEmail": "E-mail mittente",
+      "fromName": "Nome mittente",
+      "security": "Sicurezza",
+      "testConnection": "Prova connessione",
+      "testConnectionTitle": "Prova la configurazione prima di salvare",
+      "testEmailPlaceholder": "Indirizzo e-mail di prova",
+      "test_success": "Connessione SMTP riuscita. E-mail di prova inviata.",
+      "test_failed": "Errore di connessione SMTP",
+      "settings_saved": "Impostazioni SMTP salvate",
+      "consoleNote": "In modalità console le e-mail vengono mostrate nella console del server invece di essere inviate. Utile in sviluppo.",
+      "disabledNote": "Con l'e-mail disattivata, da questo studio non partirà alcuna notifica e-mail.",
+      "status": {
+        "not_configured": "Non configurato",
+        "verified": "Verificato e funzionante",
+        "not_verified": "Configurato ma non verificato",
+        "disabled": "E-mail disattivata",
+        "console": "Modalità console (sviluppo)"
+      },
+      "errors": {
+        "fetch_failed": "Errore nel caricamento delle impostazioni SMTP",
+        "save_failed": "Errore nel salvataggio delle impostazioni SMTP",
+        "test_failed": "Errore nella prova della connessione SMTP"
+      }
+    },
+    "onboarding": {
+      "label": "Invio e-mail",
+      "description": "Imposta il mittente per inviare via e-mail conferme di appuntamento e preventivi."
+    }
+  },
+  "invoice": {
+    "title": "Fatture",
+    "description": "Gestisci fatture e fatturazione",
+    "new": "Nuova fattura",
+    "edit": "Modifica fattura",
+    "view": "Vedi fattura",
+    "delete": "Elimina fattura",
+    "noItems": "Nessuna fattura",
+    "empty": "Nessuna fattura registrata",
+    "emptyAction": "Crea la prima fattura",
+    "searchPlaceholder": "Cerca per numero o paziente...",
+    "notFound": "Fattura non trovata",
+    "draftNoNumber": "Bozza",
+    "details": "Dettagli",
+    "invoiceNumber": "Numero fattura",
+    "patient": "Paziente",
+    "searchPatient": "Cerca paziente",
+    "searchPatientPlaceholder": "Cerca per nome...",
+    "professional": "Professionista",
+    "billingData": "Dati di fatturazione",
+    "billingName": "Intestazione fattura",
+    "taxId": "Codice fiscale / P. IVA",
+    "billingEmail": "E-mail di fatturazione",
+    "billingAddress": "Indirizzo di fatturazione",
+    "billingDataComplete": "Completi",
+    "billingDataIncomplete": "Incompleti",
+    "billingDataIncompleteHint": "Al paziente mancano alcuni dati di fatturazione.",
+    "editPatientBilling": "Modifica i dati del paziente",
+    "fromPatient": "Dal paziente",
+    "editInPatient": "Modifica nel profilo",
+    "billingFromPatientHint": "Questi dati provengono dalla scheda del paziente. Per cambiarli, modifica i dati di fatturazione del paziente.",
+    "paymentTerms": "Termini di pagamento",
+    "linkedToBudget": "Collegata al preventivo",
+    "selectPatient": "Seleziona paziente",
+    "noBillingData": "Nessun dato di fatturazione",
+    "street": "Via",
+    "city": "Città",
+    "postalCode": "CAP",
+    "province": "Provincia",
+    "country": "Paese",
+    "linkedBudget": "Preventivo collegato",
+    "creditNoteFor": "Nota di credito per",
+    "paymentTermDays": "Termine di pagamento (giorni)",
+    "dueDate": "Scadenza",
+    "issueDate": "Data di emissione",
+    "subtotal": "Subtotale",
+    "discount": "Sconto",
+    "totalDiscount": "Sconto totale",
+    "tax": "Imposta",
+    "total": "Totale",
+    "paid": "Pagato",
+    "totalPaid": "Totale incassato",
+    "balance": "Saldo",
+    "balanceDue": "Saldo dovuto",
+    "overdue": "Scaduta",
+    "overdueDays": "Scaduta da {n} g",
+    "info": {
+      "issueDate": "Data di emissione",
+      "dueDate": "Scadenza",
+      "issuedBy": "Emessa da",
+      "createdBy": "Creata da",
+      "createdAt": "Creata",
+      "budget": "Preventivo",
+      "creditNoteFor": "Nota di credito per"
+    },
+    "criticalBanner": {
+      "aeatRejected": {
+        "title": "L'AEAT ha respinto questa fattura",
+        "cta": "Correggi e reinvia"
+      },
+      "billingIncomplete": {
+        "title": "Dati di fatturazione incompleti",
+        "cta": "Completa i dati"
+      }
+    },
+    "collect": {
+      "title": "Incassa la fattura",
+      "submit": "Incassa",
+      "noteAppliedToInvoice": "imputato a questa fattura.",
+      "notePendingAfter": "Saldo residuo",
+      "noteFullySettled": "Questo pagamento salda interamente la fattura.",
+      "noteToInvoice": "imputato a questa fattura e",
+      "noteExcessToOnAccount": "accreditato sul conto del paziente.",
+      "noteInvoiceSettled": "Questa fattura è già pagata.",
+      "noteToOnAccount": "sarà accreditato sul conto del paziente."
+    },
+    "tooth": "Dente",
+    "vat": "IVA",
+    "currency": "Valuta",
+    "internalNotes": "Note interne",
+    "internalNotesPlaceholder": "Note visibili solo allo staff...",
+    "publicNotes": "Note pubbliche",
+    "publicNotesPlaceholder": "Note visibili in fattura...",
+    "items": "Voci",
+    "addItem": "Aggiungi voce",
+    "editItem": "Modifica voce",
+    "selectTreatment": "Trattamento",
+    "searchCatalog": "Cerca trattamento nel listino...",
+    "itemDescription": "Descrizione",
+    "itemPrice": "Prezzo unitario",
+    "itemQuantity": "Quantità",
+    "selectVatType": "Seleziona aliquota IVA",
+    "summary": "Riepilogo",
+    "createDraft": "Crea bozza",
+    "createFromBudget": "Crea fattura da preventivo",
+    "notes": "Note",
+    "status": {
+      "draft": "Bozza",
+      "issued": "Emessa",
+      "partial": "Parzialmente pagata",
+      "paid": "Pagata",
+      "cancelled": "Annullata",
+      "voided": "Stornata"
+    },
+    "actions": {
+      "issue": "Emetti fattura",
+      "void": "Storna",
+      "recordPayment": "Registra pagamento",
+      "createCreditNote": "Crea nota di credito",
+      "downloadPdf": "Scarica PDF",
+      "previewPdf": "Anteprima PDF",
+      "sendEmail": "Invia via e-mail"
+    },
+    "recordPayment": "Registra pagamento",
+    "paymentAmount": "Importo",
+    "paymentMethod": "Metodo di pagamento",
+    "paymentDate": "Data del pagamento",
+    "paymentReference": "Riferimento",
+    "paymentReferencePlaceholder": "Numero transazione, ricevuta...",
+    "paymentNotes": "Note sul pagamento",
+    "paymentVoided": "Pagamento stornato",
+    "createCreditNote": "Crea nota di credito",
+    "creditNoteReason": "Motivo della nota di credito",
+    "creditNoteReasonPlaceholder": "Descrivi il motivo della nota di credito...",
+    "creditNoteInfo": "Verrà creata una nota di credito per l'intero importo della fattura.",
+    "prompts": {
+      "voidPaymentReason": "Inserisci il motivo dello storno di questo pagamento"
+    },
+    "payments": {
+      "title": "Pagamenti",
+      "record": "Registra pagamento",
+      "void": "Storna pagamento",
+      "amount": "Importo",
+      "method": "Metodo di pagamento",
+      "date": "Data",
+      "reference": "Riferimento",
+      "notes": "Note",
+      "noPayments": "Nessun pagamento registrato",
+      "recorded": "Pagamento registrato",
+      "voided": "Pagamento stornato",
+      "voidReason": "Motivo dello storno",
+      "voidReasonPlaceholder": "Motivo dello storno di questo pagamento...",
+      "methods": {
+        "cash": "Contanti",
+        "card": "Carta",
+        "bank_transfer": "Bonifico",
+        "direct_debit": "Addebito diretto",
+        "insurance": "Assicurazione",
+        "other": "Altro"
+      }
+    },
+    "creditNote": {
+      "title": "Nota di credito",
+      "create": "Crea nota di credito",
+      "reason": "Motivo",
+      "reasonPlaceholder": "Motivo della nota di credito...",
+      "selectItems": "Seleziona le voci da rettificare",
+      "fullCreditNote": "Nota di credito totale (tutte le voci)",
+      "partialCreditNote": "Nota di credito parziale (voci selezionate)",
+      "originalInvoice": "Fattura originale",
+      "created": "Nota di credito creata"
+    },
+    "history": {
+      "title": "Storico",
+      "noChanges": "Nessuna modifica registrata",
+      "actions": {
+        "created": "Fattura creata",
+        "updated": "Fattura aggiornata",
+        "issued": "Fattura emessa",
+        "voided": "Fattura stornata",
+        "payment_recorded": "Pagamento registrato",
+        "payment_voided": "Pagamento stornato",
+        "credit_note_created": "Nota di credito creata"
+      }
+    },
+    "fromBudget": "Crea fattura da preventivo",
+    "selectItems": "Seleziona le voci da fatturare",
+    "selectItemsHint": "Seleziona le voci del preventivo che vuoi fatturare",
+    "availableQuantity": "Disponibile",
+    "quantityToInvoice": "Q.tà da fatturare",
+    "alreadyInvoiced": "Già fatturato",
+    "remaining": "Rimanente",
+    "noItemsAvailable": "Nessuna voce disponibile da fatturare",
+    "allItemsInvoiced": "Tutte le voci sono state fatturate",
+    "series": {
+      "title": "Serie di fatturazione",
+      "prefix": "Prefisso",
+      "type": "Tipo",
+      "currentNumber": "Numero attuale",
+      "resetYearly": "Azzera ogni anno",
+      "default": "Predefinita",
+      "active": "Attiva",
+      "invoice": "Fattura",
+      "credit_note": "Nota di credito"
+    },
+    "filters": {
+      "allStatuses": "Stato",
+      "overdueOnly": "Scadute",
+      "dateFrom": "Dal",
+      "dateTo": "Al"
+    },
+    "sortFields": {
+      "created": "Creata",
+      "issueDate": "Data di emissione",
+      "dueDate": "Scadenza",
+      "total": "Totale"
+    },
+    "overdueByDays": "Scaduta da {days} g",
+    "pdf": {
+      "generating": "Generazione del PDF...",
+      "downloadError": "Errore nello scaricamento del PDF"
+    },
+    "reports": {
+      "title": "Report di fatturazione",
+      "summary": "Riepilogo",
+      "overdue": "Scadute",
+      "overdueInvoices": "Fatture scadute",
+      "byPaymentMethod": "Per metodo di pagamento",
+      "byProfessional": "Per professionista",
+      "vatSummary": "Riepilogo IVA",
+      "gaps": "Buchi di numerazione",
+      "period": "Periodo",
+      "from": "Dal",
+      "to": "Al",
+      "refresh": "Aggiorna",
+      "totalInvoiced": "Totale fatturato",
+      "totalCollected": "Totale incassato",
+      "totalPaid": "Totale pagato",
+      "totalPending": "Totale in sospeso",
+      "pending": "Saldo in sospeso",
+      "invoices": "fatture",
+      "paid": "pagate",
+      "payments": "pagamenti",
+      "noGaps": "Nessun buco nella numerazione",
+      "gapsFound": "Trovati {count} buchi nella numerazione",
+      "gapsDetected": "Buchi rilevati nella numerazione",
+      "missingNumbers": "Numeri mancanti:",
+      "noData": "Nessun dato per il periodo selezionato",
+      "noOverdue": "Nessuna fattura scaduta",
+      "daysOverdue": "giorni di ritardo",
+      "vatType": "Aliquota IVA",
+      "base": "Imponibile",
+      "tax": "Imposta",
+      "thisMonth": "Questo mese",
+      "thisQuarter": "Questo trimestre",
+      "thisYear": "Quest'anno",
+      "lastMonth": "Mese scorso",
+      "lastQuarter": "Trimestre scorso",
+      "lastYear": "Anno scorso"
+    },
+    "confirmations": {
+      "issue": "Emettere la fattura?",
+      "issueDescription": "Una volta emessa, la fattura non è più modificabile. Si possono solo registrare pagamenti o creare note di credito.",
+      "void": "Stornare la fattura?",
+      "voidDescription": "Questa azione non può essere annullata.",
+      "delete": "Eliminare la fattura?",
+      "deleteDescription": "Questa azione non può essere annullata."
+    },
+    "messages": {
+      "created": "Fattura creata",
+      "updated": "Fattura aggiornata",
+      "deleted": "Fattura eliminata",
+      "issued": "Fattura emessa",
+      "voided": "Fattura stornata",
+      "itemAdded": "Voce aggiunta",
+      "itemUpdated": "Voce aggiornata",
+      "sentByEmail": "Fattura inviata via e-mail",
+      "sentManually": "Fattura contrassegnata come inviata"
+    },
+    "send": {
+      "title": "Invia fattura",
+      "description": "Puoi inviare la fattura via e-mail o contrassegnarla come consegnata manualmente (stampata o consegnata di persona).",
+      "sendByEmail": "Invia via e-mail",
+      "willSendTo": "Sarà inviata a",
+      "noPatientEmail": "Il paziente non ha un indirizzo e-mail",
+      "customMessage": "Messaggio personalizzato (facoltativo)",
+      "customMessagePlaceholder": "Aggiungi un messaggio per il paziente...",
+      "manualNote": "La fattura sarà contrassegnata come inviata senza inviare alcuna e-mail.",
+      "sendEmail": "Invia e-mail",
+      "markAsSent": "Segna come inviata"
+    },
+    "errors": {
+      "load": "Errore nel caricamento delle fatture",
+      "create": "Errore nella creazione della fattura",
+      "update": "Errore nell'aggiornamento della fattura",
+      "delete": "Errore nell'eliminazione della fattura",
+      "issue": "Errore nell'emissione della fattura",
+      "void": "Errore nello storno della fattura",
+      "recordPayment": "Errore nella registrazione del pagamento",
+      "voidPayment": "Errore nello storno del pagamento",
+      "createCreditNote": "Errore nella creazione della nota di credito",
+      "send": "Errore nell'invio della fattura",
+      "creditNoteReasonRequired": "Il motivo della nota di credito è obbligatorio",
+      "notFound": "Fattura non trovata",
+      "onlyDraft": "Solo le fatture in bozza sono modificabili",
+      "canOnlyDeleteDraft": "Solo le fatture in bozza sono eliminabili",
+      "patientRequired": "Il paziente è obbligatorio",
+      "itemsRequired": "È richiesta almeno una voce",
+      "itemRequired": "Descrizione e prezzo sono obbligatori",
+      "selectCatalogItem": "Seleziona un trattamento dal listino",
+      "cannotEdit": "Solo le fatture in bozza sono modificabili"
+    },
+    "newItemsPending": "Nuove voci in attesa di salvataggio",
+    "linkedPlan": "Piano di cura"
+  },
+  "reports": {
+    "title": "Report",
+    "subtitle": "Analisi e statistiche dello studio",
+    "viewReports": "Vedi report",
+    "noAccess": "Non hai accesso ad alcun report",
+    "dashboard": {
+      "title": "Cruscotto",
+      "subtitle": "Il tuo studio a colpo d'occhio",
+      "period": "Periodo",
+      "snapshotBadge": "Oggi",
+      "snapshotTooltip": "Non influenzato dall'intervallo di date",
+      "vsPrev": "vs periodo precedente",
+      "empty": {
+        "noData": "Nessun dato in questo intervallo"
+      },
+      "drilldown": {
+        "title": "Approfondisci",
+        "payments": "Pagamenti"
+      },
+      "kpi": {
+        "cashCollected": "Incassato",
+        "cashCollectedHint": "{count} pagamenti",
+        "patientAdvance": "Credito dei pazienti",
+        "patientAdvanceHint": "Anticipi non imputati",
+        "production": "Produzione",
+        "productionHint": "{count} trattamenti",
+        "byMethod": "Per metodo di pagamento",
+        "methodCount": "{count} pagamenti",
+        "total": "Totale",
+        "newPatients": "Nuovi pazienti",
+        "newPatientsHint": "{rate}% degli appuntamenti totali",
+        "appointmentFunnel": "Tasso di assenze",
+        "funnelHint": "{completed}% completati",
+        "avgCollectedTicket": "Incasso medio",
+        "avgTicketHint": "Su {count} pagamenti",
+        "aging": "Anzianità dei crediti"
+      },
+      "charts": {
+        "cashOverTime": "Incassi nel tempo",
+        "productionByDoctor": "Produzione per odontoiatra",
+        "refunded": "Rimborsi"
+      },
+      "production": {
+        "unassigned": "Non assegnato",
+        "others": "Altri",
+        "treatmentCount": "{count} trattamenti"
+      },
+      "aging": {
+        "bucket0_30": "0-30 giorni",
+        "bucket31_60": "31-60 giorni",
+        "bucket61_90": "61-90 giorni",
+        "bucket90plus": "90+ giorni",
+        "empty": "Nessun credito in sospeso",
+        "patientCount": "{count} pazienti"
+      }
+    },
+    "billing": {
+      "title": "Fatturazione",
+      "description": "Ricavi, pagamenti, IVA e fatture scadute",
+      "summary": "Riepilogo",
+      "overdue": "Scadute",
+      "overdueInvoices": "Fatture scadute",
+      "byPaymentMethod": "Per metodo di pagamento",
+      "byProfessional": "Per professionista",
+      "vatSummary": "Riepilogo IVA",
+      "gaps": "Buchi di numerazione",
+      "period": "Periodo",
+      "from": "Dal",
+      "to": "Al",
+      "refresh": "Aggiorna",
+      "totalInvoiced": "Totale fatturato",
+      "totalCollected": "Totale incassato",
+      "pending": "Saldo in sospeso",
+      "invoices": "fatture",
+      "paid": "pagate",
+      "payments": "pagamenti",
+      "gapsDetected": "Buchi rilevati nella numerazione",
+      "missingNumbers": "Numeri mancanti:",
+      "noData": "Nessun dato per il periodo selezionato",
+      "noOverdue": "Nessuna fattura scaduta",
+      "daysOverdue": "giorni di ritardo",
+      "vatType": "Aliquota IVA",
+      "base": "Imponibile",
+      "tax": "Imposta",
+      "thisMonth": "Questo mese",
+      "thisQuarter": "Questo trimestre",
+      "thisYear": "Quest'anno",
+      "lastMonth": "Mese scorso",
+      "lastQuarter": "Trimestre scorso",
+      "lastYear": "Anno scorso"
+    },
+    "budgets": {
+      "title": "Preventivi",
+      "description": "Tassi di accettazione, analisi per professionista e trattamenti",
+      "comingSoonDescription": "I report dei preventivi saranno presto disponibili. Potrai analizzare tassi di accettazione, preventivi per professionista e trattamenti più richiesti.",
+      "features": {
+        "acceptanceRate": "Tasso di accettazione",
+        "acceptanceRateDesc": "Percentuale di preventivi accettati vs rifiutati",
+        "byProfessional": "Per professionista",
+        "byProfessionalDesc": "Preventivi creati da ogni professionista",
+        "byTreatment": "Per trattamento",
+        "byTreatmentDesc": "Trattamenti più preventivati",
+        "averageValue": "Valore medio",
+        "averageValueDesc": "Importo medio dei preventivi"
+      },
+      "labels": {
+        "totalCreated": "Totale creati",
+        "accepted": "Accettati",
+        "rejected": "rifiutati",
+        "pending": "in sospeso",
+        "completed": "Completati",
+        "acceptanceRate": "Tasso di accettazione",
+        "averageValue": "Valore medio",
+        "byStatus": "Per stato",
+        "topTreatments": "Trattamenti più preventivati",
+        "treatment": "Trattamento",
+        "occurrences": "Occorrenze",
+        "quantity": "Quantità"
+      }
+    },
+    "scheduling": {
+      "title": "Agenda",
+      "description": "Prime visite, ore lavorate e occupazione",
+      "comingSoonDescription": "I report dell'agenda saranno presto disponibili. Potrai analizzare prime visite, ore per professionista e tassi di annullamento.",
+      "features": {
+        "firstVisits": "Prime visite",
+        "firstVisitsDesc": "Nuovi pazienti per periodo",
+        "hoursWorked": "Ore lavorate",
+        "hoursWorkedDesc": "Tempo per professionista",
+        "cancellations": "Annullamenti",
+        "cancellationsDesc": "Tassi di annullamento e assenza",
+        "cabinetUtilization": "Occupazione dei riuniti",
+        "cabinetUtilizationDesc": "Utilizzo di ogni riunito"
+      },
+      "labels": {
+        "totalAppointments": "Appuntamenti totali",
+        "completionRate": "Tasso di completamento",
+        "completed": "completati",
+        "cancellationRate": "Tasso di annullamento",
+        "cancelled": "annullati",
+        "noShowRate": "Tasso di assenze",
+        "noShows": "assenze",
+        "newPatients": "nuovi pazienti",
+        "firstVisitRate": "Tasso di prime visite",
+        "ofTotalAppointments": "degli appuntamenti totali",
+        "appointmentsInPeriod": "Appuntamenti nel periodo",
+        "excludingCancelled": "esclusi gli annullati",
+        "appointments": "appuntamenti",
+        "byDayOfWeek": "Per giorno della settimana",
+        "statusBreakdown": "Ripartizione per stato",
+        "pending": "in sospeso"
+      },
+      "analytics": {
+        "funnel": "Funnel degli stati",
+        "funnelDesc": "Distribuzione degli appuntamenti per stato nel periodo",
+        "waitingTimes": "Tempi di attesa",
+        "waitingTimesDesc": "Minuti tra l'arrivo del paziente e l'ingresso al riunito",
+        "punctuality": "Puntualità dei pazienti",
+        "punctualityDesc": "Differenza tra l'orario previsto e l'arrivo effettivo",
+        "durationVariance": "Durata prevista vs effettiva",
+        "durationVarianceDesc": "Confronto tra durata prevista e tempo effettivo al riunito",
+        "samples": "Campioni",
+        "average": "Media",
+        "median": "Mediana",
+        "p90": "P90",
+        "avgDelta": "Delta medio",
+        "medianDelta": "Delta mediano",
+        "onTime": "% puntuali",
+        "avgOverrun": "Sforamento medio",
+        "overrunCount": "Numero di sforamenti",
+        "underCount": "Numero sotto il previsto",
+        "completionRate": "Completamento",
+        "noShowRate": "Assenze",
+        "cancellationRate": "Annullamenti",
+        "punctuality_early": "In anticipo (<-5)",
+        "punctuality_on_time": "Puntuali (±5)",
+        "punctuality_late_short": "In ritardo (5-15)",
+        "punctuality_late_long": "In ritardo (>15)"
+      },
+      "tabs": {
+        "overview": "Panoramica",
+        "activity": "Attività",
+        "quality": "Qualità"
+      },
+      "hero": {
+        "inPeriod": "nel periodo"
+      },
+      "filters": {
+        "cabinet": "Riunito",
+        "professional": "Professionista",
+        "custom": "Intervallo personalizzato",
+        "all": "Tutti",
+        "clear": "Cancella filtri"
+      },
+      "empty": {
+        "title": "Nessun dato per questo periodo",
+        "desc": "Prova un intervallo di date più ampio o rimuovi i filtri."
+      }
+    }
+  },
+  "invoiceSeries": {
+    "title": "Serie di fatturazione",
+    "description": "Configura prefissi e numerazione delle fatture",
+    "regularInvoices": "Fatture",
+    "creditNotes": "Note di credito",
+    "new": "Nuova serie",
+    "newTitle": "Nuova serie {type}",
+    "editTitle": "Modifica serie",
+    "prefix": "Prefisso",
+    "prefixHint": "es. INV, CR. L'anno sarà aggiunto automaticamente.",
+    "descriptionLabel": "Descrizione",
+    "descriptionPlaceholder": "Descrizione facoltativa della serie...",
+    "nextNumber": "Prossimo numero",
+    "preview": "Anteprima",
+    "resetYearly": "Azzeramento annuale",
+    "resetYearlyLabel": "Azzera la numerazione ogni anno",
+    "setAsDefault": "Imposta come predefinita",
+    "activeLabel": "Serie attiva",
+    "showInactive": "Mostra inattive",
+    "noItems": "Nessuna serie configurata",
+    "resetCounter": "Azzera contatore",
+    "currentNumber": "Numero attuale",
+    "seriesPrefix": "Prefisso della serie",
+    "newNumber": "Nuovo numero",
+    "newNumberHint": "Il numero deve essere maggiore del numero più alto esistente in questa serie.",
+    "resetWarningTitle": "Attenzione",
+    "resetWarning": "Questa azione sarà registrata nel log di audit e non può essere annullata.",
+    "confirmReset": "Azzera contatore",
+    "created": "Serie creata con successo",
+    "saved": "Serie aggiornata con successo",
+    "resetSuccess": "Contatore azzerato con successo",
+    "onboarding": {
+      "label": "Serie di fatturazione",
+      "description": "Necessaria per emettere la prima fattura (es. FAC-2026-0001)."
+    }
+  },
+  "documents": {
+    "title": "Documenti",
+    "add": "Aggiungi",
+    "edit": "Modifica documento",
+    "upload": "Carica documento",
+    "uploading": "Caricamento...",
+    "empty": "Ancora nessun documento",
+    "uploadFirst": "Carica il primo documento",
+    "types": {
+      "consent": "Consenso",
+      "id_scan": "Documento d'identità",
+      "insurance": "Assicurazione",
+      "report": "Referto",
+      "referral": "Impegnativa",
+      "other": "Altro"
+    },
+    "fields": {
+      "type": "Tipo",
+      "title": "Titolo",
+      "titlePlaceholder": "Titolo del documento",
+      "description": "Descrizione",
+      "descriptionPlaceholder": "Note facoltative"
+    },
+    "dropzone": {
+      "hint": "Trascina un file qui o fai clic per selezionarlo"
+    },
+    "filter": {
+      "allTypes": "Tutti i tipi"
+    },
+    "deleteConfirm": {
+      "title": "Elimina documento",
+      "message": "Vuoi davvero eliminare questo documento? Questa azione non può essere annullata."
+    },
+    "fetchError": "Errore nel caricamento dei documenti",
+    "uploadSuccess": "Documento caricato con successo",
+    "uploadError": "Errore nel caricamento del documento",
+    "downloadError": "Errore nello scaricamento del documento",
+    "deleteSuccess": "Documento eliminato",
+    "deleteError": "Errore nell'eliminazione del documento",
+    "updateSuccess": "Documento aggiornato",
+    "updateError": "Errore nell'aggiornamento del documento",
+    "viewer": {
+      "loading": "Caricamento del documento...",
+      "error": "Impossibile caricare il documento",
+      "downloadInstead": "Scarica invece",
+      "unsupported": "Anteprima non disponibile per questo tipo di file",
+      "zoomOut": "Riduci",
+      "zoomIn": "Ingrandisci",
+      "resetZoom": "Ripristina al 100%",
+      "zoomHint": "Ctrl + rotellina per lo zoom"
+    },
+    "typeDesc": {
+      "consent": "Documento firmato",
+      "id_scan": "Carta d'identità / passaporto",
+      "insurance": "Polizza o tessera",
+      "report": "Referto clinico",
+      "referral": "Lettera di invio",
+      "other": "Non classificato"
+    },
+    "errors": {
+      "mime": "Tipo di file non consentito. Solo PDF, JPG o PNG.",
+      "size": "Il file supera i 10 MB."
+    },
+    "pdfPreviewHint": "Anteprima disponibile dopo il caricamento",
+    "uploadHelp": "Classifica il file perché compaia nella categoria corretta."
+  },
+  "photoGallery": {
+    "title": "Galleria del paziente",
+    "add": "Aggiungi foto",
+    "empty": "Ancora nessuna foto",
+    "uploadFirst": "Carica la prima",
+    "showingOf": "Mostrate {count} di {total}",
+    "upload": "Carica foto",
+    "uploadHelp": "Classifica perché compaia nella categoria corretta",
+    "dropHere": "Trascina una foto qui o fai clic",
+    "category": "Tipo",
+    "subtype": "Vista",
+    "titlePlaceholder": "Frontale intraorale — 02/05",
+    "capturedAt": "Data",
+    "exifHint": "Automatico da EXIF",
+    "cat": {
+      "all": "Tutte",
+      "intraoral": "Intraorali",
+      "extraoral": "Extraorali",
+      "xray": "Radiografie",
+      "clinical": "Prima/Dopo",
+      "other": "Altre"
+    },
+    "catDesc": {
+      "intraoral": "Dentro la bocca",
+      "extraoral": "Viso e profilo",
+      "xray": "Immagine radiologica",
+      "clinical": "Confronto del trattamento",
+      "other": "Non classificate"
+    },
+    "sub": {
+      "frontal": "Frontale",
+      "lateral_left": "Laterale sinistra",
+      "lateral_right": "Laterale destra",
+      "occlusal_upper": "Occlusale superiore",
+      "occlusal_lower": "Occlusale inferiore",
+      "palatal": "Palatale",
+      "lingual": "Linguale",
+      "smile": "Sorriso",
+      "rest": "A riposo",
+      "frontal_face": "Frontale",
+      "profile_left": "Profilo sinistro",
+      "profile_right": "Profilo destro",
+      "three_quarter_left": "3/4 sinistro",
+      "three_quarter_right": "3/4 destro",
+      "panoramic": "Panoramica",
+      "periapical": "Periapicale",
+      "bitewing": "Bitewing",
+      "ceph_lat": "Teleradiografia laterale",
+      "ceph_pa": "Teleradiografia PA",
+      "cbct": "CBCT",
+      "occlusal_xray": "Radiografia occlusale",
+      "before": "Prima",
+      "after": "Dopo",
+      "progress": "Avanzamento",
+      "reference": "Riferimento",
+      "portrait": "Ritratto",
+      "document_scan": "Documento",
+      "model_photo": "Modello"
+    },
+    "compare": {
+      "before": "Prima",
+      "after": "Dopo"
+    },
+    "pair": {
+      "pickHint": "Scegli la foto da abbinare:",
+      "noCandidates": "Nessuna foto disponibile. Caricane prima un'altra.",
+      "paired": "Abbinata",
+      "exitCompare": "Esci dal confronto",
+      "compare": "Confronta",
+      "unpair": "Rimuovi",
+      "pair": "Abbina prima/dopo"
+    }
+  },
+  "help": {
+    "label": "Aiuto",
+    "openHelp": "Apri l'aiuto",
+    "drawerTitle": "Aiuto per questa pagina",
+    "unavailable": "Per questa pagina non è ancora disponibile un aiuto contestuale.",
+    "openFullManual": "Apri il manuale completo"
+  },
+  "charts": {
+    "trend": {
+      "ariaLabel": "Andamento su {count} punti"
+    },
+    "donut": {
+      "ariaLabel": "Grafico ad anello, {count} segmenti"
+    }
+  }
+}

--- a/frontend/i18n/locales/pl.json
+++ b/frontend/i18n/locales/pl.json
@@ -1,0 +1,3052 @@
+{
+  "app": {
+    "name": "DentalPin",
+    "tagline": "Zarządzanie gabinetem stomatologicznym"
+  },
+  "demo": {
+    "bannerMessage": "Publiczna wersja demo — nie wprowadzaj prawdziwych danych pacjentów. Baza danych jest okresowo resetowana.",
+    "bannerDismiss": "Ukryj",
+    "credentialsTitle": "Dane logowania do wersji demo",
+    "credentialsNote": "Wyłącznie do celów testowych — widoczne, ponieważ to publiczna instancja demo.",
+    "copyEmail": "Kopiuj e-mail",
+    "copyPassword": "Kopiuj hasło",
+    "copied": "Skopiowano do schowka"
+  },
+  "nav": {
+    "dashboard": "Start",
+    "patients": "Pacjenci",
+    "appointments": "Terminarz",
+    "recalls": "Wizyty kontrolne",
+    "treatmentPlans": "Plany leczenia",
+    "budgets": "Kosztorysy",
+    "invoices": "Faktury",
+    "reports": "Raporty",
+    "settings": "Ustawienia",
+    "defaultClinicName": "Gabinet",
+    "catalog": "Katalog zabiegów",
+    "contacts": "Kontakty",
+    "expenses": "Wydatki",
+    "labOrdersForm": "Nowe zlecenie laboratoryjne",
+    "labOrdersStatus": "Zlecenia laboratoryjne",
+    "menu": "Menu",
+    "openMenu": "Otwórz menu",
+    "close": "Zamknij",
+    "toggleSidebar": "Przełącz pasek boczny"
+  },
+  "auth": {
+    "login": "Zaloguj się",
+    "logout": "Wyloguj się",
+    "email": "E-mail",
+    "password": "Hasło",
+    "loginButton": "Zaloguj",
+    "loginSuccess": "Zalogowano pomyślnie",
+    "invalidCredentials": "Nieprawidłowy e-mail lub hasło",
+    "emailRequired": "Podaj swój adres e-mail",
+    "passwordRequired": "Podaj swoje hasło",
+    "emailInvalid": "Nieprawidłowy adres e-mail",
+    "accountInactive": "Twoje konto jest nieaktywne. Skontaktuj się z administratorem",
+    "tooManyAttempts": "Zbyt wiele prób. Spróbuj ponownie za kilka minut",
+    "sessionExpired": "Twoja sesja wygasła",
+    "networkError": "Nie udało się połączyć z serwerem",
+    "serverError": "Serwer jest niedostępny. Spróbuj ponownie za kilka minut",
+    "unknownError": "Nieoczekiwany błąd. Spróbuj ponownie"
+  },
+  "setup": {
+    "title": "Pierwsza konfiguracja",
+    "subtitle": "Utwórz konto i swój gabinet. Zaczniesz pracę w dwie minuty.",
+    "stepAccount": "Konto administratora",
+    "stepClinic": "Dane gabinetu",
+    "firstName": "Imię",
+    "lastName": "Nazwisko",
+    "email": "E-mail",
+    "password": "Hasło",
+    "passwordConfirm": "Potwierdź hasło",
+    "passwordHint": "Co najmniej 8 znaków, litery i cyfry",
+    "clinicName": "Nazwa gabinetu",
+    "taxId": "NIP",
+    "next": "Dalej",
+    "back": "Wstecz",
+    "submit": "Utwórz mój gabinet",
+    "success": "Gotowe! Witamy w DentalPin",
+    "firstNameRequired": "Podaj imię",
+    "lastNameRequired": "Podaj nazwisko",
+    "emailRequired": "Podaj adres e-mail",
+    "emailInvalid": "Adres e-mail jest nieprawidłowy",
+    "passwordRequired": "Podaj hasło",
+    "passwordTooShort": "Hasło musi mieć co najmniej 8 znaków",
+    "passwordWeak": "Hasło musi zawierać litery i cyfry",
+    "passwordMismatch": "Hasła nie są zgodne",
+    "clinicNameRequired": "Podaj nazwę gabinetu",
+    "taxIdRequired": "Podaj NIP",
+    "alreadyInitialized": "System jest już skonfigurowany. Zaloguj się.",
+    "error": "Nie udało się ukończyć konfiguracji. Spróbuj ponownie",
+    "stepOf": "Krok {current} z {total}",
+    "country": "Kraj",
+    "countryHelp": "Ustawia podatki, walutę i strefę czasową",
+    "countryRequired": "Wybierz kraj",
+    "taxIdGeneric": "Numer identyfikacji podatkowej",
+    "taxIdLooksInvalid": "To nie wygląda na prawidłowy numer. Sprawdź go przed wystawianiem faktur.",
+    "taxIdFormat": "Nieprawidłowy format (przykład: {example})",
+    "timezoneRequired": "Wybierz strefę czasową",
+    "currencyRequired": "Wybierz walutę",
+    "derivedSettings": "Strefa czasowa i waluta",
+    "willSeed": "Utworzymy dla Ciebie katalog zabiegów, stawki VAT, serię faktur, jeden gabinet zabiegowy i grafik od poniedziałku do piątku. Wszystko można później zmienić.",
+    "willSuggestVerifactu": "Następnie zaproponujemy włączenie VeriFactu.",
+    "invalidData": "Sprawdź dane: któreś pole jest nieprawidłowe."
+  },
+  "onboarding": {
+    "title": "Pierwsze kroki",
+    "progress": "Ukończono {done} z {total} kroków",
+    "configure": "Skonfiguruj",
+    "skip": "Pomiń",
+    "unskip": "Cofnij",
+    "dismiss": "Ukryj",
+    "guidedMode": "Tryb z przewodnikiem",
+    "optional": "Opcjonalne ({count})",
+    "stepOf": "Krok {current} z {total}",
+    "next": "Dalej",
+    "finish": "Zakończ",
+    "exit": "Wyjdź",
+    "completedTitle": "Twój gabinet jest gotowy!",
+    "completedDescription": "Konfiguracja zakończona. Możesz teraz normalnie pracować.",
+    "guidedDoneTitle": "Przewodnik ukończony",
+    "guidedDoneDescription": "Nie ma już żadnych zaległych kroków.",
+    "items": {
+      "team": {
+        "label": "Twój zespół",
+        "description": "Dodaj lekarzy przyjmujących pacjentów lub oznacz siebie jako lekarza, jeśli pracujesz samodzielnie."
+      },
+      "verifactu": {
+        "label": "Włącz VeriFactu",
+        "description": "Wymagane w Hiszpanii do wystawiania faktur ważnych dla urzędu skarbowego (AEAT)."
+      }
+    }
+  },
+  "actions": {
+    "edit": "Edytuj",
+    "cancel": "Anuluj",
+    "save": "Zapisz",
+    "create": "Utwórz",
+    "delete": "Usuń",
+    "close": "Zamknij",
+    "remove": "Usuń"
+  },
+  "patients": {
+    "title": "Pacjenci",
+    "create": "Nowy pacjent",
+    "edit": "Edytuj pacjenta",
+    "search": "Szukaj pacjenta...",
+    "searchPlaceholder": "Imię, nazwisko lub telefon",
+    "noResults": "Nie znaleziono pacjentów",
+    "empty": "Brak zarejestrowanych pacjentów",
+    "emptyAction": "Dodaj pierwszego pacjenta",
+    "name": "Imię i nazwisko",
+    "firstName": "Imię",
+    "lastName": "Nazwisko",
+    "phone": "Telefon",
+    "email": "E-mail",
+    "dateOfBirth": "Data urodzenia",
+    "notes": "Notatki",
+    "created": "Pacjent dodany",
+    "updated": "Dane pacjenta zaktualizowane",
+    "archived": "Pacjent zarchiwizowany",
+    "notFound": "Nie znaleziono pacjenta",
+    "archiveConfirm": "Zarchiwizować pacjenta {name}?",
+    "archiveDescription": "Pacjent zostanie ukryty w wyszukiwaniu. Istniejące wizyty nie zostaną usunięte.",
+    "cancel": "Anuluj",
+    "archive": "Archiwizuj",
+    "dangerZone": {
+      "title": "Strefa ryzyka",
+      "archiveHelp": "Zarchiwizuj pacjenta, aby ukryć go w wyszukiwaniu. Wizyty i historia zostaną zachowane."
+    },
+    "billingSection": "Dane do faktur",
+    "billingSectionHint": "Te dane będą automatycznie używane przy wystawianiu faktur dla tego pacjenta.",
+    "editingBillingForInvoice": "Edycja danych do faktur. Zmiany pojawią się na fakturze.",
+    "returnToInvoice": "Wróć do faktury",
+    "billingName": "Nazwa na fakturze",
+    "billingNamePlaceholder": "Imię i nazwisko lub firma na fakturach",
+    "billingTaxId": "NIP",
+    "billingEmail": "E-mail do faktur",
+    "billingAddress": "Adres na fakturze",
+    "billingComplete": "Kompletne",
+    "billingIncomplete": "Niekompletne",
+    "demographics": "Dane osobowe",
+    "nationalId": "Dokument tożsamości",
+    "nationalIdType": "Rodzaj dokumentu",
+    "passport": "Paszport",
+    "profession": "Zawód",
+    "workplace": "Miejsce pracy",
+    "years": "lat",
+    "status": {
+      "active": "Aktywny",
+      "archived": "Zarchiwizowany"
+    },
+    "filters": {
+      "status": "Status",
+      "city": "Miasto",
+      "withDebt": "Z zadłużeniem",
+      "doNotContact": "Nie kontaktować",
+      "doNotContactOnly": "Tylko oznaczeni „nie kontaktować”",
+      "doNotContactOnlyContactable": "Tylko dostępni do kontaktu"
+    },
+    "columns": {
+      "city": "Miasto",
+      "contact": "Kontakt",
+      "debt": "Zadłużenie"
+    },
+    "sort": {
+      "lastVisit": "Ostatnia wizyta",
+      "lastName": "Nazwisko",
+      "firstName": "Imię",
+      "createdAt": "Data rejestracji",
+      "updatedAt": "Ostatnio edytowani"
+    },
+    "doNotContact": {
+      "label": "Nie kontaktować",
+      "hint": "Pacjent zostanie wykluczony z listy telefonicznej i automatycznych powiadomień",
+      "badge": "Nie kontaktować"
+    },
+    "gender": {
+      "label": "Płeć",
+      "select": "Wybierz płeć",
+      "male": "Mężczyzna",
+      "female": "Kobieta",
+      "other": "Inna",
+      "preferNotSay": "Wolę nie podawać"
+    },
+    "emergencyContact": {
+      "title": "Kontakt alarmowy",
+      "hasContact": "Ma kontakt alarmowy",
+      "noContact": "Brak zarejestrowanego kontaktu alarmowego",
+      "name": "Imię i nazwisko",
+      "namePlaceholder": "Imię i nazwisko osoby kontaktowej",
+      "relationship": "Pokrewieństwo",
+      "relationshipPlaceholder": "Wybierz pokrewieństwo",
+      "phone": "Telefon",
+      "phonePlaceholder": "Telefon osoby kontaktowej",
+      "email": "E-mail",
+      "emailPlaceholder": "E-mail osoby kontaktowej",
+      "isLegalGuardian": "Jest opiekunem prawnym",
+      "remove": "Usuń kontakt",
+      "relationships": {
+        "spouse": "Małżonek/małżonka",
+        "parent": "Rodzic",
+        "child": "Dziecko",
+        "sibling": "Rodzeństwo",
+        "friend": "Znajomy",
+        "other": "Inne"
+      }
+    },
+    "medicalHistory": {
+      "title": "Wywiad medyczny",
+      "save": "Zapisz wywiad",
+      "fetchError": "Błąd podczas wczytywania wywiadu medycznego",
+      "saveSuccess": "Wywiad medyczny zapisany",
+      "saveError": "Błąd podczas zapisywania wywiadu medycznego",
+      "allergies": "Alergie",
+      "allergiesCount": "{n} alergia | {n} alergie | {n} alergii",
+      "onAnticoagulants": "Przyjmuje leki przeciwzakrzepowe",
+      "allergyName": "Nazwa alergii",
+      "type": "Rodzaj",
+      "allergyTypes": {
+        "drug": "Lek",
+        "food": "Pokarm",
+        "material": "Materiał",
+        "environmental": "Środowiskowa"
+      },
+      "severity": {
+        "low": "Łagodna",
+        "medium": "Umiarkowana",
+        "high": "Ciężka",
+        "critical": "Krytyczna"
+      },
+      "medications": "Leki",
+      "medicationName": "Nazwa leku",
+      "dosage": "Dawkowanie",
+      "frequency": "Częstotliwość",
+      "systemicDiseases": "Choroby ogólnoustrojowe",
+      "diseaseName": "Nazwa choroby",
+      "diseaseTypes": {
+        "cardiovascular": "Sercowo-naczyniowa",
+        "respiratory": "Oddechowa",
+        "endocrine": "Endokrynologiczna",
+        "neurological": "Neurologiczna",
+        "autoimmune": "Autoimmunologiczna",
+        "other": "Inna"
+      },
+      "critical": "Krytyczna",
+      "controlled": "Kontrolowana",
+      "notControlled": "Niekontrolowana",
+      "specialConditions": "Stany szczególne",
+      "pregnant": "W ciąży",
+      "pregnancyWeek": "Tydzień ciąży",
+      "lactating": "Karmi piersią",
+      "anticoagulants": "Leki przeciwzakrzepowe",
+      "anticoagulantMedication": "Lek przeciwzakrzepowy",
+      "inrValue": "Wartość INR",
+      "anesthesiaReaction": "Reakcja na znieczulenie",
+      "anesthesiaReactionDetails": "Szczegóły reakcji",
+      "bruxism": "Bruksizm",
+      "lifestyle": "Styl życia",
+      "smoker": "Pali papierosy",
+      "smokingFrequency": "Papierosów dziennie",
+      "alcoholConsumption": "Spożycie alkoholu",
+      "alcohol": {
+        "none": "Brak",
+        "occasional": "Okazjonalne",
+        "moderate": "Umiarkowane",
+        "heavy": "Duże"
+      },
+      "surgicalHistory": "Przebyte operacje",
+      "procedure": "Zabieg"
+    },
+    "timeline": {
+      "empty": "Brak zarejestrowanej aktywności",
+      "emptyFiltered": "Brak zdarzeń w tej kategorii",
+      "clearFilter": "Pokaż całą aktywność",
+      "endOfTimeline": "Koniec osi czasu",
+      "totalEntries": "{count} wpis | {count} wpisy | {count} wpisów",
+      "groups": {
+        "today": "Dzisiaj",
+        "yesterday": "Wczoraj",
+        "thisWeek": "W tym tygodniu",
+        "thisMonth": "W tym miesiącu",
+        "earlier": "Wcześniej"
+      },
+      "author": "przez {name}",
+      "meta": {
+        "cabinet": "Gabinet {name}",
+        "teeth": "Zęby: {list}",
+        "total": "Razem: {amount}",
+        "number": "Nr {value}",
+        "via": "Kanał: {channel}",
+        "template": "Szablon: {key}",
+        "docType": "Rodzaj: {type}"
+      },
+      "categories": {
+        "all": "Wszystkie",
+        "visit": "Wizyty",
+        "treatment": "Zabiegi",
+        "financial": "Finanse",
+        "communication": "Komunikacja",
+        "medical": "Wywiad medyczny",
+        "document": "Dokumenty",
+        "note": "Notatki kliniczne"
+      }
+    },
+    "alerts": {
+      "title": "{count} ostrzeżenie | {count} ostrzeżenia | {count} ostrzeżeń",
+      "label": "Ostrzeżenia kliniczne"
+    },
+    "editDemographics": "Edytuj dane osobowe",
+    "editEmergencyContact": "Edytuj kontakt alarmowy",
+    "editBilling": "Edytuj dane do faktur",
+    "editMedicalHistory": "Edytuj wywiad medyczny",
+    "medicalSnapshot": {
+      "title": "Informacje medyczne",
+      "allergiesLabel": "Alergie",
+      "allergiesEmpty": "Brak znanych alergii",
+      "allergiesNotReviewed": "Wywiad medyczny niezarejestrowany",
+      "completeHistory": "Uzupełnij wywiad",
+      "reviewedOn": "Sprawdzono {date}",
+      "conditions": {
+        "pregnantWeek": "W ciąży · tydz. {week}",
+        "anticoagulantInr": "Leki przeciwzakrzepowe · INR {inr}",
+        "smokerFreq": "Pali · {freq}/dzień"
+      }
+    },
+    "personalInfo": {
+      "title": "Dane osobowe",
+      "ageLabel": "{age} lat",
+      "birthWithAge": "{date} ({age} lat)"
+    },
+    "contactInfo": {
+      "title": "Kontakt",
+      "copyPhone": "Kopiuj telefon",
+      "copyEmail": "Kopiuj e-mail",
+      "address": "Adres",
+      "addEmergency": "Dodaj kontakt alarmowy",
+      "addGuardian": "Dodaj opiekuna prawnego",
+      "guardianRequired": "Wymagany opiekun prawny"
+    },
+    "administrative": {
+      "title": "Administracja"
+    },
+    "header": {
+      "ariaLabel": "Nagłówek pacjenta"
+    },
+    "quickActions": {
+      "ariaLabel": "Szybkie akcje pacjenta"
+    },
+    "onboarding": {
+      "label": "Dodaj pierwszego pacjenta",
+      "description": "Najszybszy sposób, aby zobaczyć w działaniu dokumentację, terminarz i kosztorysy."
+    }
+  },
+  "patientDetail": {
+    "tabs": {
+      "summary": "Podsumowanie",
+      "info": "Dane",
+      "clinical": "Kliniczne",
+      "odontogram": "Diagram zębowy",
+      "administration": "Administracja",
+      "history": "Historia",
+      "timeline": "Aktywność",
+      "appointments": "Wizyty",
+      "budgets": "Kosztorysy",
+      "billing": "Faktury",
+      "payments": "Płatności",
+      "documents": "Dokumenty",
+      "gallery": "Galeria"
+    },
+    "historyPlaceholder": "Notatki kliniczne dostępne w przyszłej wersji",
+    "noAppointments": "Ten pacjent nie ma wizyt",
+    "scheduleAppointment": "Umów wizytę",
+    "noBudgets": "Ten pacjent nie ma kosztorysów",
+    "createBudget": "Utwórz kosztorys",
+    "viewAllBudgets": "Zobacz wszystkie kosztorysy",
+    "activePlan": "Aktywny plan",
+    "noActivePlan": "Brak aktywnego planu",
+    "viewPlan": "Otwórz plan",
+    "createPlan": "Utwórz plan",
+    "nextAppointment": "Następna wizyta",
+    "noUpcomingAppointments": "Brak nadchodzących wizyt",
+    "openAppointment": "Otwórz wizytę",
+    "lastVisit": "Ostatnia wizyta",
+    "neverVisited": "Jeszcze nie było wizyty",
+    "reschedule": "Przełóż",
+    "balance": "Saldo",
+    "collect": "Przyjmij płatność",
+    "viewLedger": "Otwórz rozliczenia",
+    "noPayments": "Brak operacji",
+    "diagnoses": "Rozpoznania",
+    "pending": "nieleczone",
+    "noDiagnoses": "Brak oczekujących rozpoznań",
+    "openOdontogram": "Otwórz diagram zębowy",
+    "medicalHistory": "Wywiad medyczny",
+    "completeMedicalHistory": "Brak wywiadu medycznego. Uzupełnij go, aby zapisać alergie, choroby i leki.",
+    "editMedicalHistory": "Edytuj wywiad medyczny",
+    "quickActions": "Szybkie akcje",
+    "edit": "Edytuj",
+    "editPatient": "Edytuj pacjenta",
+    "noSummaryCards": "Brak modułów zarejestrowanych w podsumowaniu.",
+    "actions": {
+      "label": "Akcje",
+      "newAppointment": "Wizyta",
+      "collect": "Płatność",
+      "newNote": "Notatka",
+      "newBudget": "Kosztorys",
+      "uploadDocument": "Dokument"
+    }
+  },
+  "patientBilling": {
+    "totalBudgeted": "Suma kosztorysów",
+    "workInProgress": "Prace w toku",
+    "workCompleted": "Prace ukończone",
+    "totalInvoiced": "Zafakturowano łącznie",
+    "totalPaid": "Zapłacono łącznie",
+    "balancePending": "Saldo do zapłaty",
+    "invoices": "Faktury",
+    "createInvoice": "Wystaw fakturę",
+    "noInvoices": "Ten pacjent nie ma faktur",
+    "pending": "Oczekujące",
+    "totalDiscount": "rabatów"
+  },
+  "odontogram": {
+    "title": "Diagram zębowy",
+    "tooth": "Ząb",
+    "globals": {
+      "category": "Cała jama ustna",
+      "applied": "{name} dodano do planu",
+      "archPickerTitle": "Który łuk dla \"{name}\"?",
+      "upperArch": "Łuk górny",
+      "lowerArch": "Łuk dolny",
+      "searchPlaceholder": "Szukaj zabiegu…"
+    },
+    "selectCondition": "Wybierz rozpoznanie",
+    "readOnly": "Tylko podgląd",
+    "legend": "Legenda",
+    "statusLegend": "Status zabiegu",
+    "toothPosition": "Położenie zęba",
+    "displaced": "Przemieszczony",
+    "rotated": "Zrotowany",
+    "dentition": {
+      "permanent": "Stałe",
+      "deciduous": "Mleczne",
+      "toggle": "Przełącz uzębienie"
+    },
+    "quadrants": {
+      "upper": "Łuk górny",
+      "lower": "Łuk dolny",
+      "upperRight": "Górny prawy",
+      "upperLeft": "Górny lewy",
+      "lowerRight": "Dolny prawy",
+      "lowerLeft": "Dolny lewy"
+    },
+    "surfaces": {
+      "M": "Mezjalna",
+      "D": "Dystalna",
+      "O": "Okluzyjna",
+      "V": "Przedsionkowa",
+      "L": "Językowa"
+    },
+    "conditions": {
+      "healthy": "Zdrowy",
+      "caries": "Próchnica",
+      "filling": "Wypełnienie",
+      "crown": "Korona",
+      "missing": "Brak zęba",
+      "root_canal": "Leczenie kanałowe",
+      "implant": "Implant",
+      "bridge_pontic": "Przęsło mostu",
+      "bridge_abutment": "Filar mostu",
+      "extraction_indicated": "Wskazana ekstrakcja",
+      "sealant": "Lakowanie",
+      "fracture": "Złamanie"
+    },
+    "history": {
+      "title": "Historia zmian",
+      "noChanges": "Brak zarejestrowanych zmian",
+      "changedBy": "Zmienione przez",
+      "changeTypes": {
+        "created": "Utworzono",
+        "general_condition": "Stan ogólny",
+        "surface_update": "Zmiana powierzchni",
+        "note": "Notatka"
+      }
+    },
+    "messages": {
+      "updated": "Diagram zębowy zaktualizowany",
+      "error": "Błąd podczas aktualizacji diagramu zębowego",
+      "loadError": "Nie udało się wczytać diagramu zębowego"
+    },
+    "actions": {
+      "save": "Zapisz",
+      "reset": "Resetuj",
+      "print": "Drukuj"
+    },
+    "status": {
+      "existing": "Istniejący",
+      "planned": "Zaplanowany"
+    },
+    "treatments": {
+      "title": "Zabiegi",
+      "addTreatment": "Dodaj zabieg",
+      "selectStatus": "Wybierz status",
+      "noTreatments": "Brak zarejestrowanych zabiegów",
+      "markPerformed": "Oznacz jako wykonany",
+      "categories": {
+        "common": "Częste",
+        "restorative": "Zachowawcze",
+        "diagnostic": "Diagnostyka",
+        "orthodontic": "Ortodoncja",
+        "periodontic": "Periodontologia",
+        "position": "Położenie",
+        "other": "Inne",
+        "diagnostico": "Diagnostyka",
+        "restauradora": "Zachowawcze",
+        "cirugia": "Chirurgia",
+        "endodoncia": "Endodoncja",
+        "ortodoncia": "Ortodoncja"
+      },
+      "types": {
+        "pulpitis": "Zapalenie miazgi",
+        "caries": "Próchnica",
+        "incipient_caries": "Próchnica początkowa",
+        "pigmentation": "Przebarwienie",
+        "fracture": "Złamanie",
+        "missing": "Brak zęba",
+        "periapical_small": "Zmiana okołowierzchołkowa <2mm",
+        "periapical_medium": "Zmiana okołowierzchołkowa 2-4mm",
+        "periapical_large": "Zmiana okołowierzchołkowa >4mm",
+        "rotated": "Zrotowany",
+        "displaced": "Przemieszczony",
+        "unerupted": "Niewyrznięty",
+        "filling": "Wypełnienie",
+        "filling_composite": "Wypełnienie kompozytowe",
+        "filling_amalgam": "Wypełnienie amalgamatowe",
+        "filling_temporary": "Wypełnienie tymczasowe",
+        "sealant": "Lakowanie",
+        "veneer": "Licówka",
+        "inlay": "Inlay",
+        "overlay": "Overlay",
+        "crown": "Korona",
+        "crown_on_implant": "Korona na implancie",
+        "provisional_crown_on_implant": "Korona tymczasowa na implancie",
+        "pontic": "Przęsło",
+        "bridge_pontic": "Przęsło mostu",
+        "bridge_abutment": "Filar mostu",
+        "extraction": "Ekstrakcja",
+        "implant": "Implant",
+        "apicoectomy": "Resekcja wierzchołka korzenia",
+        "root_canal": "Leczenie kanałowe",
+        "root_canal_full": "Pełne wypełnienie kanału",
+        "root_canal_two_thirds": "Wypełnienie kanału 2/3",
+        "root_canal_half": "Wypełnienie kanału 1/2",
+        "root_canal_overfill": "Przepełniony kanał",
+        "post": "Wkład koronowo-korzeniowy",
+        "bracket": "Zamek",
+        "tube": "Rurka",
+        "band": "Pierścień",
+        "attachment": "Attachment",
+        "retainer": "Retainer",
+        "rotate": "Zrotowany",
+        "displace": "Przemieszczony",
+        "splint": "Szyna",
+        "migrated": "Zabieg ogólny",
+        "other": "Inny zabieg"
+      },
+      "treatmentAdded": "Zabieg dodany",
+      "treatmentPerformed": "Zabieg oznaczony jako wykonany",
+      "treatmentDeleted": "Zabieg usunięty",
+      "status": {
+        "existing": "Istniejący",
+        "planned": "Zaplanowany"
+      }
+    },
+    "position": {
+      "displaced": "Przemieszczony",
+      "rotated": "Zrotowany",
+      "normal": "Prawidłowe"
+    },
+    "views": {
+      "occlusal": "Widok okluzyjny",
+      "lateral": "Widok boczny",
+      "dual": "Widok podwójny"
+    },
+    "selectSurfaces": "Wybierz powierzchnie",
+    "selectedSurfaces": "Wybrane powierzchnie",
+    "surfacesSelected": "wybranych powierzchni",
+    "instructions": {
+      "selectTreatment": "Wybierz zabieg do zastosowania",
+      "clickTooth": "Kliknij ząb, aby zastosować"
+    },
+    "addToPlan": "Dodaj do planu",
+    "noPlan": "Brak planu",
+    "createNewPlan": "Utwórz nowy plan...",
+    "applyTo": "Zastosuj do",
+    "oneTooth": "1 ząb",
+    "multipleTeeth": "Wiele zębów",
+    "surfacePricingHint": "Cena wg powierzchni: {range}",
+    "toothNames": {
+      "centralIncisor": "Siekacz przyśrodkowy",
+      "lateralIncisor": "Siekacz boczny",
+      "canine": "Kieł",
+      "firstPremolar": "Pierwszy przedtrzonowiec",
+      "secondPremolar": "Drugi przedtrzonowiec",
+      "firstMolar": "Pierwszy trzonowiec",
+      "secondMolar": "Drugi trzonowiec",
+      "thirdMolar": "Trzeci trzonowiec (ząb mądrości)"
+    },
+    "positions": {
+      "upper": "górny",
+      "lower": "dolny",
+      "left": "lewy",
+      "right": "prawy"
+    },
+    "tooltip": {
+      "clickToEdit": "Kliknij, aby edytować"
+    },
+    "planning": "Planowanie",
+    "diagnosisMode": "Diagnoza",
+    "treatmentList": {
+      "title": "Lista zabiegów",
+      "noTreatments": "Brak zarejestrowanych zabiegów"
+    },
+    "changeHistory": {
+      "title": "Historia zmian",
+      "noChanges": "Brak zarejestrowanych zmian",
+      "treatmentAdded": "Zabieg"
+    },
+    "timeline": {
+      "title": "Oś czasu",
+      "viewingDate": "Podgląd: {date}",
+      "viewingHistory": "Przeglądasz historyczny stan diagramu zębowego",
+      "returnToNow": "Wróć do stanu bieżącego",
+      "noHistory": "Brak wcześniejszej historii"
+    },
+    "multiTooth": {
+      "bridge": {
+        "label": "Most stały"
+      },
+      "splint": {
+        "label": "Szyna"
+      },
+      "veneers": {
+        "label": "Wiele licówek"
+      },
+      "crowns": {
+        "label": "Wiele koron"
+      },
+      "pillar": "filar",
+      "pontic": "przęsło",
+      "roleHint": "Kliknij ząb, aby przełączyć filar / przęsło.",
+      "needPillar": "Most wymaga co najmniej jednego zęba filarowego.",
+      "confirmHint": "Zamierzasz utworzyć grupę zabiegów obejmującą {n} zębów.",
+      "willBePlanned": "Grupa zostanie oznaczona jako zaplanowana.",
+      "willBeExisting": "Grupa zostanie zarejestrowana jako istniejąca.",
+      "hints": {
+        "range": "Kliknij pierwszy, a następnie ostatni ząb",
+        "free": "Klikaj, aby dodawać lub usuwać zęby"
+      },
+      "errors": {
+        "tooFew": "Wymagane co najmniej {n} zębów",
+        "tooMany": "Dozwolone najwyżej {n} zębów",
+        "sameArchRequired": "Zęby muszą znajdować się w tym samym łuku"
+      },
+      "sectionLabel": "Zabiegi obejmujące wiele zębów"
+    }
+  },
+  "clinical": {
+    "modes": {
+      "history": "Historia",
+      "diagnosis": "Diagnoza",
+      "plans": "Plany leczenia",
+      "appointments": "Wizyty"
+    },
+    "history": {
+      "stateAt": "Stan na",
+      "changesOnDate": "Zmiany w tym dniu",
+      "noChanges": "Brak zarejestrowanych zmian"
+    },
+    "diagnosis": {
+      "registeredConditions": "Rozpoznane zmiany",
+      "registerConditions": "Zarejestruj zmiany",
+      "noConditions": "Brak zarejestrowanych zmian",
+      "startDiagnosis": "Wybierz ząb i dodaj istniejące zmiany",
+      "generalConditions": "Zmiany ogólne",
+      "readyToCreatePlan": "Diagnoza zakończona?",
+      "createPlan": "Utwórz plan leczenia",
+      "continuePlan": "Kontynuuj plan \"{name}\"",
+      "selectPlan": "Wybierz plan",
+      "continue": "Kontynuuj",
+      "odontogramTab": "Diagram zębowy"
+    },
+    "plans": {
+      "title": "Plany leczenia",
+      "create": "Nowy plan",
+      "backToList": "Wróć do planów",
+      "treatments": "Zabiegi planu",
+      "addTreatment": "Dodaj zabieg",
+      "total": "Razem",
+      "activate": "Aktywuj plan",
+      "generateBudget": "Utwórz kosztorys",
+      "empty": "Brak planów leczenia",
+      "emptyDescription": "Utwórz plan, aby uporządkować zabiegi pacjenta",
+      "createFirst": "Utwórz pierwszy plan",
+      "active": "Aktywne plany",
+      "drafts": "Wersje robocze",
+      "completed": "Ukończone",
+      "closed": "Zamknięte",
+      "other": "Inne",
+      "noItems": "Brak zabiegów w planie",
+      "markComplete": "Oznacz jako ukończony",
+      "removeItem": "Usuń z planu",
+      "sessions": {
+        "progress": "{done}/{total} sesji",
+        "markDone": "Oznacz sesję jako wykonaną",
+        "cancel": "Anuluj sesję",
+        "markedDone": "Sesja oznaczona jako wykonana",
+        "cancelled": "Sesja anulowana",
+        "untitled": "Sesja {n}"
+      },
+      "unknownTreatment": "Zabieg",
+      "odontogram": "Diagram zębowy",
+      "pending": "oczekujące",
+      "dragToReorder": "Przeciągnij, aby zmienić kolejność",
+      "reorderHint": "Przenoś za pomocą Alt + strzałek",
+      "emptyDraft": {
+        "title": "Zaplanuj zabiegi",
+        "step1": "Wybierz zabieg z paska poniżej",
+        "step2": "Kliknij ząb na diagramie zębowym",
+        "step3": "Zatwierdź plan, aby wygenerować kosztorys i wizyty"
+      },
+      "steps": {
+        "plan": "Planowanie",
+        "confirm": "Zatwierdzenie",
+        "inProgress": "W trakcie"
+      },
+      "confirmCta": {
+        "titleWithItems": "Zatwierdź plan",
+        "subtitleWithItems": "Zatwierdzenie odblokowuje tworzenie kosztorysu i umawianie wizyt.",
+        "empty": "Dodaj co najmniej jeden zabieg, aby zatwierdzić plan"
+      },
+      "ghostHint": "Dostępne po zatwierdzeniu planu",
+      "addedToPlan": "Dodano do planu",
+      "addingToPlan": "Dodawanie do tego planu",
+      "cancelPlan": "Anuluj plan",
+      "locked": {
+        "title": "Plan zablokowany",
+        "subtitle": "Kosztorys {number} został wystawiony. Aby edytować zabiegi, użyj opcji Otwórz ponownie (jeśli oczekuje) lub renegocjuj kosztorys.",
+        "viewBudget": "Zobacz kosztorys"
+      }
+    },
+    "tooth": "Ząb"
+  },
+  "appointments": {
+    "title": "Terminarz",
+    "create": "Nowa wizyta",
+    "edit": "Edytuj wizytę",
+    "today": "Dzisiaj",
+    "tomorrow": "Jutro",
+    "yesterday": "Wczoraj",
+    "week": "Tydzień",
+    "prevWeek": "Poprzedni tydzień",
+    "nextWeek": "Następny tydzień",
+    "selectPatient": "Wybierz pacjenta",
+    "selectProfessional": "Wybierz lekarza",
+    "openPatientFile": "Otwórz kartę pacjenta",
+    "patient": "Pacjent",
+    "professional": "Lekarz",
+    "cabinet": "Gabinet",
+    "date": "Data",
+    "time": "Godzina",
+    "startTime": "Rozpoczęcie",
+    "duration": "Czas trwania",
+    "treatmentType": "Rodzaj zabiegu",
+    "treatments": "Zabiegi",
+    "addTreatment": "Dodaj zabieg",
+    "selectTreatment": "Wybierz zabieg",
+    "estimatedDuration": "Szacowany czas",
+    "notes": "Notatki",
+    "hasNotes": "Ma notatki",
+    "actionsMenu": "Akcje wizyty",
+    "status": {
+      "label": "Status",
+      "scheduled": "Zaplanowana",
+      "confirmed": "Potwierdzona",
+      "checked_in": "W poczekalni",
+      "in_treatment": "Na fotelu",
+      "completed": "Zakończona",
+      "cancelled": "Odwołana",
+      "no_show": "Nieobecność"
+    },
+    "scheduled": "Zaplanowana",
+    "confirmed": "Potwierdzona",
+    "inProgress": "W trakcie",
+    "in_progress": "W trakcie",
+    "completed": "Zakończona",
+    "cancelled": "Odwołana",
+    "noShow": "Nieobecność",
+    "no_show": "Nieobecność",
+    "transitions": {
+      "confirmed": "Oznacz jako potwierdzoną",
+      "checked_in": "Zarejestruj przybycie",
+      "in_treatment": "Przenieś na fotel",
+      "completed": "Zakończ wizytę",
+      "cancelled": "Odwołaj wizytę",
+      "no_show": "Oznacz nieobecność"
+    },
+    "timer": {
+      "startsIn": "zacznie się za {minutes} min",
+      "startsInOverdue": "{minutes} min opóźnienia",
+      "waiting": "czeka {minutes} min",
+      "inTreatment": "{elapsed}/{planned} min",
+      "completedAt": "zakończono {time}",
+      "cancelledAt": "odwołano",
+      "noShowAt": "nieobecność"
+    },
+    "confirmTransitionTitle": "Potwierdź zmianę statusu",
+    "confirmCancelMessage": "Odwołać tę wizytę? Zmiana zostanie zapisana w historii.",
+    "confirmNoShowMessage": "Oznaczyć nieobecność pacjenta? Zmiana zostanie zapisana w historii.",
+    "noteLabel": "Notatka (opcjonalnie)",
+    "transitionFailed": "Nie udało się zmienić statusu wizyty",
+    "when": "Kiedy",
+    "whereWho": "Gabinet i lekarz",
+    "followup": {
+      "title": "Czynności po wizycie"
+    },
+    "created": "Wizyta utworzona",
+    "saved": "Wizyta zapisana",
+    "updated": "Wizyta zaktualizowana",
+    "conflict": "Ten termin jest już zajęty",
+    "cancel": "Odwołaj wizytę",
+    "markCompleted": "Oznacz jako zakończoną",
+    "markNoShow": "Nieobecność",
+    "dailyView": "Dzień",
+    "weeklyView": "Tydzień",
+    "kanbanView": "Kanban",
+    "kanban": {
+      "upcoming": "Nadchodzące",
+      "waiting": "Poczekalnia",
+      "inChair": "Na fotelu",
+      "done": "Zakończone",
+      "missed": "Nieobecność / Odwołane",
+      "free": "Wolny",
+      "inactive": "Nieaktywny",
+      "empty": "Brak wizyt",
+      "nextIn": "Następna o {time}",
+      "subtitleCount": "{count} wizyt",
+      "subtitleEmpty": "Brak wizyt",
+      "subtitleWaiting": "{count} oczekujących · śr. {avg} min",
+      "subtitleInChair": "{busy} zajętych · {free} wolnych"
+    },
+    "cabinetAssignment": {
+      "assignLater": "Przydziel później",
+      "unassigned": "Nieprzydzielony",
+      "assign": "Przydziel gabinet",
+      "reassign": "Zmień gabinet",
+      "unassign": "Cofnij przydział gabinetu",
+      "requiredForTreatment": "Przydziel gabinet przed rozpoczęciem zabiegu"
+    },
+    "professionals": {
+      "strip": "Lekarze",
+      "state": {
+        "free": "Wolny",
+        "in_treatment": "Na fotelu",
+        "on_break": "Na przerwie",
+        "off": "Poza pracą"
+      }
+    },
+    "noProfessionals": "Brak skonfigurowanych lekarzy",
+    "overlapWarning": "Wykryto nakładanie się terminów",
+    "overlapProfessional": "Lekarz ma {count} wizyt w tym czasie",
+    "overlapCabinet": "Gabinet ma {count} wizyt w tym czasie",
+    "selectDuration": "Wybierz czas trwania...",
+    "sendEmail": "Wyślij e-mail",
+    "sendConfirmationEmail": "Wyślij potwierdzenie",
+    "resendConfirmation": "Wyślij potwierdzenie ponownie",
+    "sendReminderEmail": "Wyślij przypomnienie",
+    "emailSent": "E-mail wysłany pomyślnie",
+    "automatic": "automatycznie",
+    "selectPatientFirst": "Wybierz pacjenta, aby zobaczyć oczekujące zabiegi",
+    "noPendingTreatments": "Brak oczekujących zabiegów",
+    "createPlanFirst": "Utwórz plan leczenia dla tego pacjenta",
+    "addTreatmentFromPlan": "Dodaj zabieg z planu",
+    "selectPendingTreatment": "Wybierz oczekujący zabieg",
+    "emptyDay": "Brak wizyt w tym dniu",
+    "noPatient": "Brak pacjenta",
+    "freeSlots": {
+      "byProfessional": "Lekarz",
+      "byCabinet": "Gabinet",
+      "freeSuffix": "wolne",
+      "freeShort": "wolne",
+      "noFreeTime": "Brak wolnych terminów",
+      "tapToBook": "Dotknij, aby umówić",
+      "tapToBookAria": "Wolny termin {duration} o {time}",
+      "nextFreeAt": "Następny o {time}",
+      "gapsAtLeast": "{count} przerw ≥ {min} min",
+      "minDuration": "Minimum",
+      "noFreeSlots": "Brak wolnych terminów dzisiaj",
+      "clinicClosed": "Gabinet zamknięty",
+      "professionalOff": "Poza godzinami pracy",
+      "onBreak": "Na przerwie"
+    }
+  },
+  "dashboard": {
+    "greetings": {
+      "morning": "Dzień dobry",
+      "afternoon": "Dzień dobry",
+      "evening": "Dobry wieczór"
+    },
+    "welcome": "Witamy w DentalPin",
+    "welcomeMessage": "Zacznij od dodania pierwszego pacjenta.",
+    "quickActions": {
+      "newAppointment": "Nowa wizyta",
+      "newPatient": "Nowy pacjent",
+      "search": "Szukaj pacjenta",
+      "searchPlaceholder": "Szukaj po imieniu, telefonie lub e-mailu"
+    },
+    "timeline": {
+      "title": "Dzisiaj",
+      "empty": "Brak wizyt zaplanowanych na dzisiaj",
+      "now": "Teraz",
+      "openSchedule": "Otwórz terminarz"
+    },
+    "todayKpi": {
+      "title": "Dzisiejsze wizyty",
+      "completed": "zakończone",
+      "inProgress": "w trakcie",
+      "upcoming": "nadchodzące",
+      "cancelled": "odwołane",
+      "noShow": "nieobecności",
+      "empty": "Brak wizyt dzisiaj"
+    },
+    "inClinic": {
+      "title": "Teraz w gabinecie",
+      "inTreatment": "{n} na fotelu",
+      "waiting": "{n} oczekuje",
+      "empty": "Nikogo nie ma w gabinecie"
+    },
+    "unconfirmed": {
+      "title": "Niepotwierdzone na jutro",
+      "empty": "Wszystkie jutrzejsze wizyty potwierdzone",
+      "confirm": "Potwierdź",
+      "confirmError": "Nie udało się potwierdzić"
+    },
+    "overdue": {
+      "title": "Zaległe płatności",
+      "daysOverdue": "{n} dzień po terminie | {n} dni po terminie | {n} dni po terminie",
+      "viewAll": "Zobacz wszystkie",
+      "empty": "Brak zaległych faktur"
+    },
+    "recent": {
+      "title": "Ostatni pacjenci",
+      "empty": "Brak pacjentów"
+    },
+    "weekGlance": {
+      "title": "Tydzień w skrócie",
+      "subtitle": "Ostatnie 7 dni vs poprzednie 7",
+      "appointments": "Wizyty",
+      "completed": "Zakończone",
+      "invoiced": "Zafakturowano",
+      "empty": "Brak danych w tym tygodniu"
+    }
+  },
+  "settings": {
+    "title": "Ustawienia",
+    "subtitle": "Zarządzaj gabinetem, zespołem i modułami.",
+    "allCategories": "Wszystkie kategorie",
+    "navLabel": "Kategorie ustawień",
+    "attentionRequired": "Wymaga uwagi",
+    "categories": {
+      "general": {
+        "label": "Ogólne",
+        "description": "Profil gabinetu, marka i strefa czasowa."
+      },
+      "workspace": {
+        "label": "Miejsce pracy",
+        "description": "Gabinety zabiegowe, godziny otwarcia i dostępność."
+      },
+      "people": {
+        "label": "Zespół",
+        "description": "Użytkownicy, role i zaproszenia."
+      },
+      "clinical": {
+        "label": "Kliniczne",
+        "description": "Katalog, ustawienia zabiegów i szablony."
+      },
+      "billing": {
+        "label": "Fakturowanie i podatki",
+        "description": "Serie faktur, VAT i zgodność podatkowa."
+      },
+      "communications": {
+        "label": "Komunikacja",
+        "description": "Powiadomienia, SMTP i szablony."
+      },
+      "integrations": {
+        "label": "Integracje",
+        "description": "Usługi zewnętrzne i dostawcy."
+      },
+      "modules": {
+        "label": "Moduły",
+        "description": "Instalowanie, aktualizowanie i odinstalowywanie modułów."
+      },
+      "account": {
+        "label": "Konto",
+        "description": "Twój profil, hasło i język."
+      }
+    },
+    "search": {
+      "placeholder": "Szukaj w ustawieniach…",
+      "empty": "Brak wyników dla tego wyszukiwania.",
+      "navigate": "nawigacja",
+      "open": "otwórz"
+    },
+    "locked": {
+      "title": "Nie masz dostępu do tej sekcji",
+      "description": "Poproś administratora gabinetu o nadanie wymaganych uprawnień."
+    },
+    "emptyCategory": {
+      "title": "Brak dostępnych opcji",
+      "description": "Gdy zostaną włączone zgodne moduły, ich ustawienia pojawią się tutaj."
+    },
+    "loadError": {
+      "description": "Nie udało się wczytać tego edytora. Spróbuj ponownie za kilka sekund."
+    },
+    "comingSoon": {
+      "title": "Wkrótce",
+      "subtitle": "Pracujemy nad tą sekcją. Tymczasem możesz zarządzać tym przez API."
+    },
+    "onboarding": {
+      "title": "Dokończ konfigurację gabinetu",
+      "subtitle": "Pozostało {count} kroków do zakończenia wstępnej konfiguracji.",
+      "dismiss": "Ukryj",
+      "items": {
+        "clinicInfo": {
+          "label": "Uzupełnij profil gabinetu",
+          "description": "Nazwa, NIP i adres pojawiają się na kosztorysach i fakturach."
+        },
+        "cabinets": {
+          "label": "Utwórz co najmniej jeden gabinet zabiegowy",
+          "description": "Bez gabinetów nie można umawiać wizyt."
+        }
+      }
+    },
+    "cabinetsDescription": "Pomieszczenia, w których przyjmowani są pacjenci.",
+    "usersDescription": "Konta z dostępem do tego gabinetu i ich role.",
+    "profileDescription": "Twoje dane osobowe w tym gabinecie.",
+    "clinic": "Gabinet",
+    "profile": "Profil",
+    "clinicName": "Nazwa gabinetu",
+    "clinicInfo": "Dane gabinetu",
+    "clinicInfoDescription": "Te dane pojawią się na kosztorysach i dokumentach",
+    "taxId": "NIP",
+    "legalName": "Nazwa prawna",
+    "legalNameHelp": "Prawna nazwa podmiotu do fakturowania. Pozostaw puste, aby użyć nazwy gabinetu.",
+    "street": "Adres",
+    "city": "Miasto",
+    "postalCode": "Kod pocztowy",
+    "country": "Kraj",
+    "countryPlaceholder": "Wybierz kraj",
+    "countrySearchPlaceholder": "Szukaj kraju…",
+    "phone": "Telefon",
+    "timezone": "Strefa czasowa",
+    "timezoneHelp": "Wszystkie grafiki i wizyty są interpretowane w tej strefie czasowej.",
+    "currency": "Waluta",
+    "currencyHelp": "Waluta gabinetu używana w kosztorysach, fakturach i katalogu.",
+    "editClinicInfo": "Edytuj dane",
+    "clinicUpdated": "Dane gabinetu zaktualizowane",
+    "clinicUpdateError": "Błąd podczas aktualizacji danych",
+    "cabinets": "Gabinety zabiegowe",
+    "language": "Język",
+    "languageDescription": "Wybierz preferowany język",
+    "users": "Użytkownicy gabinetu",
+    "newUser": "Nowy użytkownik",
+    "createUser": "Utwórz użytkownika",
+    "editUser": "Edytuj użytkownika",
+    "deleteUser": "Usuń użytkownika",
+    "deleteUserConfirm": "Czy na pewno chcesz usunąć",
+    "deleteUserNote": "Użytkownik straci dostęp do tego gabinetu, ale jego konto nie zostanie usunięte.",
+    "noUsers": "Brak zarejestrowanych użytkowników",
+    "youTag": "(Ty)",
+    "userActive": "Użytkownik aktywny",
+    "isProfessional": "Przyjmuje pacjentów",
+    "isProfessionalHelp": "Pojawia się w terminarzu, ma godziny pracy i można mu przypisywać zabiegi. Administrator też może przyjmować pacjentów.",
+    "userInactiveNote": "(Nie może się zalogować)",
+    "saveChanges": "Zapisz zmiany",
+    "noCabinets": "Brak skonfigurowanych gabinetów",
+    "addCabinet": "Dodaj",
+    "newCabinet": "Nowy gabinet",
+    "editCabinet": "Edytuj gabinet",
+    "deleteCabinet": "Usuń gabinet",
+    "deleteCabinetConfirm": "Czy na pewno chcesz usunąć gabinet",
+    "deleteCabinetNote": "Istniejące wizyty w tym gabinecie nie zostaną naruszone.",
+    "createCabinet": "Utwórz gabinet",
+    "roles": {
+      "admin": "Administrator",
+      "dentist": "Stomatolog",
+      "hygienist": "Higienistka",
+      "assistant": "Asystent",
+      "receptionist": "Recepcjonista"
+    },
+    "errors": {
+      "loadUsers": "Błąd podczas wczytywania użytkowników",
+      "createUser": "Błąd podczas tworzenia użytkownika",
+      "updateUser": "Błąd podczas aktualizacji użytkownika",
+      "deleteUser": "Błąd podczas usuwania użytkownika",
+      "emailExists": "Taki e-mail już istnieje",
+      "userNotFound": "Nie znaleziono użytkownika",
+      "operationNotAllowed": "Operacja niedozwolona",
+      "invalidData": "Nieprawidłowe dane",
+      "inviteLink": "Nie udało się wygenerować linku dostępu"
+    },
+    "messages": {
+      "userCreated": "Użytkownik utworzony pomyślnie",
+      "userUpdated": "Użytkownik zaktualizowany pomyślnie",
+      "userDeleted": "Użytkownik usunięty z gabinetu"
+    },
+    "modules": {
+      "title": "Moduły",
+      "subtitle": "Instaluj, odinstalowuj i aktualizuj moduły gabinetu.",
+      "description": "Zarządzaj modułami aktywnymi w Twoim gabinecie.",
+      "deps": "Zależności",
+      "noDeps": "Brak zależności",
+      "state": {
+        "installed": "Zainstalowany",
+        "uninstalled": "Niezainstalowany",
+        "toInstall": "Oczekuje na instalację",
+        "toUpgrade": "Oczekuje na aktualizację",
+        "toRemove": "Oczekuje na usunięcie",
+        "disabled": "Wyłączony",
+        "error": "Błąd"
+      },
+      "category": {
+        "official": "Oficjalny",
+        "community": "Społecznościowy"
+      },
+      "actions": {
+        "install": "Zainstaluj",
+        "uninstall": "Odinstaluj",
+        "upgrade": "Zaktualizuj",
+        "apply": "Zastosuj zmiany",
+        "viewDetails": "Szczegóły",
+        "force": "Wymuś odinstalowanie"
+      },
+      "confirmInstall": {
+        "title": "Zainstalować {name}?",
+        "message": "Moduł zostanie zaplanowany do instalacji i będzie aktywny po zastosowaniu zmian.",
+        "scheduled": "Zostaną zainstalowane również te zależności:"
+      },
+      "confirmUninstall": {
+        "title": "Odinstalować {name}?",
+        "warning": "Tabele modułu zostaną usunięte. Najpierw tworzona jest kopia pg_dump, aby można było odzyskać dane.",
+        "forceHint": "Ignoruje moduły zależne. Używaj tylko wtedy, gdy wiesz, co robisz."
+      },
+      "confirmUpgrade": {
+        "title": "Zaktualizować {name}?",
+        "message": "Moduł zostanie zaktualizowany do wersji z manifestu na dysku po zastosowaniu zmian."
+      },
+      "confirmApply": {
+        "title": "Zastosuj zmiany",
+        "message": "Backend zostanie zrestartowany. Sesja może zostać na chwilę przerwana podczas wykonywania oczekujących operacji."
+      },
+      "pending": {
+        "banner": "Oczekujące zmiany:",
+        "apply": "Zastosuj zmiany"
+      },
+      "doctor": {
+        "banner": "Wykryto problemy w systemie modułów.",
+        "orphans": "osierocone moduły",
+        "missingDeps": "brakujące zależności",
+        "manifestErrors": "błędy manifestu",
+        "errored": "moduły z błędami"
+      },
+      "detail": {
+        "state": "Stan",
+        "category": "Kategoria",
+        "installedAt": "Zainstalowano",
+        "lastChange": "Ostatnia zmiana",
+        "baseRevision": "Rewizja bazowa",
+        "appliedRevision": "Zastosowana rewizja",
+        "manifest": "Pełny manifest",
+        "errorMessage": "Komunikat błędu",
+        "operationLog": "Dziennik operacji",
+        "noOperations": "Brak zarejestrowanych operacji."
+      },
+      "restart": {
+        "inProgress": "Restartowanie backendu…",
+        "done": "Zmiany zastosowane",
+        "failed": "Nie udało się zastosować zmian",
+        "timeout": "Przekroczono czas oczekiwania na backend"
+      },
+      "toasts": {
+        "scheduled": "Operacja zaplanowana. Zastosuj zmiany, aby ją dokończyć.",
+        "applied": "Zmiany zastosowane pomyślnie."
+      }
+    },
+    "invite": {
+      "linkTitle": "Link dostępu",
+      "linkHelp": "Wyślij ten link do {name}, aby ta osoba wybrała swoje hasło. Wygasa {date} i działa tylko raz.",
+      "copy": "Kopiuj link",
+      "copied": "Link skopiowany",
+      "whatsapp": "Wyślij przez WhatsApp",
+      "shareText": "Cześć {name}, oto Twój dostęp do DentalPin. Otwórz link i wybierz hasło: {url}",
+      "secretNote": "Traktuj go jak hasło: każdy, kto ma link, może zalogować się na to konto.",
+      "passwordOptionalHelp": "Pozostaw puste, aby wygenerować link dostępu do wysłania przez WhatsApp lub e-mail.",
+      "passwordOptionalPlaceholder": "Opcjonalne",
+      "createAndLink": "Utwórz i wygeneruj link",
+      "rowAction": "Link dostępu",
+      "setPasswordTitle": "Wybierz swoje hasło",
+      "setPasswordSubtitle": "Otrzymałeś(-aś) zaproszenie do DentalPin. Utwórz hasło, aby się zalogować.",
+      "setPasswordSubmit": "Zapisz i zaloguj",
+      "invalidToken": "Ten link jest nieprawidłowy lub został już użyty. Poproś administratora gabinetu o nowy."
+    }
+  },
+  "selector": {
+    "recentPatients": "Ostatni pacjenci",
+    "commonTreatments": "Częste zabiegi",
+    "noRecentPatients": "Brak ostatnich pacjentów",
+    "noCommonTreatments": "Brak częstych zabiegów",
+    "noMatches": "Brak wyników",
+    "typeToSearch": "Wpisz, aby wyszukać..."
+  },
+  "density": {
+    "switchToCompact": "Widok kompaktowy",
+    "switchToComfortable": "Widok komfortowy"
+  },
+  "patientSelector": {
+    "createOption": "Utwórz pacjenta \"{query}\"",
+    "createOptionEmpty": "Utwórz nowego pacjenta",
+    "newBadge": "Nowy",
+    "duplicateWarning": "{name} już istnieje z tym numerem telefonu",
+    "useExisting": "Użyj tego pacjenta",
+    "createForm": {
+      "title": "Nowy pacjent",
+      "back": "Wróć do wyszukiwania",
+      "firstName": "Imię",
+      "lastName": "Nazwisko",
+      "phone": "Telefon",
+      "phoneHint": "Możesz dodać go później w karcie pacjenta.",
+      "submit": "Utwórz i wybierz",
+      "cancel": "Anuluj",
+      "errorGeneric": "Nie udało się utworzyć pacjenta. Spróbuj ponownie."
+    }
+  },
+  "common": {
+    "save": "Zapisz",
+    "add": "Dodaj",
+    "cancel": "Anuluj",
+    "clear": "Wyczyść",
+    "close": "Zamknij",
+    "delete": "Usuń",
+    "comingSoon": "Wkrótce",
+    "edit": "Edytuj",
+    "change": "zmiana | zmiany | zmian",
+    "back": "Wstecz",
+    "loading": "Wczytywanie...",
+    "error": "Błąd",
+    "success": "Sukces",
+    "completed": "Zakończone",
+    "retry": "Ponów",
+    "refresh": "Odśwież",
+    "hide": "Ukryj",
+    "forbidden": "Brak dostępu",
+    "confirm": "Potwierdź",
+    "yes": "Tak",
+    "no": "Nie",
+    "actions": "Akcje",
+    "viewDetails": "Zobacz szczegóły",
+    "previous": "Poprzedni",
+    "next": "Następny",
+    "previousYear": "Poprzedni rok",
+    "nextYear": "Następny rok",
+    "undo": "Cofnij",
+    "undone": "Cofnięto",
+    "added": "Dodano",
+    "removed": "Usunięto",
+    "page": "Strona {current} z {total}",
+    "noData": "Brak danych",
+    "noValue": "brak wartości",
+    "noResults": "Brak wyników",
+    "search": "Szukaj...",
+    "selectAll": "Wszystkie",
+    "deselectAll": "Żadne",
+    "all": "Wszystkie",
+    "required": "To pole jest wymagane",
+    "invalidEmail": "Nieprawidłowy e-mail",
+    "networkError": "Błąd połączenia",
+    "serverError": "Błąd serwera",
+    "notFound": "Nie znaleziono",
+    "offline": "Offline — dane mogą być nieaktualne",
+    "inactive": "Nieaktywny",
+    "name": "Nazwa",
+    "color": "Kolor",
+    "firstName": "Imię",
+    "lastName": "Nazwisko",
+    "email": "E-mail",
+    "password": "Hasło",
+    "passwordPlaceholder": "Co najmniej 8 znaków",
+    "role": "Rola",
+    "readOnly": "Tylko do odczytu",
+    "createdBy": "Utworzone przez",
+    "date": "Data",
+    "upload": "Prześlij",
+    "uploading": "Przesyłanie…",
+    "maxFileSize": "do 10 MB",
+    "durationMinutes": "{value} min",
+    "days": {
+      "sunday": "Niedziela",
+      "monday": "Poniedziałek",
+      "tuesday": "Wtorek",
+      "wednesday": "Środa",
+      "thursday": "Czwartek",
+      "friday": "Piątek",
+      "saturday": "Sobota"
+    },
+    "now": "Teraz",
+    "today": "Dzisiaj",
+    "tomorrow": "Jutro",
+    "yesterday": "Wczoraj",
+    "copied": "Skopiowano do schowka",
+    "copy": "Kopiuj",
+    "copyFailed": "Nie udało się skopiować"
+  },
+  "cabinet": {
+    "toast": {
+      "created": "Gabinet utworzony",
+      "updated": "Gabinet zaktualizowany",
+      "deleted": "Gabinet usunięty",
+      "duplicateName": "Gabinet o tej nazwie już istnieje",
+      "notFound": "Nie znaleziono gabinetu",
+      "createFailed": "Nie udało się utworzyć gabinetu",
+      "updateFailed": "Nie udało się zaktualizować gabinetu",
+      "deleteFailed": "Nie udało się usunąć gabinetu"
+    }
+  },
+  "professionals": {
+    "toast": {
+      "loadFailed": "Nie udało się wczytać lekarzy"
+    }
+  },
+  "lists": {
+    "empty": {
+      "title": "Brak wyników",
+      "description": "Zmień filtry lub wyczyść je, aby zobaczyć wszystkie rekordy."
+    },
+    "resultCount": "{shown} z {total}",
+    "filter": {
+      "title": "Filtry",
+      "more": "Filtry",
+      "moreCount": "Filtry ({count})",
+      "clear": "Wyczyść",
+      "apply": "Zastosuj",
+      "date": "Daty",
+      "dateFrom": "Od",
+      "dateTo": "Do",
+      "searchPlaceholder": "Szukaj...",
+      "noResults": "Brak wyników",
+      "all": "Wszystkie"
+    },
+    "sort": {
+      "label": "Sortuj",
+      "asc": "Rosnąco",
+      "desc": "Malejąco"
+    },
+    "datePreset": {
+      "today": "Dzisiaj",
+      "last7": "Ostatnie 7 dni",
+      "last30": "Ostatnie 30 dni",
+      "thisMonth": "Ten miesiąc",
+      "thisQuarter": "Kwartał",
+      "thisYear": "Rok",
+      "custom": "Niestandardowy"
+    },
+    "truncatedWarning": "Wyniki obcięte (>1000). Doprecyzuj filtry."
+  },
+  "shared": {
+    "totals": "Podsumowanie",
+    "info": "Szczegóły",
+    "moreActions": "Więcej akcji",
+    "criticalBanner": {
+      "dismiss": "Ukryj ostrzeżenie"
+    },
+    "collect": {
+      "amountLabel": "Kwota do pobrania",
+      "methodLabel": "Metoda płatności",
+      "dateLabel": "Data płatności",
+      "today": "Dzisiaj",
+      "quickFull": "Całość",
+      "optionalDetails": "Dodaj numer referencyjny lub notatki (opcjonalnie)",
+      "referenceLabel": "Numer referencyjny",
+      "referencePlaceholder": "np. numer transakcji z terminala",
+      "notesLabel": "Notatki wewnętrzne",
+      "submit": "Pobierz płatność",
+      "cancel": "Anuluj"
+    }
+  },
+  "validation": {
+    "required": "To pole jest wymagane",
+    "email": "Podaj prawidłowy adres e-mail",
+    "minLength": "Co najmniej {min} znaków",
+    "maxLength": "Najwyżej {max} znaków",
+    "phone": "Podaj prawidłowy numer telefonu"
+  },
+  "time": {
+    "minutes": "{n} min",
+    "hours": "{n} godzina | {n} godziny | {n} godzin"
+  },
+  "calendar": {
+    "today": "Dzisiaj",
+    "prevWeek": "Poprzedni tydzień",
+    "nextWeek": "Następny tydzień",
+    "monday": "Poniedziałek",
+    "tuesday": "Wtorek",
+    "wednesday": "Środa",
+    "thursday": "Czwartek",
+    "friday": "Piątek",
+    "saturday": "Sobota",
+    "sunday": "Niedziela"
+  },
+  "catalog": {
+    "title": "Katalog zabiegów",
+    "description": "Zarządzaj zabiegami, cenami i podatkami",
+    "items": "Zabiegi",
+    "categories": "Kategorie",
+    "noItems": "Brak zabiegów w katalogu",
+    "searchPlaceholder": "Szukaj po kodzie lub nazwie...",
+    "code": "Kod",
+    "name": "Nazwa",
+    "category": "Kategoria",
+    "price": "Cena",
+    "defaultPrice": "Cena podstawowa",
+    "costPrice": "Koszt własny",
+    "currency": "Waluta",
+    "vatType": "Stawka VAT",
+    "vatRate": "VAT %",
+    "duration": "Czas trwania",
+    "system": "Systemowy",
+    "newItem": "Nowy zabieg",
+    "editItem": "Edytuj zabieg",
+    "deleteItem": "Usuń zabieg",
+    "deleteItemConfirm": "Czy na pewno chcesz usunąć zabieg \"{name}\"?",
+    "deleteItemNote": "Tej operacji nie można cofnąć.",
+    "pricing": "Cennik",
+    "scheduling": "Planowanie",
+    "characteristics": "Cechy",
+    "scope": "Zakres",
+    "requiresAppointment": "Wymaga wizyty",
+    "isDiagnostic": "Diagnostyczny",
+    "requiresSurfaces": "Wymaga powierzchni",
+    "materialNotes": "Notatki o materiałach",
+    "materialNotesPlaceholder": "Wymagane materiały...",
+    "active": "Aktywny",
+    "vatTypes": {
+      "exempt": "Zwolniony",
+      "reduced": "Obniżony",
+      "standard": "Podstawowy"
+    },
+    "scopeTypes": {
+      "tooth": "Ząb",
+      "multi_tooth": "Wiele zębów",
+      "global_mouth": "Cała jama ustna",
+      "global_arch": "Na łuk"
+    },
+    "pricingStrategy": {
+      "label": "Strategia cenowa",
+      "help": "Jak obliczana jest cena zabiegu przy zastosowaniu",
+      "flat": "Stała (jedna cena)",
+      "per_tooth": "Za ząb (× liczba zębów)",
+      "per_surface": "Za powierzchnię (progowo)",
+      "per_role": "Wg roli (most: filar/przęsło)"
+    },
+    "surfacePrices": {
+      "title": "Ceny wg liczby powierzchni",
+      "help": "Określ cenę dla 1–5 powierzchni. Po wyborze powierzchni zęba stosowany jest odpowiedni próg. Brakujące progi korzystają z najbliższego niższego uzupełnionego progu.",
+      "tier": "{n} pow."
+    },
+    "sessions": {
+      "title": "Sesje (rozliczanie częściowe)",
+      "help": "Określ nazwane etapy realizacji i rozliczania zabiegu (np. korona: 'Wyciski' + 'Osadzenie'). Suma musi być równa cenie podstawowej.",
+      "label": "Nazwa",
+      "labelPlaceholder": "np. Wyciski",
+      "price": "Kwota",
+      "add": "Dodaj sesję",
+      "sumStatus": "Suma {sum} € · Razem {total} €"
+    },
+    "categoryCreated": "Kategoria utworzona",
+    "categoryUpdated": "Kategoria zaktualizowana",
+    "categoryDeleted": "Kategoria usunięta",
+    "categoryKeyExists": "Kategoria z tym kluczem już istnieje",
+    "categoryCreateFailed": "Błąd podczas tworzenia kategorii",
+    "categoryUpdateFailed": "Błąd podczas aktualizacji kategorii",
+    "categoryDeleteFailed": "Błąd podczas usuwania kategorii",
+    "cannotModifySystemCategory": "Nie można modyfikować kategorii systemowej",
+    "cannotDeleteSystemCategory": "Nie można usunąć kategorii systemowej",
+    "itemCreated": "Zabieg utworzony",
+    "itemUpdated": "Zabieg zaktualizowany",
+    "itemDeleted": "Zabieg usunięty",
+    "itemCodeExists": "Zabieg z tym kodem już istnieje",
+    "categoryNotFound": "Nie znaleziono kategorii",
+    "itemCreateFailed": "Błąd podczas tworzenia zabiegu",
+    "itemUpdateFailed": "Błąd podczas aktualizacji zabiegu",
+    "itemDeleteFailed": "Błąd podczas usuwania zabiegu",
+    "cannotModifySystemItem": "Nie można modyfikować zabiegu systemowego",
+    "systemItemHint": "Zabieg systemowy: kod, kategoria, strategia cenowa i zakres są zablokowane; cenę, koszt, VAT, nazwy, czas trwania, sesje i status można edytować.",
+    "cannotDeleteSystemItem": "Nie można usunąć zabiegu systemowego",
+    "odontogramMapping": "Wizualizacja na diagramie zębowym",
+    "odontogramMappingDescription": "Powiąż ten zabieg z typem wizualizacji, aby pojawiał się na diagramie zębowym pacjenta.",
+    "odontogramType": "Typ zabiegu",
+    "clinicalCategory": "Kategoria kliniczna",
+    "noOdontogramMapping": "Brak powiązania",
+    "odontogramMappingHint": "Cechy zabiegu zostaną automatycznie dostosowane do wybranego typu.",
+    "selectCategory": "Wybierz kategorię...",
+    "selectVatType": "Wybierz stawkę VAT...",
+    "selectScope": "Wybierz zakres...",
+    "selectOdontogramType": "Wybierz typ...",
+    "selectClinicalCategory": "Wybierz kategorię...",
+    "expandAll": "Rozwiń wszystko",
+    "collapseAll": "Zwiń wszystko",
+    "unnamed": "Bez nazwy",
+    "activeHint": "Dostępny dla kosztorysów i planów",
+    "tabs": {
+      "general": "Ogólne",
+      "pricing": "Cennik",
+      "scheduling": "Planowanie",
+      "clinical": "Kliniczne"
+    },
+    "onboarding": {
+      "label": "Katalog zabiegów",
+      "description": "Bez zabiegów nie ma kosztorysów ani planów. Wczytaj domyślny katalog lub utwórz własny.",
+      "createOwn": "Utworzę własny"
+    },
+    "manageCategories": "Zarządzaj kategoriami",
+    "newCategory": "Nowa kategoria",
+    "categoryName": "Nazwa",
+    "categoryNamePlaceholder": "np. Ortodoncja",
+    "categoryOrder": "Kolejność",
+    "noCategories": "Brak kategorii. Utwórz jedną lub wczytaj domyślny katalog.",
+    "inactiveCategories": "Nieaktywne kategorie",
+    "reactivate": "Aktywuj ponownie",
+    "deleteCategoryConfirm": "Kategoria zostanie dezaktywowana; jej zabiegi pozostaną. Kontynuować?",
+    "systemCategoryNote": "Kategorii systemowych nie można edytować ani usuwać.",
+    "loadDefaults": "Wczytaj domyślny katalog",
+    "loadDefaultsHint": "Stawki VAT, kategorie i referencyjne zabiegi dla kraju gabinetu. Dodawane są tylko brakujące pozycje.",
+    "defaultsLoaded": "Katalog wczytany: {categories} kategorii, {items} zabiegów, {vat_types} stawek VAT",
+    "defaultsFailed": "Nie udało się wczytać domyślnego katalogu"
+  },
+  "placeholders": {
+    "selectRole": "Wybierz rolę..."
+  },
+  "vatTypes": {
+    "title": "Stawki VAT",
+    "description": "Zarządzaj stawkami VAT dostępnymi dla zabiegów",
+    "name": "Nazwa",
+    "rate": "Stawka",
+    "default": "Domyślna",
+    "system": "Systemowa",
+    "active": "Aktywna",
+    "new": "Nowa stawka VAT",
+    "edit": "Edytuj stawkę VAT",
+    "delete": "Usuń stawkę VAT",
+    "setAsDefault": "Ustaw jako domyślną",
+    "showInactive": "Pokaż nieaktywne",
+    "noItems": "Brak skonfigurowanych stawek VAT",
+    "namePlaceholder": "Np.: Obniżona (10%)",
+    "systemNote": "W stawkach systemowych można zmienić tylko status domyślny.",
+    "deleteConfirm": "Czy na pewno chcesz usunąć stawkę VAT",
+    "deleteNote": "Zabiegi używające tej stawki nie zostaną naruszone.",
+    "created": "Stawka VAT utworzona",
+    "updated": "Stawka VAT zaktualizowana",
+    "deleted": "Stawka VAT usunięta",
+    "loadError": "Błąd podczas wczytywania stawek VAT",
+    "createError": "Błąd podczas tworzenia stawki VAT",
+    "updateError": "Błąd podczas aktualizacji stawki VAT",
+    "deleteError": "Błąd podczas usuwania stawki VAT"
+  },
+  "treatmentPlans": {
+    "title": "Plany leczenia",
+    "description": "Zarządzaj planami leczenia pacjentów",
+    "new": "Nowy plan",
+    "create": "Utwórz plan leczenia",
+    "edit": "Edytuj plan",
+    "view": "Zobacz plan",
+    "delete": "Usuń plan",
+    "noItems": "Ten plan nie ma zabiegów",
+    "noPlans": "Ten pacjent nie ma planów leczenia",
+    "noPlansHint": "Zaznacz zabiegi na diagramie zębowym i utwórz plan, aby je uporządkować",
+    "createFirst": "Utwórz pierwszy plan",
+    "empty": "Brak zarejestrowanych planów leczenia",
+    "emptyAction": "Utwórz pierwszy plan",
+    "searchPlaceholder": "Szukaj po numerze, pacjencie lub tytule...",
+    "planNumber": "Numer",
+    "patient": "Pacjent",
+    "untitled": "Bez tytułu",
+    "untitledPlan": "Plan bez tytułu",
+    "itemCount": "{count} zabieg | {count} zabiegi | {count} zabiegów",
+    "treatments": "zabiegi",
+    "progress": "Postęp",
+    "pendingTreatments": "Oczekujące zabiegi",
+    "completedTreatments": "Ukończone zabiegi",
+    "linkedBudget": "Powiązany kosztorys",
+    "unknownTreatment": "Nieznany zabieg",
+    "globalTreatment": "Zabieg ogólny",
+    "activePlan": "Aktywny plan",
+    "otherPlans": "Inne plany",
+    "viewAllPlans": "Zobacz historię planów",
+    "activate": "Aktywuj",
+    "generateBudget": "Utwórz kosztorys",
+    "scheduleAppointment": "Umów wizytę",
+    "status": {
+      "draft": "Wersja robocza",
+      "pending": "Oczekujący",
+      "active": "Aktywny",
+      "completed": "Ukończony",
+      "closed": "Zamknięty",
+      "archived": "Zarchiwizowany"
+    },
+    "fields": {
+      "title": "Tytuł",
+      "titlePlaceholder": "Np.: Pełna rehabilitacja jamy ustnej",
+      "assignedProfessional": "Przypisany lekarz",
+      "selectProfessional": "Wybierz lekarza",
+      "diagnosisNotes": "Notatki z diagnozy",
+      "diagnosisNotesPlaceholder": "Diagnoza i obserwacje kliniczne...",
+      "internalNotes": "Notatki wewnętrzne",
+      "internalNotesPlaceholder": "Notatki widoczne tylko dla zespołu..."
+    },
+    "modal": {
+      "subtitle": "Uporządkuj zabiegi pacjenta",
+      "titleHint": "Opcjonalny - pomaga zidentyfikować plan",
+      "additionalNotes": "Dodatkowe notatki",
+      "quickTip": "Po utworzeniu planu możesz dodawać zabiegi z diagramu zębowego lub katalogu.",
+      "createButton": "Utwórz plan"
+    },
+    "actions": {
+      "activate": "Aktywuj plan",
+      "confirm": "Zatwierdź plan",
+      "complete": "Oznacz jako ukończony",
+      "generateBudget": "Utwórz kosztorys",
+      "linkBudget": "Powiąż kosztorys",
+      "syncBudget": "Synchronizuj kosztorys",
+      "cancelPlan": "Anuluj plan",
+      "reopen": "Otwórz ponownie",
+      "close": "Zamknij plan",
+      "reactivate": "Aktywuj plan ponownie",
+      "logContact": "Zarejestruj kontakt"
+    },
+    "items": {
+      "title": "Zabiegi",
+      "add": "Dodaj zabieg",
+      "addSelected": "Dodaj {count} zabieg | Dodaj {count} zabiegi | Dodaj {count} zabiegów",
+      "remove": "Usuń zabieg",
+      "empty": "Brak zabiegów w tym planie",
+      "assignedProfessional": "Przypisany stomatolog",
+      "assignedProfessionalAriaLabel": "Zmień przypisanego stomatologa dla tego zabiegu",
+      "useUsersPlanDoctor": "Użyj stomatologa planu",
+      "noProfessional": "Brak przypisanego stomatologa",
+      "inactiveProfessional": "Nieaktywny lekarz",
+      "cascadeReassign": {
+        "title": "Przepisać oczekujące zabiegi?",
+        "body": "Zmieniono stomatologa planu. {count} oczekujących zabiegów było przypisanych do {previousName}. Przepisać je również do nowego stomatologa?",
+        "confirm": "Tak, przepisz oczekujące",
+        "cancel": "Nie, pozostaw jak są"
+      }
+    },
+    "filters": {
+      "allStatuses": "Wszystkie statusy"
+    },
+    "confirmations": {
+      "delete": "Usunąć ten plan leczenia?",
+      "completeItem": "Oznaczyć zabieg jako ukończony?",
+      "completeItemDescription": "Tej operacji nie można cofnąć.",
+      "activateTitle": "Zatwierdzić plan leczenia?",
+      "activateDescription": "Zatwierdzenie odblokowuje tworzenie kosztorysu i umawianie wizyt. Potem nadal można dodawać i kończyć zabiegi.",
+      "unlockTitle": "Zmodyfikować plan?",
+      "unlockIntro": "Do tego planu wystawiono już kosztorys {number}. Aby go zmodyfikować, bieżący kosztorys musi zostać anulowany.",
+      "unlockConsequence1": "Kosztorys {number} zostanie anulowany i przestanie obowiązywać pacjenta.",
+      "unlockConsequence2": "Będzie można dodawać, edytować i usuwać zabiegi z planu.",
+      "unlockConsequence3": "Po zakończeniu zmian trzeba będzie wygenerować nowy kosztorys.",
+      "unlockConsequence4": "Anulowany kosztorys pozostaje w historii dla identyfikowalności.",
+      "cancelTitle": "Anulować plan leczenia?",
+      "cancelDescription": "Plan przejdzie w stan anulowany, a niewykonane zaplanowane zabiegi zostaną usunięte z diagramu zębowego. Historia planu zostanie zachowana."
+    },
+    "messages": {
+      "created": "Plan leczenia utworzony",
+      "updated": "Plan leczenia zaktualizowany",
+      "deleted": "Plan leczenia usunięty",
+      "itemsAdded": "Zabiegi dodane do planu"
+    },
+    "itemCompleted": "Zabieg ukończony",
+    "budgetGenerated": "Kosztorys wygenerowany",
+    "created": "Plan leczenia utworzony",
+    "updated": "Plan leczenia zaktualizowany",
+    "statusUpdated": "Status planu zaktualizowany",
+    "deleted": "Plan leczenia usunięty",
+    "budgetLinked": "Kosztorys powiązany z planem",
+    "budgetSynced": "Kosztorys zsynchronizowany",
+    "errors": {
+      "load": "Błąd podczas wczytywania planów leczenia",
+      "create": "Błąd podczas tworzenia planu leczenia",
+      "update": "Błąd podczas aktualizacji planu leczenia",
+      "delete": "Błąd podczas usuwania planu leczenia"
+    },
+    "notes": {
+      "title": "Notatki kliniczne",
+      "empty": "Brak notatek klinicznych",
+      "addNote": "Dodaj notatkę",
+      "edit": "Edytuj notatkę",
+      "delete": "Usuń notatkę",
+      "attachments": "Załączniki",
+      "author": "Autor",
+      "createdAt": "Utworzono",
+      "templatePicker": "Szablony",
+      "bodyPlaceholder": "Napisz notatkę kliniczną…",
+      "saved": "Notatka zapisana",
+      "deleted": "Notatka usunięta"
+    },
+    "completionNudge": {
+      "title": "Ukończ zabieg",
+      "description": "Przed oznaczeniem jako ukończony dodaj notatkę kliniczną opisującą przebieg wizyty.",
+      "completeWithNote": "Ukończ z notatką",
+      "skip": "Pomiń notatkę",
+      "skipConfirm": "Ukończyć bez notatki klinicznej?"
+    },
+    "visitNote": {
+      "title": "Notatka kliniczna z wizyty",
+      "save": "Zapisz notatkę",
+      "empty": "Brak notatki z wizyty",
+      "saved": "Notatka zapisana"
+    },
+    "clinicalNotesTab": "Notatki kliniczne",
+    "filterBy": {
+      "plan": "Plan",
+      "item": "Zabieg",
+      "visit": "Wizyta",
+      "all": "Wszystkie"
+    },
+    "byPlan": {
+      "empty": "Ten pacjent nie ma notatek klinicznych w żadnym planie leczenia",
+      "planNotesLabel": "Notatki planu",
+      "noNotesForTreatment": "Brak notatek dla tego zabiegu",
+      "noNotesForPlan": "Brak notatek w tym planie"
+    },
+    "noteTemplates": {
+      "endo": {
+        "singleVisit": "Endodoncja — jedna wizyta",
+        "multiVisit": "Endodoncja — wiele wizyt"
+      },
+      "perio": {
+        "scaling": "Skaling / wygładzanie korzeni"
+      },
+      "implant": {
+        "placement": "Wszczepienie implantu"
+      },
+      "general": {
+        "followUp": "Kontrola ogólna"
+      }
+    },
+    "closureReason": {
+      "rejected_by_patient": "Odrzucony przez pacjenta",
+      "expired": "Wygasł",
+      "cancelled_by_clinic": "Anulowany przez gabinet",
+      "patient_abandoned": "Pacjent zrezygnował",
+      "other": "Inny powód"
+    },
+    "confirmed": "Plan zatwierdzony",
+    "reopened": "Plan otwarty ponownie",
+    "closed": "Plan zamknięty",
+    "reactivated": "Plan aktywowany ponownie",
+    "contactLogged": "Kontakt zarejestrowany",
+    "modals": {
+      "confirm": {
+        "title": "Zatwierdź plan",
+        "description": "Plan przejdzie do stanu Oczekujący i automatycznie powstanie roboczy kosztorys. Po zatwierdzeniu zabiegi są tylko do odczytu.",
+        "submit": "Zatwierdź plan"
+      },
+      "reopen": {
+        "title": "Otwórz plan do edycji",
+        "description": "Bieżący kosztorys zostanie anulowany. Plan wróci do wersji roboczej, aby można było edytować zabiegi.",
+        "submit": "Otwórz ponownie"
+      },
+      "close": {
+        "title": "Zamknij plan",
+        "description": "Wybierz powód zamknięcia. Oczekujące zabiegi zostaną zarchiwizowane.",
+        "reasonLabel": "Powód",
+        "noteLabel": "Notatka (opcjonalnie)",
+        "submit": "Zamknij plan"
+      },
+      "reactivate": {
+        "title": "Aktywuj ponownie zamknięty plan",
+        "description": "Aktywujesz ponownie plan zamknięty {date} z powodem «{reason}». Kontynuować?",
+        "submit": "Aktywuj ponownie"
+      },
+      "contactLog": {
+        "title": "Zarejestruj kontakt",
+        "description": "Zapisuje kontakt bez zmiany statusu planu.",
+        "channelLabel": "Kanał",
+        "noteLabel": "Notatka (opcjonalnie)",
+        "submit": "Zarejestruj"
+      }
+    },
+    "newBudgetHint": {
+      "text": "Ten pacjent ma plan {plan} bez kosztorysu. Wygeneruj kosztorys z planu, aby pozostały powiązane.",
+      "cta": "Otwórz plan"
+    }
+  },
+  "pipeline": {
+    "title": "Pipeline planów",
+    "description": "Zarządzaj przepływem leczenia.",
+    "tabs": {
+      "por_presupuestar": "Do wyceny",
+      "esperando_paciente": "Oczekiwanie na pacjenta",
+      "sin_cita": "Bez wizyty",
+      "sin_proxima_cita": "Bez następnej wizyty",
+      "cerrados": "Zamknięte",
+      "listado": "Lista"
+    },
+    "row": {
+      "patient": "Pacjent",
+      "plan": "Plan",
+      "budget": "Kosztorys",
+      "items": "Zabiegi",
+      "daysIn": "{n} dni w tym statusie",
+      "nextAppt": "Nast. wizyta",
+      "noNextAppt": "Brak wizyty",
+      "noBudget": "Brak kosztorysu"
+    },
+    "actions": {
+      "open": "Otwórz",
+      "send": "Wyślij",
+      "remind": "Wyślij ponownie",
+      "schedule": "Umów",
+      "scheduleNext": "Umów następną",
+      "reactivate": "Aktywuj ponownie",
+      "call": "Zadzwoń",
+      "whatsapp": "WhatsApp",
+      "markContacted": "Oznacz jako skontaktowano",
+      "acceptInClinic": "Zaakceptuj w gabinecie"
+    },
+    "search": "Szukaj po nazwisku lub numerze…",
+    "empty": "Brak pozycji w tej zakładce.",
+    "loading": "Wczytywanie…"
+  },
+  "budget": {
+    "title": "Kosztorysy",
+    "description": "Zarządzaj kosztorysami leczenia pacjentów",
+    "new": "Nowy kosztorys",
+    "edit": "Edytuj kosztorys",
+    "view": "Zobacz kosztorys",
+    "delete": "Usuń kosztorys",
+    "duplicate": "Utwórz nową wersję",
+    "noItems": "Brak kosztorysów",
+    "empty": "Brak zarejestrowanych kosztorysów",
+    "emptyAction": "Utwórz pierwszy kosztorys",
+    "linkedToPlan": "Powiązany z planem",
+    "searchPlaceholder": "Szukaj po numerze lub pacjencie...",
+    "budgetNumber": "Numer",
+    "version": "Wersja",
+    "treatmentPlan": "Plan leczenia",
+    "patient": "Pacjent",
+    "selectPatient": "Wybierz pacjenta",
+    "selectPatientHint": "Wyszukaj i wybierz pacjenta dla tego kosztorysu",
+    "professional": "Lekarz",
+    "validFrom": "Ważny od",
+    "validUntil": "Ważny do",
+    "validUntilHint": "Pozostaw puste dla kosztorysu bez terminu ważności",
+    "noExpiry": "Bez terminu ważności",
+    "createAndAddItems": "Utwórz i dodaj zabiegi",
+    "subtotal": "Suma częściowa",
+    "totalDiscount": "Suma rabatów",
+    "totalTax": "Suma VAT",
+    "total": "Razem",
+    "globalDiscount": "Rabat całkowity",
+    "discountType": "Rodzaj rabatu",
+    "discountValue": "Wartość rabatu",
+    "percentage": "Procentowy",
+    "absolute": "Kwotowy",
+    "internalNotes": "Notatki wewnętrzne",
+    "internalNotesPlaceholder": "Notatki widoczne tylko dla zespołu...",
+    "patientNotes": "Notatki dla pacjenta",
+    "patientNotesPlaceholder": "Notatki widoczne na kosztorysie...",
+    "status": {
+      "title": "Status",
+      "draft": "Wersja robocza",
+      "sent": "Wysłany",
+      "partially_accepted": "Częściowo zaakceptowany",
+      "accepted": "Zaakceptowany",
+      "in_progress": "W trakcie",
+      "completed": "Ukończony",
+      "invoiced": "Zafakturowany",
+      "rejected": "Odrzucony",
+      "expired": "Wygasły",
+      "cancelled": "Anulowany"
+    },
+    "itemStatus": {
+      "pending": "Oczekujący",
+      "accepted": "Zaakceptowany",
+      "rejected": "Odrzucony",
+      "in_progress": "W trakcie",
+      "completed": "Ukończony"
+    },
+    "actions": {
+      "send": "Wyślij do pacjenta",
+      "accept": "Zaakceptuj kosztorys",
+      "acceptPartial": "Zaakceptuj wybrane",
+      "reject": "Odrzuć",
+      "cancel": "Anuluj kosztorys",
+      "duplicate": "Utwórz nową wersję",
+      "downloadPdf": "Pobierz PDF",
+      "previewPdf": "Podgląd PDF",
+      "startTreatment": "Rozpocznij leczenie",
+      "completeTreatment": "Zakończ leczenie",
+      "renegotiate": "Renegocjuj",
+      "acceptInClinic": "Zaakceptuj w gabinecie",
+      "resend": "Wyślij ponownie",
+      "sendReminder": "Wyślij przypomnienie",
+      "setPublicCode": "Ustaw kod dostępu",
+      "unlockPublic": "Odblokuj dostęp"
+    },
+    "items": {
+      "title": "Zabiegi",
+      "add": "Dodaj zabieg",
+      "remove": "Usuń zabieg",
+      "edit": "Edytuj zabieg",
+      "empty": "Brak zabiegów w tym kosztorysie",
+      "singular": "zabieg",
+      "plural": "zabiegi",
+      "addFromCatalog": "Dodaj z katalogu",
+      "addFromOdontogram": "Dodaj z diagramu zębowego",
+      "treatment": "Zabieg",
+      "searchCatalog": "Szukaj w katalogu zabiegów...",
+      "unitPrice": "Cena jednostkowa",
+      "quantity": "Ilość",
+      "discount": "Rabat",
+      "lineTotal": "Suma pozycji",
+      "tooth": "Ząb",
+      "toothNumber": "Numer zęba",
+      "toothNumberPlaceholder": "Np.: 11, 21, 36...",
+      "surfaces": "Powierzchnie",
+      "notes": "Notatki",
+      "notesPlaceholder": "Notatki dotyczące tego zabiegu...",
+      "managedByPlan": "Pozycje tego kosztorysu są zarządzane z planu leczenia {plan}."
+    },
+    "signature": {
+      "title": "Podpis cyfrowy",
+      "viewAction": "Zobacz podpis",
+      "signedBy": "Podpisano przez",
+      "signedAt": "Data podpisu",
+      "methodLabel": "Metoda",
+      "relationshipLabel": "Pokrewieństwo",
+      "documentHash": "Skrót dokumentu (SHA-256)",
+      "hashHint": "Skrót {short} — wiąże podpis z tym konkretnym PDF-em. Każda zmiana by go unieważniła.",
+      "downloadSignedPdf": "Pobierz podpisany PDF",
+      "downloadError": "Nie udało się pobrać podpisanego PDF-a.",
+      "notSigned": "Dla tego kosztorysu nie zarejestrowano jeszcze podpisu.",
+      "method": {
+        "drawn": "Podpis odręczny",
+        "clickAccept": "Akceptacja kliknięciem",
+        "external": "Dostawca zewnętrzny"
+      },
+      "email": "E-mail",
+      "relationship": "Pokrewieństwo z pacjentem",
+      "patient": "Pacjent",
+      "guardian": "Opiekun prawny",
+      "representative": "Pełnomocnik",
+      "accept": "Akceptuję warunki kosztorysu",
+      "signHere": "Podpisz tutaj",
+      "clear": "Wyczyść podpis"
+    },
+    "history": {
+      "title": "Historia zmian",
+      "noChanges": "Brak zarejestrowanych zmian",
+      "actions": {
+        "created": "Kosztorys utworzony",
+        "updated": "Kosztorys zaktualizowany",
+        "status_changed": "Status zmieniony",
+        "item_added": "Zabieg dodany",
+        "item_removed": "Zabieg usunięty",
+        "signed": "Kosztorys podpisany",
+        "sent": "Kosztorys wysłany",
+        "duplicated": "Utworzono nową wersję",
+        "deleted": "Kosztorys usunięty",
+        "item_treatment_started": "Leczenie rozpoczęte",
+        "item_treatment_completed": "Leczenie zakończone"
+      }
+    },
+    "versions": {
+      "title": "Wersje",
+      "current": "Bieżąca",
+      "viewVersion": "Zobacz wersję"
+    },
+    "confirmations": {
+      "send": "Wysłać kosztorys do pacjenta?",
+      "sendDescription": "Kosztorys zostanie oznaczony jako wysłany.",
+      "reject": "Odrzucić kosztorys?",
+      "rejectDescription": "Tej operacji nie można cofnąć.",
+      "cancel": "Anulować kosztorys?",
+      "cancelDescription": "Tej operacji nie można cofnąć.",
+      "resend": "Utworzyć nową wersję tego kosztorysu? Powiązany plan leczenia będzie podążał za nową wersją.",
+      "delete": "Usunąć kosztorys?",
+      "deleteDescription": "Tej operacji nie można cofnąć."
+    },
+    "send": {
+      "description": "Możesz wysłać kosztorys e-mailem lub oznaczyć jako przekazany ręcznie (wydrukowany lub wręczony).",
+      "sendByEmail": "Wyślij e-mailem",
+      "willSendTo": "Zostanie wysłany do",
+      "noPatientEmail": "Pacjent nie ma zarejestrowanego e-maila",
+      "customMessage": "Własna wiadomość (opcjonalnie)",
+      "customMessagePlaceholder": "Dodaj wiadomość dla pacjenta...",
+      "manualNote": "Kosztorys zostanie oznaczony jako wysłany bez wysyłania e-maila.",
+      "sendEmail": "Wyślij e-mail",
+      "markAsSent": "Oznacz jako wysłany"
+    },
+    "messages": {
+      "created": "Kosztorys utworzony",
+      "updated": "Kosztorys zaktualizowany",
+      "deleted": "Kosztorys usunięty",
+      "sent": "Kosztorys wysłany",
+      "sentByEmail": "Kosztorys wysłany e-mailem",
+      "sentManually": "Kosztorys oznaczony jako wysłany",
+      "accepted": "Kosztorys zaakceptowany",
+      "rejected": "Kosztorys odrzucony",
+      "cancelled": "Kosztorys anulowany",
+      "duplicated": "Utworzono nową wersję",
+      "resent": "Nowa wersja utworzona z poprzedniego kosztorysu",
+      "itemAdded": "Zabieg dodany",
+      "itemUpdated": "Zabieg zaktualizowany",
+      "itemRemoved": "Zabieg usunięty",
+      "treatmentStarted": "Leczenie rozpoczęte",
+      "treatmentCompleted": "Leczenie zakończone"
+    },
+    "errors": {
+      "load": "Błąd podczas wczytywania kosztorysów",
+      "create": "Błąd podczas tworzenia kosztorysu",
+      "update": "Błąd podczas aktualizacji kosztorysu",
+      "delete": "Błąd podczas usuwania kosztorysu",
+      "send": "Błąd podczas wysyłania kosztorysu",
+      "accept": "Błąd podczas akceptowania kosztorysu",
+      "reject": "Błąd podczas odrzucania kosztorysu",
+      "notFound": "Nie znaleziono kosztorysu",
+      "onlyDraft": "Edytować można tylko wersje robocze"
+    },
+    "filters": {
+      "allStatuses": "Wszystkie statusy",
+      "status": "Status",
+      "paymentStatus": "Status",
+      "professional": "Lekarz",
+      "validity": "Ważność",
+      "validityValid": "Ważny",
+      "validityExpiringSoon": "Wygasa za 7 dni",
+      "validityExpired": "Wygasły",
+      "dateFrom": "Od",
+      "dateTo": "Do",
+      "showExpired": "Pokaż wygasłe",
+      "advanced": "Filtry zaawansowane",
+      "clear": "Wyczyść filtry"
+    },
+    "sortFields": {
+      "createdAt": "Utworzono",
+      "validUntil": "Ważny do",
+      "total": "Razem",
+      "status": "Status",
+      "budgetNumber": "Numer"
+    },
+    "validity": {
+      "expired": "Wygasły",
+      "expiresIn": "Wygasa za {days} dni"
+    },
+    "pdf": {
+      "generating": "Generowanie PDF...",
+      "downloadError": "Błąd podczas pobierania PDF"
+    },
+    "modals": {
+      "renegotiate": {
+        "title": "Renegocjuj kosztorys",
+        "description": "Bieżący kosztorys zostanie anulowany, a plan wróci do wersji roboczej, aby można było dostosować zabiegi.",
+        "submit": "Renegocjuj"
+      },
+      "acceptInClinic": {
+        "title": "Zaakceptuj kosztorys w gabinecie",
+        "description": "Zarejestruj akceptację pacjenta. Możesz pobrać podpis na tablecie (opcjonalnie).",
+        "signerLabel": "Imię i nazwisko podpisującego",
+        "captureSignature": "Pobierz podpis",
+        "submit": "Oznacz jako zaakceptowany"
+      },
+      "setPublicCode": {
+        "title": "Ustaw kod dostępu",
+        "description": "Ten pacjent nie ma w kartotece ani telefonu, ani daty urodzenia. Ustaw kod 4-6 cyfr i przekaż go pacjentowi ustnie. NIE umieszczaj kodu w e-mailu.",
+        "codeLabel": "Kod (4-6 cyfr)",
+        "submit": "Zapisz kod"
+      }
+    },
+    "publicLink": {
+      "action": "Udostępnij link",
+      "title": "Link dla pacjenta",
+      "help": "Skopiuj ten link i udostępnij pacjentowi przez WhatsApp, SMS lub e-mail. Przed wyświetleniem kosztorysu zostanie poproszony o jedną daną weryfikacyjną.",
+      "copy": "Kopiuj link",
+      "copied": "Skopiowano!",
+      "whatsapp": "Wyślij przez WhatsApp",
+      "whatsappNoPhone": "Pacjent nie ma telefonu w kartotece",
+      "whatsappGreeting": "Cześć {name}, oto Twój kosztorys:",
+      "whatsappGreetingFallback": "Dzień dobry, oto Twój kosztorys:",
+      "preview": "Podgląd",
+      "statusSent": "Wysłany",
+      "statusAccepted": "Zaakceptowany",
+      "statusRejected": "Odrzucony",
+      "statusExpired": "Wygasły"
+    },
+    "public": {
+      "title": "Twój kosztorys",
+      "intro": "{clinic} przesyła Ci ten kosztorys. Zapoznaj się z zabiegami i wybierz opcję.",
+      "greeting": "Dzień dobry, {name}",
+      "subtitle": "Twój spersonalizowany plan leczenia",
+      "budgetNumber": "Kosztorys",
+      "issuedOn": "Wystawiono {date}",
+      "items": "Zabiegi objęte kosztorysem",
+      "tooth": "Ząb {number}",
+      "subtotal": "Suma częściowa",
+      "discount": "Rabat",
+      "tax": "VAT",
+      "total": "Razem",
+      "validUntil": "Ważny do {date}",
+      "trustSecure": "Bezpieczne połączenie",
+      "trustEncrypted": "Szyfrowane dane",
+      "trustSignature": "Prawnie wiążący podpis",
+      "needHelp": "Potrzebujesz pomocy? Zadzwoń do gabinetu",
+      "noteFromClinic": "Wiadomość od gabinetu",
+      "callClinic": "Zadzwoń do gabinetu",
+      "emailClinic": "Wyślij e-mail",
+      "cta_accept": "Zaakceptuj i podpisz",
+      "cta_reject": "Nie jestem zainteresowany(-a)",
+      "expired": "Ten kosztorys wygasł. Skontaktuj się z gabinetem.",
+      "locked": "Dostęp zablokowany po zbyt wielu próbach. Zadzwoń do gabinetu.",
+      "already_accepted": "Ten kosztorys został już zaakceptowany. Gabinet skontaktuje się w sprawie pierwszej wizyty.",
+      "already_rejected": "Ten kosztorys został odrzucony. Jeśli zmienisz zdanie, zadzwoń do gabinetu.",
+      "download": {
+        "signedPdf": "Pobierz podpisany PDF",
+        "notSigned": "Ten kosztorys nie ma jeszcze załączonego podpisu.",
+        "error": "Nie udało się pobrać PDF-a. Spróbuj ponownie.",
+        "reauthIntro": "Ze względów bezpieczeństwa zweryfikuj ponownie swoją tożsamość, aby pobrać podpisany PDF."
+      },
+      "verify": {
+        "title": "Zweryfikuj swoją tożsamość",
+        "intro": "Aby chronić Twoje dane, potwierdź jedną informację przed wyświetleniem kosztorysu.",
+        "phone_last4_label": "Ostatnie 4 cyfry Twojego telefonu",
+        "dob_label": "Twoja data urodzenia",
+        "manual_code_label": "Kod otrzymany od gabinetu",
+        "submit": "Kontynuuj",
+        "invalid": "Nieprawidłowa dana. Spróbuj ponownie.",
+        "locked": "Dostęp zablokowany po zbyt wielu próbach. Zadzwoń do gabinetu.",
+        "rate_limited": "Zbyt wiele prób. Odczekaj 15 minut."
+      },
+      "accept": {
+        "title": "Zaakceptuj i podpisz",
+        "signerLabel": "Twoje imię i nazwisko",
+        "signatureLabel": "Podpisz tutaj (opcjonalnie)",
+        "signatureClear": "Wyczyść",
+        "consent": "Akceptuję ten kosztorys i wyrażam zgodę na opisane leczenie.",
+        "submit": "Potwierdź akceptację",
+        "success": "Gotowe! Gabinet skontaktuje się w sprawie pierwszej wizyty."
+      },
+      "reject": {
+        "title": "Nie jestem zainteresowany(-a)",
+        "intro": "Dlaczego ten kosztorys Ci nie odpowiada?",
+        "reasonLabel": "Powód",
+        "noteLabel": "Komentarz (opcjonalnie)",
+        "submit": "Potwierdź odrzucenie",
+        "success": "Powiadomiliśmy gabinet.",
+        "reasons": {
+          "price": "Cena",
+          "time": "Brak czasu",
+          "second_opinion": "Druga opinia",
+          "other": "Inny powód"
+        }
+      }
+    },
+    "settings": {
+      "title": "Ustawienia kosztorysów",
+      "description": "Skonfiguruj wygasanie, przypomnienia i weryfikację linku publicznego.",
+      "cards": {
+        "expiry": {
+          "title": "Wygasanie i automatyczne zamykanie",
+          "description": "Jak długo kosztorys jest ważny i kiedy automatycznie zamykać oczekujące plany."
+        },
+        "reminders": {
+          "title": "Automatyczne przypomnienia",
+          "description": "Włącz lub wyłącz przypomnienia e-mail po 7 i 14 dniach dla pacjentów bez odpowiedzi."
+        },
+        "publicLink": {
+          "title": "Link publiczny i weryfikacja",
+          "description": "Skonfiguruj zabezpieczenie linku do kosztorysu dla pacjenta."
+        }
+      },
+      "expiry": {
+        "validityDays": "Ważność kosztorysu (dni)",
+        "validityHelp": "Po tylu dniach bez odpowiedzi kosztorys przechodzi w stan Wygasły (zakres 7-180).",
+        "autoCloseDays": "Dni do automatycznego zamknięcia planu",
+        "autoCloseHelp": "Plany z wygasłym kosztorysem i bez aktywności przez tyle dni przechodzą w stan Zamknięty (zakres 7-180).",
+        "save": "Zapisz"
+      },
+      "reminders": {
+        "enabled": "Wysyłaj automatyczne przypomnienia po 7 i 14 dniach",
+        "enabledHelp": "Gdy włączone, system wysyła pacjentowi e-maile o oczekujących kosztorysach. Gdy wyłączone, recepcja kontaktuje się ręcznie.",
+        "save": "Zapisz"
+      },
+      "publicLink": {
+        "authDisabled": "Wyłącz weryfikację linku publicznego",
+        "authDisabledHelp": "Gdy włączone, pacjent widzi kosztorys po samym linku — bez weryfikacji telefonu lub daty urodzenia. Zaakceptuj ryzyko udostępnienia linku.",
+        "save": "Zapisz"
+      },
+      "saved": "Ustawienia zapisane"
+    }
+  },
+  "notifications": {
+    "communications": {
+      "language": {
+        "cardTitle": "Język komunikacji",
+        "cardDescription": "Język widoku kosztorysu dla pacjenta, e-maili i SMS-ów.",
+        "title": "Język komunikacji z pacjentami",
+        "label": "Język",
+        "help": "Dotyczy widoku kosztorysu dla pacjenta oraz automatycznych szablonów e-mail/SMS. Interfejs zespołu zachowuje język każdego użytkownika.",
+        "save": "Zapisz",
+        "saved": "Język zapisany"
+      }
+    },
+    "title": "Powiadomienia",
+    "description": "Skonfiguruj powiadomienia e-mail gabinetu",
+    "pageDescription": "Skonfiguruj, które powiadomienia są wysyłane automatycznie, a które wymagają ręcznego wysłania.",
+    "autoVsManual": "Powiadomienia automatyczne i ręczne",
+    "autoVsManualDescription": "Określ, które powiadomienia są wysyłane automatycznie przy wystąpieniu zdarzenia, a które użytkownik musi wysłać ręcznie.",
+    "notificationType": "Rodzaj powiadomienia",
+    "enabled": "Włączone",
+    "autoSend": "Wysyłka automatyczna",
+    "options": "Opcje",
+    "hoursBefore": "godz. wcześniej",
+    "testConnection": "Testuj połączenie",
+    "testEmailTitle": "Wyślij testowy e-mail",
+    "testEmailDescription": "Wyślemy testowy e-mail, aby sprawdzić poprawność konfiguracji.",
+    "sendTestEmail": "Wyślij test",
+    "test_email_sent": "Testowy e-mail wysłany pomyślnie",
+    "settings_saved": "Ustawienia zapisane",
+    "emailProvider": "Dostawca e-mail",
+    "providerConfigured": "Dostawca e-mail skonfigurowany",
+    "providerNote": "Konfiguracja serwera e-mail odbywa się w zmiennych środowiskowych serwera.",
+    "infoTitle": "Informacja",
+    "infoAutoSend": "Wysyłka automatyczna: powiadomienie jest wysyłane przy wystąpieniu zdarzenia (np. przy tworzeniu wizyty).",
+    "infoManualSend": "Wysyłka ręczna: pojawi się przycisk do wysłania powiadomienia w dowolnym momencie.",
+    "infoDisabled": "Wyłączone: powiadomienie nie będzie wysyłane i opcja wysyłki nie pojawi się.",
+    "types": {
+      "appointment_confirmation": "Potwierdzenie wizyty",
+      "appointment_confirmation_desc": "E-mail z potwierdzeniem przy umawianiu wizyty",
+      "appointment_cancelled": "Odwołanie wizyty",
+      "appointment_cancelled_desc": "E-mail z powiadomieniem o odwołaniu wizyty",
+      "appointment_reminder": "Przypomnienie o wizycie",
+      "appointment_reminder_desc": "E-mail z przypomnieniem przed wizytą",
+      "budget_sent": "Wysyłka kosztorysu",
+      "budget_sent_desc": "E-mail ze szczegółami kosztorysu",
+      "budget_accepted": "Kosztorys zaakceptowany",
+      "budget_accepted_desc": "E-mail z potwierdzeniem akceptacji kosztorysu",
+      "welcome": "Powitanie",
+      "welcome_desc": "E-mail powitalny dla nowych pacjentów"
+    },
+    "sendConfirmation": "Wyślij potwierdzenie",
+    "sendReminder": "Wyślij przypomnienie",
+    "sendCancellation": "Wyślij odwołanie",
+    "sendBudget": "Wyślij e-mailem",
+    "sendAcceptance": "Wyślij potwierdzenie",
+    "sendWelcome": "Wyślij powitanie",
+    "sendEmail": "Wyślij e-mail",
+    "errors": {
+      "fetch_failed": "Błąd podczas wczytywania ustawień",
+      "save_failed": "Błąd podczas zapisywania ustawień",
+      "test_failed": "Błąd podczas wysyłania testowego e-maila",
+      "send_failed": "Błąd podczas wysyłania powiadomienia"
+    },
+    "smtp": {
+      "title": "Konfiguracja serwera e-mail",
+      "description": "Skonfiguruj serwer SMTP do wysyłania e-maili z Twojego gabinetu. Każdy gabinet może mieć własną konfigurację.",
+      "configure": "Skonfiguruj",
+      "provider": "Dostawca",
+      "host": "Serwer",
+      "port": "Port",
+      "username": "Nazwa użytkownika",
+      "password": "Hasło",
+      "passwordHint": "Pozostaw puste, aby zachować obecne hasło",
+      "useTls": "Użyj TLS",
+      "useSsl": "Użyj SSL",
+      "fromEmail": "E-mail nadawcy",
+      "fromName": "Nazwa nadawcy",
+      "security": "Bezpieczeństwo",
+      "testConnection": "Testuj połączenie",
+      "testConnectionTitle": "Przetestuj konfigurację przed zapisaniem",
+      "testEmailPlaceholder": "Testowy adres e-mail",
+      "test_success": "Połączenie SMTP powiodło się. Testowy e-mail wysłany.",
+      "test_failed": "Błąd połączenia SMTP",
+      "settings_saved": "Ustawienia SMTP zapisane",
+      "consoleNote": "W trybie konsoli e-maile są wyświetlane w konsoli serwera zamiast wysyłane. Przydatne w trakcie prac programistycznych.",
+      "disabledNote": "Przy wyłączonym e-mailu z tego gabinetu nie będą wysyłane żadne powiadomienia e-mail.",
+      "status": {
+        "not_configured": "Nieskonfigurowany",
+        "verified": "Zweryfikowany i działa",
+        "not_verified": "Skonfigurowany, ale niezweryfikowany",
+        "disabled": "E-mail wyłączony",
+        "console": "Tryb konsoli (deweloperski)"
+      },
+      "errors": {
+        "fetch_failed": "Błąd podczas wczytywania ustawień SMTP",
+        "save_failed": "Błąd podczas zapisywania ustawień SMTP",
+        "test_failed": "Błąd podczas testowania połączenia SMTP"
+      }
+    },
+    "onboarding": {
+      "label": "Wysyłka e-maili",
+      "description": "Ustaw nadawcę, aby wysyłać potwierdzenia wizyt i kosztorysy."
+    }
+  },
+  "invoice": {
+    "title": "Faktury",
+    "description": "Zarządzaj fakturami i rozliczeniami",
+    "new": "Nowa faktura",
+    "edit": "Edytuj fakturę",
+    "view": "Zobacz fakturę",
+    "delete": "Usuń fakturę",
+    "noItems": "Brak faktur",
+    "empty": "Brak zarejestrowanych faktur",
+    "emptyAction": "Wystaw pierwszą fakturę",
+    "searchPlaceholder": "Szukaj po numerze lub pacjencie...",
+    "notFound": "Nie znaleziono faktury",
+    "draftNoNumber": "Wersja robocza",
+    "details": "Szczegóły",
+    "invoiceNumber": "Numer faktury",
+    "patient": "Pacjent",
+    "searchPatient": "Szukaj pacjenta",
+    "searchPatientPlaceholder": "Szukaj po nazwisku...",
+    "professional": "Lekarz",
+    "billingData": "Dane do faktury",
+    "billingName": "Nazwa na fakturze",
+    "taxId": "NIP",
+    "billingEmail": "E-mail do faktur",
+    "billingAddress": "Adres na fakturze",
+    "billingDataComplete": "Kompletne",
+    "billingDataIncomplete": "Niekompletne",
+    "billingDataIncompleteHint": "Pacjentowi brakuje części danych do faktury.",
+    "editPatientBilling": "Edytuj dane pacjenta",
+    "fromPatient": "Z karty pacjenta",
+    "editInPatient": "Edytuj w profilu",
+    "billingFromPatientHint": "Te dane pochodzą z karty pacjenta. Aby je zmienić, edytuj dane do faktur pacjenta.",
+    "paymentTerms": "Warunki płatności",
+    "linkedToBudget": "Powiązana z kosztorysem",
+    "selectPatient": "Wybierz pacjenta",
+    "noBillingData": "Brak danych do faktury",
+    "street": "Ulica",
+    "city": "Miasto",
+    "postalCode": "Kod pocztowy",
+    "province": "Województwo",
+    "country": "Kraj",
+    "linkedBudget": "Powiązany kosztorys",
+    "creditNoteFor": "Korekta do",
+    "paymentTermDays": "Termin płatności (dni)",
+    "dueDate": "Termin płatności",
+    "issueDate": "Data wystawienia",
+    "subtotal": "Suma częściowa",
+    "discount": "Rabat",
+    "totalDiscount": "Suma rabatów",
+    "tax": "Podatek",
+    "total": "Razem",
+    "paid": "Zapłacono",
+    "totalPaid": "Zapłacono łącznie",
+    "balance": "Saldo",
+    "balanceDue": "Do zapłaty",
+    "overdue": "Po terminie",
+    "overdueDays": "{n} dni po terminie",
+    "info": {
+      "issueDate": "Data wystawienia",
+      "dueDate": "Termin płatności",
+      "issuedBy": "Wystawione przez",
+      "createdBy": "Utworzone przez",
+      "createdAt": "Utworzono",
+      "budget": "Kosztorys",
+      "creditNoteFor": "Korekta do"
+    },
+    "criticalBanner": {
+      "aeatRejected": {
+        "title": "AEAT odrzucił tę fakturę",
+        "cta": "Popraw i wyślij ponownie"
+      },
+      "billingIncomplete": {
+        "title": "Niekompletne dane do faktury",
+        "cta": "Uzupełnij dane"
+      }
+    },
+    "collect": {
+      "title": "Pobierz płatność za fakturę",
+      "submit": "Pobierz płatność",
+      "noteAppliedToInvoice": "zaliczono na tę fakturę.",
+      "notePendingAfter": "Pozostałe saldo",
+      "noteFullySettled": "Ta płatność w pełni rozlicza fakturę.",
+      "noteToInvoice": "zaliczono na tę fakturę, a",
+      "noteExcessToOnAccount": "zapisano na koncie pacjenta.",
+      "noteInvoiceSettled": "Ta faktura jest już opłacona.",
+      "noteToOnAccount": "zostanie zapisane na koncie pacjenta."
+    },
+    "tooth": "Ząb",
+    "vat": "VAT",
+    "currency": "Waluta",
+    "internalNotes": "Notatki wewnętrzne",
+    "internalNotesPlaceholder": "Notatki widoczne tylko dla zespołu...",
+    "publicNotes": "Notatki publiczne",
+    "publicNotesPlaceholder": "Notatki widoczne na fakturze...",
+    "items": "Pozycje",
+    "addItem": "Dodaj pozycję",
+    "editItem": "Edytuj pozycję",
+    "selectTreatment": "Zabieg",
+    "searchCatalog": "Szukaj zabiegu w katalogu...",
+    "itemDescription": "Opis",
+    "itemPrice": "Cena jednostkowa",
+    "itemQuantity": "Ilość",
+    "selectVatType": "Wybierz stawkę VAT",
+    "summary": "Podsumowanie",
+    "createDraft": "Utwórz wersję roboczą",
+    "createFromBudget": "Wystaw fakturę z kosztorysu",
+    "notes": "Notatki",
+    "status": {
+      "draft": "Wersja robocza",
+      "issued": "Wystawiona",
+      "partial": "Częściowo opłacona",
+      "paid": "Opłacona",
+      "cancelled": "Anulowana",
+      "voided": "Unieważniona"
+    },
+    "actions": {
+      "issue": "Wystaw fakturę",
+      "void": "Unieważnij",
+      "recordPayment": "Zarejestruj płatność",
+      "createCreditNote": "Wystaw korektę",
+      "downloadPdf": "Pobierz PDF",
+      "previewPdf": "Podgląd PDF",
+      "sendEmail": "Wyślij e-mailem"
+    },
+    "recordPayment": "Zarejestruj płatność",
+    "paymentAmount": "Kwota",
+    "paymentMethod": "Metoda płatności",
+    "paymentDate": "Data płatności",
+    "paymentReference": "Numer referencyjny",
+    "paymentReferencePlaceholder": "Numer transakcji, pokwitowanie...",
+    "paymentNotes": "Notatki do płatności",
+    "paymentVoided": "Płatność unieważniona",
+    "createCreditNote": "Wystaw korektę",
+    "creditNoteReason": "Powód korekty",
+    "creditNoteReasonPlaceholder": "Opisz powód wystawienia korekty...",
+    "creditNoteInfo": "Korekta zostanie wystawiona na pełną kwotę faktury.",
+    "prompts": {
+      "voidPaymentReason": "Podaj powód unieważnienia tej płatności"
+    },
+    "payments": {
+      "title": "Płatności",
+      "record": "Zarejestruj płatność",
+      "void": "Unieważnij płatność",
+      "amount": "Kwota",
+      "method": "Metoda płatności",
+      "date": "Data",
+      "reference": "Numer referencyjny",
+      "notes": "Notatki",
+      "noPayments": "Brak zarejestrowanych płatności",
+      "recorded": "Płatność zarejestrowana",
+      "voided": "Płatność unieważniona",
+      "voidReason": "Powód unieważnienia",
+      "voidReasonPlaceholder": "Powód unieważnienia tej płatności...",
+      "methods": {
+        "cash": "Gotówka",
+        "card": "Karta",
+        "bank_transfer": "Przelew",
+        "direct_debit": "Polecenie zapłaty",
+        "insurance": "Ubezpieczenie",
+        "other": "Inna"
+      }
+    },
+    "creditNote": {
+      "title": "Faktura korygująca",
+      "create": "Wystaw korektę",
+      "reason": "Powód",
+      "reasonPlaceholder": "Powód wystawienia korekty...",
+      "selectItems": "Wybierz pozycje do skorygowania",
+      "fullCreditNote": "Pełna korekta (wszystkie pozycje)",
+      "partialCreditNote": "Częściowa korekta (wybrane pozycje)",
+      "originalInvoice": "Faktura pierwotna",
+      "created": "Korekta wystawiona"
+    },
+    "history": {
+      "title": "Historia",
+      "noChanges": "Brak zarejestrowanych zmian",
+      "actions": {
+        "created": "Faktura utworzona",
+        "updated": "Faktura zaktualizowana",
+        "issued": "Faktura wystawiona",
+        "voided": "Faktura unieważniona",
+        "payment_recorded": "Płatność zarejestrowana",
+        "payment_voided": "Płatność unieważniona",
+        "credit_note_created": "Korekta wystawiona"
+      }
+    },
+    "fromBudget": "Wystaw fakturę z kosztorysu",
+    "selectItems": "Wybierz pozycje do zafakturowania",
+    "selectItemsHint": "Wybierz pozycje kosztorysu, które chcesz zafakturować",
+    "availableQuantity": "Dostępne",
+    "quantityToInvoice": "Ilość do zafakturowania",
+    "alreadyInvoiced": "Już zafakturowane",
+    "remaining": "Pozostało",
+    "noItemsAvailable": "Brak pozycji do zafakturowania",
+    "allItemsInvoiced": "Wszystkie pozycje zostały zafakturowane",
+    "series": {
+      "title": "Serie faktur",
+      "prefix": "Prefiks",
+      "type": "Rodzaj",
+      "currentNumber": "Bieżący numer",
+      "resetYearly": "Resetuj co rok",
+      "default": "Domyślna",
+      "active": "Aktywna",
+      "invoice": "Faktura",
+      "credit_note": "Faktura korygująca"
+    },
+    "filters": {
+      "allStatuses": "Status",
+      "overdueOnly": "Po terminie",
+      "dateFrom": "Od",
+      "dateTo": "Do"
+    },
+    "sortFields": {
+      "created": "Utworzono",
+      "issueDate": "Data wystawienia",
+      "dueDate": "Termin płatności",
+      "total": "Razem"
+    },
+    "overdueByDays": "{days} dni po terminie",
+    "pdf": {
+      "generating": "Generowanie PDF...",
+      "downloadError": "Błąd podczas pobierania PDF"
+    },
+    "reports": {
+      "title": "Raporty rozliczeń",
+      "summary": "Podsumowanie",
+      "overdue": "Po terminie",
+      "overdueInvoices": "Faktury po terminie",
+      "byPaymentMethod": "Wg metody płatności",
+      "byProfessional": "Wg lekarza",
+      "vatSummary": "Podsumowanie VAT",
+      "gaps": "Luki w numeracji",
+      "period": "Okres",
+      "from": "Od",
+      "to": "Do",
+      "refresh": "Odśwież",
+      "totalInvoiced": "Zafakturowano łącznie",
+      "totalCollected": "Pobrano łącznie",
+      "totalPaid": "Zapłacono łącznie",
+      "totalPending": "Zaległości łącznie",
+      "pending": "Saldo zaległości",
+      "invoices": "faktur",
+      "paid": "opłacone",
+      "payments": "płatności",
+      "noGaps": "Brak luk w numeracji",
+      "gapsFound": "Znaleziono {count} luk w numeracji",
+      "gapsDetected": "Wykryto luki w numeracji",
+      "missingNumbers": "Brakujące numery:",
+      "noData": "Brak danych dla wybranego okresu",
+      "noOverdue": "Brak faktur po terminie",
+      "daysOverdue": "dni po terminie",
+      "vatType": "Stawka VAT",
+      "base": "Podstawa",
+      "tax": "Podatek",
+      "thisMonth": "Ten miesiąc",
+      "thisQuarter": "Ten kwartał",
+      "thisYear": "Ten rok",
+      "lastMonth": "Poprzedni miesiąc",
+      "lastQuarter": "Poprzedni kwartał",
+      "lastYear": "Poprzedni rok"
+    },
+    "confirmations": {
+      "issue": "Wystawić fakturę?",
+      "issueDescription": "Po wystawieniu faktury nie można edytować. Można jedynie rejestrować płatności lub wystawiać korekty.",
+      "void": "Unieważnić fakturę?",
+      "voidDescription": "Tej operacji nie można cofnąć.",
+      "delete": "Usunąć fakturę?",
+      "deleteDescription": "Tej operacji nie można cofnąć."
+    },
+    "messages": {
+      "created": "Faktura utworzona",
+      "updated": "Faktura zaktualizowana",
+      "deleted": "Faktura usunięta",
+      "issued": "Faktura wystawiona",
+      "voided": "Faktura unieważniona",
+      "itemAdded": "Pozycja dodana",
+      "itemUpdated": "Pozycja zaktualizowana",
+      "sentByEmail": "Faktura wysłana e-mailem",
+      "sentManually": "Faktura oznaczona jako wysłana"
+    },
+    "send": {
+      "title": "Wyślij fakturę",
+      "description": "Możesz wysłać fakturę e-mailem lub oznaczyć jako przekazaną ręcznie (wydrukowaną lub wręczoną osobiście).",
+      "sendByEmail": "Wyślij e-mailem",
+      "willSendTo": "Zostanie wysłana do",
+      "noPatientEmail": "Pacjent nie ma adresu e-mail",
+      "customMessage": "Własna wiadomość (opcjonalnie)",
+      "customMessagePlaceholder": "Dodaj wiadomość dla pacjenta...",
+      "manualNote": "Faktura zostanie oznaczona jako wysłana bez wysyłania e-maila.",
+      "sendEmail": "Wyślij e-mail",
+      "markAsSent": "Oznacz jako wysłaną"
+    },
+    "errors": {
+      "load": "Błąd podczas wczytywania faktur",
+      "create": "Błąd podczas tworzenia faktury",
+      "update": "Błąd podczas aktualizacji faktury",
+      "delete": "Błąd podczas usuwania faktury",
+      "issue": "Błąd podczas wystawiania faktury",
+      "void": "Błąd podczas unieważniania faktury",
+      "recordPayment": "Błąd podczas rejestrowania płatności",
+      "voidPayment": "Błąd podczas unieważniania płatności",
+      "createCreditNote": "Błąd podczas wystawiania korekty",
+      "send": "Błąd podczas wysyłania faktury",
+      "creditNoteReasonRequired": "Powód korekty jest wymagany",
+      "notFound": "Nie znaleziono faktury",
+      "onlyDraft": "Edytować można tylko faktury robocze",
+      "canOnlyDeleteDraft": "Usuwać można tylko faktury robocze",
+      "patientRequired": "Pacjent jest wymagany",
+      "itemsRequired": "Wymagana jest co najmniej jedna pozycja",
+      "itemRequired": "Opis i cena są wymagane",
+      "selectCatalogItem": "Wybierz zabieg z katalogu",
+      "cannotEdit": "Edytować można tylko faktury robocze"
+    },
+    "newItemsPending": "Nowe pozycje oczekują na zapis",
+    "linkedPlan": "Plan leczenia"
+  },
+  "reports": {
+    "title": "Raporty",
+    "subtitle": "Analizy i statystyki gabinetu",
+    "viewReports": "Zobacz raporty",
+    "noAccess": "Nie masz dostępu do żadnych raportów",
+    "dashboard": {
+      "title": "Panel",
+      "subtitle": "Twój gabinet w skrócie",
+      "period": "Okres",
+      "snapshotBadge": "Dzisiaj",
+      "snapshotTooltip": "Niezależne od zakresu dat",
+      "vsPrev": "vs poprzedni okres",
+      "empty": {
+        "noData": "Brak danych w tym zakresie"
+      },
+      "drilldown": {
+        "title": "Szczegóły",
+        "payments": "Płatności"
+      },
+      "kpi": {
+        "cashCollected": "Pobrane wpłaty",
+        "cashCollectedHint": "{count} płatności",
+        "patientAdvance": "Zaliczki pacjentów",
+        "patientAdvanceHint": "Nierozliczone zaliczki",
+        "production": "Produkcja",
+        "productionHint": "{count} zabiegów",
+        "byMethod": "Wg metody płatności",
+        "methodCount": "{count} płatności",
+        "total": "Razem",
+        "newPatients": "Nowi pacjenci",
+        "newPatientsHint": "{rate}% wszystkich wizyt",
+        "appointmentFunnel": "Wskaźnik nieobecności",
+        "funnelHint": "{completed}% ukończonych",
+        "avgCollectedTicket": "Średnia pobrana wpłata",
+        "avgTicketHint": "Na {count} płatności",
+        "aging": "Struktura wiekowa należności"
+      },
+      "charts": {
+        "cashOverTime": "Wpłaty w czasie",
+        "productionByDoctor": "Produkcja wg lekarza",
+        "refunded": "Zwroty"
+      },
+      "production": {
+        "unassigned": "Nieprzypisane",
+        "others": "Inni",
+        "treatmentCount": "{count} zabiegów"
+      },
+      "aging": {
+        "bucket0_30": "0-30 dni",
+        "bucket31_60": "31-60 dni",
+        "bucket61_90": "61-90 dni",
+        "bucket90plus": "90+ dni",
+        "empty": "Brak zaległych należności",
+        "patientCount": "{count} pacjentów"
+      }
+    },
+    "billing": {
+      "title": "Rozliczenia",
+      "description": "Przychody, płatności, VAT i faktury po terminie",
+      "summary": "Podsumowanie",
+      "overdue": "Po terminie",
+      "overdueInvoices": "Faktury po terminie",
+      "byPaymentMethod": "Wg metody płatności",
+      "byProfessional": "Wg lekarza",
+      "vatSummary": "Podsumowanie VAT",
+      "gaps": "Luki w numeracji",
+      "period": "Okres",
+      "from": "Od",
+      "to": "Do",
+      "refresh": "Odśwież",
+      "totalInvoiced": "Zafakturowano łącznie",
+      "totalCollected": "Pobrano łącznie",
+      "pending": "Saldo zaległości",
+      "invoices": "faktur",
+      "paid": "opłacone",
+      "payments": "płatności",
+      "gapsDetected": "Wykryto luki w numeracji",
+      "missingNumbers": "Brakujące numery:",
+      "noData": "Brak danych dla wybranego okresu",
+      "noOverdue": "Brak faktur po terminie",
+      "daysOverdue": "dni po terminie",
+      "vatType": "Stawka VAT",
+      "base": "Podstawa",
+      "tax": "Podatek",
+      "thisMonth": "Ten miesiąc",
+      "thisQuarter": "Ten kwartał",
+      "thisYear": "Ten rok",
+      "lastMonth": "Poprzedni miesiąc",
+      "lastQuarter": "Poprzedni kwartał",
+      "lastYear": "Poprzedni rok"
+    },
+    "budgets": {
+      "title": "Kosztorysy",
+      "description": "Wskaźniki akceptacji, analiza lekarzy i zabiegów",
+      "comingSoonDescription": "Raporty kosztorysów będą wkrótce dostępne. Będzie można analizować wskaźniki akceptacji, kosztorysy wg lekarza i najczęściej wyceniane zabiegi.",
+      "features": {
+        "acceptanceRate": "Wskaźnik akceptacji",
+        "acceptanceRateDesc": "Odsetek zaakceptowanych i odrzuconych kosztorysów",
+        "byProfessional": "Wg lekarza",
+        "byProfessionalDesc": "Kosztorysy utworzone przez każdego lekarza",
+        "byTreatment": "Wg zabiegu",
+        "byTreatmentDesc": "Najczęściej wyceniane zabiegi",
+        "averageValue": "Średnia wartość",
+        "averageValueDesc": "Średnia kwota kosztorysu"
+      },
+      "labels": {
+        "totalCreated": "Utworzono łącznie",
+        "accepted": "Zaakceptowane",
+        "rejected": "odrzucone",
+        "pending": "oczekujące",
+        "completed": "Ukończone",
+        "acceptanceRate": "Wskaźnik akceptacji",
+        "averageValue": "Średnia wartość",
+        "byStatus": "Wg statusu",
+        "topTreatments": "Najczęściej wyceniane zabiegi",
+        "treatment": "Zabieg",
+        "occurrences": "Wystąpienia",
+        "quantity": "Ilość"
+      }
+    },
+    "scheduling": {
+      "title": "Terminarz",
+      "description": "Pierwsze wizyty, przepracowane godziny i obłożenie",
+      "comingSoonDescription": "Raporty terminarza będą wkrótce dostępne. Będzie można analizować pierwsze wizyty, godziny wg lekarza i wskaźniki odwołań.",
+      "features": {
+        "firstVisits": "Pierwsze wizyty",
+        "firstVisitsDesc": "Nowi pacjenci w okresie",
+        "hoursWorked": "Przepracowane godziny",
+        "hoursWorkedDesc": "Czas wg lekarza",
+        "cancellations": "Odwołania",
+        "cancellationsDesc": "Wskaźniki odwołań i nieobecności",
+        "cabinetUtilization": "Obłożenie gabinetów",
+        "cabinetUtilizationDesc": "Wykorzystanie każdego gabinetu"
+      },
+      "labels": {
+        "totalAppointments": "Wizyty łącznie",
+        "completionRate": "Wskaźnik ukończenia",
+        "completed": "ukończone",
+        "cancellationRate": "Wskaźnik odwołań",
+        "cancelled": "odwołane",
+        "noShowRate": "Wskaźnik nieobecności",
+        "noShows": "nieobecności",
+        "newPatients": "nowych pacjentów",
+        "firstVisitRate": "Wskaźnik pierwszych wizyt",
+        "ofTotalAppointments": "wszystkich wizyt",
+        "appointmentsInPeriod": "Wizyty w okresie",
+        "excludingCancelled": "bez odwołanych",
+        "appointments": "wizyt",
+        "byDayOfWeek": "Wg dnia tygodnia",
+        "statusBreakdown": "Podział wg statusu",
+        "pending": "oczekujące"
+      },
+      "analytics": {
+        "funnel": "Lejek statusów",
+        "funnelDesc": "Rozkład wizyt wg statusu w okresie",
+        "waitingTimes": "Czasy oczekiwania",
+        "waitingTimesDesc": "Minuty między przybyciem pacjenta a zajęciem fotela",
+        "punctuality": "Punktualność pacjentów",
+        "punctualityDesc": "Różnica między zaplanowaną godziną a faktycznym przybyciem",
+        "durationVariance": "Czas planowany vs rzeczywisty",
+        "durationVarianceDesc": "Porównanie planowanego czasu z rzeczywistym czasem na fotelu",
+        "samples": "Próbki",
+        "average": "Średnia",
+        "median": "Mediana",
+        "p90": "P90",
+        "avgDelta": "Śr. odchylenie",
+        "medianDelta": "Mediana odchylenia",
+        "onTime": "% punktualnie",
+        "avgOverrun": "Śr. przekroczenie",
+        "overrunCount": "Liczba przekroczeń",
+        "underCount": "Liczba krótszych",
+        "completionRate": "Ukończenie",
+        "noShowRate": "Nieobecność",
+        "cancellationRate": "Odwołanie",
+        "punctuality_early": "Wcześnie (<-5)",
+        "punctuality_on_time": "Punktualnie (±5)",
+        "punctuality_late_short": "Spóźnienie (5-15)",
+        "punctuality_late_long": "Spóźnienie (>15)"
+      },
+      "tabs": {
+        "overview": "Przegląd",
+        "activity": "Aktywność",
+        "quality": "Jakość"
+      },
+      "hero": {
+        "inPeriod": "w okresie"
+      },
+      "filters": {
+        "cabinet": "Gabinet",
+        "professional": "Lekarz",
+        "custom": "Zakres niestandardowy",
+        "all": "Wszystkie",
+        "clear": "Wyczyść filtry"
+      },
+      "empty": {
+        "title": "Brak danych dla tego okresu",
+        "desc": "Spróbuj szerszego zakresu dat lub usuń filtry."
+      }
+    }
+  },
+  "invoiceSeries": {
+    "title": "Serie faktur",
+    "description": "Skonfiguruj prefiksy i numerację faktur",
+    "regularInvoices": "Faktury",
+    "creditNotes": "Faktury korygujące",
+    "new": "Nowa seria",
+    "newTitle": "Nowa seria: {type}",
+    "editTitle": "Edytuj serię",
+    "prefix": "Prefiks",
+    "prefixHint": "np. INV, CR. Rok zostanie dodany automatycznie.",
+    "descriptionLabel": "Opis",
+    "descriptionPlaceholder": "Opcjonalny opis serii...",
+    "nextNumber": "Następny numer",
+    "preview": "Podgląd",
+    "resetYearly": "Coroczny reset",
+    "resetYearlyLabel": "Resetuj numerację co rok",
+    "setAsDefault": "Ustaw jako domyślną",
+    "activeLabel": "Seria aktywna",
+    "showInactive": "Pokaż nieaktywne",
+    "noItems": "Brak skonfigurowanych serii",
+    "resetCounter": "Resetuj licznik",
+    "currentNumber": "Bieżący numer",
+    "seriesPrefix": "Prefiks serii",
+    "newNumber": "Nowy numer",
+    "newNumberHint": "Numer musi być większy niż najwyższy istniejący numer w tej serii.",
+    "resetWarningTitle": "Ostrzeżenie",
+    "resetWarning": "Ta operacja zostanie zapisana w dzienniku audytu i nie można jej cofnąć.",
+    "confirmReset": "Resetuj licznik",
+    "created": "Seria utworzona pomyślnie",
+    "saved": "Seria zaktualizowana pomyślnie",
+    "resetSuccess": "Licznik zresetowany pomyślnie",
+    "onboarding": {
+      "label": "Seria faktur",
+      "description": "Wymagana do wystawienia pierwszej faktury (np. FAC-2026-0001)."
+    }
+  },
+  "documents": {
+    "title": "Dokumenty",
+    "add": "Dodaj",
+    "edit": "Edytuj dokument",
+    "upload": "Prześlij dokument",
+    "uploading": "Przesyłanie...",
+    "empty": "Brak dokumentów",
+    "uploadFirst": "Prześlij pierwszy dokument",
+    "types": {
+      "consent": "Zgoda",
+      "id_scan": "Dokument tożsamości",
+      "insurance": "Ubezpieczenie",
+      "report": "Raport",
+      "referral": "Skierowanie",
+      "other": "Inne"
+    },
+    "fields": {
+      "type": "Rodzaj",
+      "title": "Tytuł",
+      "titlePlaceholder": "Tytuł dokumentu",
+      "description": "Opis",
+      "descriptionPlaceholder": "Opcjonalne notatki"
+    },
+    "dropzone": {
+      "hint": "Przeciągnij i upuść plik tutaj lub kliknij, aby wybrać"
+    },
+    "filter": {
+      "allTypes": "Wszystkie rodzaje"
+    },
+    "deleteConfirm": {
+      "title": "Usuń dokument",
+      "message": "Czy na pewno chcesz usunąć ten dokument? Tej operacji nie można cofnąć."
+    },
+    "fetchError": "Błąd podczas wczytywania dokumentów",
+    "uploadSuccess": "Dokument przesłany pomyślnie",
+    "uploadError": "Błąd podczas przesyłania dokumentu",
+    "downloadError": "Błąd podczas pobierania dokumentu",
+    "deleteSuccess": "Dokument usunięty",
+    "deleteError": "Błąd podczas usuwania dokumentu",
+    "updateSuccess": "Dokument zaktualizowany",
+    "updateError": "Błąd podczas aktualizacji dokumentu",
+    "viewer": {
+      "loading": "Wczytywanie dokumentu...",
+      "error": "Nie udało się wczytać dokumentu",
+      "downloadInstead": "Pobierz zamiast tego",
+      "unsupported": "Podgląd niedostępny dla tego typu pliku",
+      "zoomOut": "Pomniejsz",
+      "zoomIn": "Powiększ",
+      "resetZoom": "Resetuj do 100%",
+      "zoomHint": "Ctrl + przewijanie, aby powiększać"
+    },
+    "typeDesc": {
+      "consent": "Podpisany dokument",
+      "id_scan": "Dowód osobisty / paszport",
+      "insurance": "Polisa lub karta",
+      "report": "Raport kliniczny",
+      "referral": "Skierowanie",
+      "other": "Niesklasyfikowany"
+    },
+    "errors": {
+      "mime": "Niedozwolony typ pliku. Tylko PDF, JPG lub PNG.",
+      "size": "Plik przekracza 10 MB."
+    },
+    "pdfPreviewHint": "Podgląd dostępny po przesłaniu",
+    "uploadHelp": "Sklasyfikuj plik, aby pojawił się we właściwej kategorii."
+  },
+  "photoGallery": {
+    "title": "Galeria pacjenta",
+    "add": "Dodaj zdjęcie",
+    "empty": "Brak zdjęć",
+    "uploadFirst": "Prześlij pierwsze",
+    "showingOf": "Wyświetlono {count} z {total}",
+    "upload": "Prześlij zdjęcie",
+    "uploadHelp": "Sklasyfikuj, aby pojawiło się we właściwej kategorii",
+    "dropHere": "Przeciągnij zdjęcie tutaj lub kliknij",
+    "category": "Rodzaj",
+    "subtype": "Widok",
+    "titlePlaceholder": "Wewnątrzustne frontalne — 02/05",
+    "capturedAt": "Data",
+    "exifHint": "Automatycznie z EXIF",
+    "cat": {
+      "all": "Wszystkie",
+      "intraoral": "Wewnątrzustne",
+      "extraoral": "Zewnątrzustne",
+      "xray": "RTG",
+      "clinical": "Przed/Po",
+      "other": "Inne"
+    },
+    "catDesc": {
+      "intraoral": "Wewnątrz jamy ustnej",
+      "extraoral": "Twarz i profil",
+      "xray": "Zdjęcie radiologiczne",
+      "clinical": "Porównanie leczenia",
+      "other": "Niesklasyfikowane"
+    },
+    "sub": {
+      "frontal": "Frontalne",
+      "lateral_left": "Boczne lewe",
+      "lateral_right": "Boczne prawe",
+      "occlusal_upper": "Okluzyjne górne",
+      "occlusal_lower": "Okluzyjne dolne",
+      "palatal": "Podniebienne",
+      "lingual": "Językowe",
+      "smile": "Uśmiech",
+      "rest": "Spoczynek",
+      "frontal_face": "Frontalne",
+      "profile_left": "Profil lewy",
+      "profile_right": "Profil prawy",
+      "three_quarter_left": "3/4 lewe",
+      "three_quarter_right": "3/4 prawe",
+      "panoramic": "Pantomogram",
+      "periapical": "Zębowe",
+      "bitewing": "Skrzydłowo-zgryzowe",
+      "ceph_lat": "Cefalometryczne boczne",
+      "ceph_pa": "Cefalometryczne PA",
+      "cbct": "CBCT",
+      "occlusal_xray": "RTG okluzyjne",
+      "before": "Przed",
+      "after": "Po",
+      "progress": "Postęp",
+      "reference": "Referencyjne",
+      "portrait": "Portret",
+      "document_scan": "Dokument",
+      "model_photo": "Model"
+    },
+    "compare": {
+      "before": "Przed",
+      "after": "Po"
+    },
+    "pair": {
+      "pickHint": "Wybierz zdjęcie do sparowania:",
+      "noCandidates": "Brak dostępnych zdjęć. Najpierw prześlij inne.",
+      "paired": "Sparowane",
+      "exitCompare": "Zakończ porównanie",
+      "compare": "Porównaj",
+      "unpair": "Usuń",
+      "pair": "Sparuj przed/po"
+    }
+  },
+  "help": {
+    "label": "Pomoc",
+    "openHelp": "Otwórz pomoc",
+    "drawerTitle": "Pomoc dla tej strony",
+    "unavailable": "Dla tej strony nie ma jeszcze pomocy kontekstowej.",
+    "openFullManual": "Otwórz pełny podręcznik"
+  },
+  "charts": {
+    "trend": {
+      "ariaLabel": "Trend na {count} punktach"
+    },
+    "donut": {
+      "ariaLabel": "Wykres pierścieniowy, {count} segmentów"
+    }
+  }
+}

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -142,7 +142,9 @@ export default defineNuxtConfig({
       { code: 'pt', name: 'Português', file: 'pt.json' },
       { code: 'ta', name: 'தமிழ்', file: 'ta.json' },
       { code: 'de', name: 'Deutsch', file: 'de.json' },
-      { code: 'hu', name: 'Magyar', file: 'hu.json' }
+      { code: 'hu', name: 'Magyar', file: 'hu.json' },
+      { code: 'pl', name: 'Polski', file: 'pl.json' },
+      { code: 'it', name: 'Italiano', file: 'it.json' }
     ],
     defaultLocale: 'en',
     lazy: true,


### PR DESCRIPTION
Core-app translations for the two remaining language issues, same structure as the merged de/hu PR (#276). Refs #144 (Polish), refs #132 (Italian) — both issues bless a core-only PR as independently mergeable.

## What's in

- **Registration**: `pl` + `it` in `SUPPORTED_LOCALES` and `nuxt.config.ts` ("Polski", "Italiano").
- **`pl.json` + `it.json`**: all **2422 keys** of `en.json`, each. Terminology follows the issue tables — pl: *diagram zębowy, kosztorys, faktura, terminarz, gabinet (stomatologiczny), wywiad medyczny, tydzień ciąży*; it: *odontogramma, preventivo, fattura, agenda, cartella clinica, **riunito** (chair/operatory), richiamo, **studio** — not clinica*.
- **Correct Polish plurals**: Polish needs three forms (`1 alergia / 2-4 alergie / 5+ alergii`, with the 12-14 teen exception) which vue-i18n's default rule can't express. `i18n.config.ts` gains a `pl` `pluralRules` entry and the seven counted pl messages carry three pipe-separated `[one|few|many]` forms. **Verified in the browser across the paradigm**: `0 alergii · 1 alergia · 2 alergie · 5 alergii · 13 alergii · 22 alergie` — all grammatically correct.

## Verified (dev server + browser)

| Check | Result |
|---|---|
| Key parity vs `en.json` (script, recursive) | 2422/2422 both files |
| `{placeholder}` parity | exact — the seven 3-form pl plurals are the only intentional divergence |
| SSR with `dentalpin_locale=pl` / `it` | "Hasło" / "Password" placeholders, `<html lang="pl">` / `"it"` |
| Polish plural paradigm (browser, `t()` with counts 0,1,2,5,13,22) | correct on every count incl. teen exception |
| Italian two-form plural | `1 voce / 3 voci` ✓ |
| `npm run typecheck:layers` / eslint on touched TS | clean |

Module layers keep degrading to **English** (never raw keys) under pl/it via the `fallbackLocale` shipped in #276, so both languages are usable today; the 11 module-layer files per language can follow one at a time as the issues suggest.

**A note for review**: machine-produced against the issue terminology tables, same caveat as #276 — a Polish- or Italian-speaking dentist skimming a few screens would be valuable, and corrections are welcome as follow-ups.