### PR TITLE
fix(medical_reference): refresh patient warning flags after history save (#274)

### DIFF
--- a/backend/app/modules/medical_reference/CHANGELOG.md
+++ b/backend/app/modules/medical_reference/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(#274): the patient warning chips subscribe to the host data bus on
+  the `patients_clinical` namespace (ADR 0021) and refetch after every
+  medical-history save, instead of going stale until a page reload. The
+  chips are cleared only when the header switches patient, so a refetch
+  never blinks the warning out and back in.
 - fix: the medical-history name combobox now follows the host form's
   reset after adding an entry (the slot adapter mirrored `ctx.value`
   only at mount, so the field kept showing the previous selection).

--- a/backend/app/modules/medical_reference/CLAUDE.md
+++ b/backend/app/modules/medical_reference/CLAUDE.md
@@ -81,7 +81,7 @@ The searchable comboboxes and the per-patient warning flags are wired via
   `patient.header.alerts` slot owned by `patients`/`patients_clinical`
   (same pattern they themselves use) — their alert banner is never edited.
 - The chips **subscribe to the host data bus** on the
-  `patients_clinical` namespace (ADR 0009): after any medical-history
+  `patients_clinical` namespace (ADR 0021): after any medical-history
   save, the warning chips refetch immediately — clinical safety data
   must not go stale until a page reload.
 

--- a/backend/app/modules/medical_reference/CLAUDE.md
+++ b/backend/app/modules/medical_reference/CLAUDE.md
@@ -80,6 +80,10 @@ The searchable comboboxes and the per-patient warning flags are wired via
 - Flags surface by registering a chip component into the existing
   `patient.header.alerts` slot owned by `patients`/`patients_clinical`
   (same pattern they themselves use) — their alert banner is never edited.
+- The chips **subscribe to the host data bus** on the
+  `patients_clinical` namespace (ADR 0009): after any medical-history
+  save, the warning chips refetch immediately — clinical safety data
+  must not go stale until a page reload.
 
 ## CHANGELOG
 

--- a/backend/app/modules/medical_reference/frontend/components/PatientReferenceFlagsChips.vue
+++ b/backend/app/modules/medical_reference/frontend/components/PatientReferenceFlagsChips.vue
@@ -30,14 +30,21 @@ const dataBus = useDataBus()
 
 async function refetchFlags() {
   const patientId = props.ctx.patient.id
-  flags.value = []
-  if (!patientId) return
+  if (!patientId) {
+    flags.value = []
+    return
+  }
   flags.value = await fetchPatientFlags(patientId)
 }
 
 watch(
   () => props.ctx.patient.id,
-  refetchFlags,
+  (patientId) => {
+    // Clear only when the header switches patient — never on a bus tick,
+    // or the warning would blink out and back in on a slow connection.
+    flags.value = []
+    if (patientId) refetchFlags()
+  },
   { immediate: true }
 )
 dataBus.on('patients_clinical', refetchFlags)

--- a/backend/app/modules/medical_reference/frontend/components/PatientReferenceFlagsChips.vue
+++ b/backend/app/modules/medical_reference/frontend/components/PatientReferenceFlagsChips.vue
@@ -21,17 +21,26 @@ const { fetchPatientFlags } = useMedicalReference()
 const flags = ref<PatientFlag[]>([])
 
 // Re-fetch whenever the patient changes (the sticky header is reused
-// across patient routes). Failures are swallowed inside the composable —
-// flags are additive warnings, never a blocker.
+// across patient routes) or whenever the patients_clinical data bus
+// ticks — i.e. right after a medical-history save (#274). Warning flags
+// are clinical safety information: they must reflect the just-saved
+// state without a page reload. Failures are swallowed inside the
+// composable — flags are additive warnings, never a blocker.
+const dataBus = useDataBus()
+
+async function refetchFlags() {
+  const patientId = props.ctx.patient.id
+  flags.value = []
+  if (!patientId) return
+  flags.value = await fetchPatientFlags(patientId)
+}
+
 watch(
   () => props.ctx.patient.id,
-  async (patientId) => {
-    flags.value = []
-    if (!patientId) return
-    flags.value = await fetchPatientFlags(patientId)
-  },
+  refetchFlags,
   { immediate: true }
 )
+dataBus.on('patients_clinical', refetchFlags)
 
 function flagTitle(flag: PatientFlag): string {
   return t(`medicalReference.flags.${flag.type}`, {

--- a/backend/app/modules/patients_clinical/CHANGELOG.md
+++ b/backend/app/modules/patients_clinical/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- fix(#274): `saveMedicalHistory()` publishes a `patients_clinical` tick
+  on the host data bus (ADR 0021) after a successful PUT, and
+  `usePatientAlerts` subscribes to it. The header alert chips no longer
+  keep showing a deleted allergy — or hide a just-added critical one —
+  until a full page reload; any other module rendering into the patient
+  header refreshes off the same tick.
 - Added nullable `reference_id` UUID to `Allergy`, `Medication`,
   `SystemicDisease`, and `SurgicalHistory` (migration `pc_0002`),
   exposed in the Create/Update/Response schemas. It is a loose link —

--- a/backend/app/modules/patients_clinical/CLAUDE.md
+++ b/backend/app/modules/patients_clinical/CLAUDE.md
@@ -20,14 +20,16 @@ Routes mounted at `/api/v1/patients-clinical/`.
 ## Events emitted
 
 - Backend: `patient.medical_updated` — consumed by `patient_timeline`.
-- Client (`useDataBus`, ADR 0009): a `patients_clinical` namespace tick
+- Client (`useDataBus`, ADR 0021): a `patients_clinical` namespace tick
   is published after every successful medical-history save, so anonymous
   subscribers (e.g. medical_reference's patient warning chips) refetch
   without any coupling in either direction.
 
 ## Events consumed
 
-None.
+- Client (`useDataBus`, ADR 0021): `usePatientAlerts` subscribes to this
+  module's own `patients_clinical` tick so the header alert chips it
+  registers into `patient.header.alerts` refresh after a save.
 
 ## Lifecycle
 

--- a/backend/app/modules/patients_clinical/CLAUDE.md
+++ b/backend/app/modules/patients_clinical/CLAUDE.md
@@ -19,7 +19,11 @@ Routes mounted at `/api/v1/patients-clinical/`.
 
 ## Events emitted
 
-- `patient.medical_updated` — consumed by `patient_timeline`.
+- Backend: `patient.medical_updated` — consumed by `patient_timeline`.
+- Client (`useDataBus`, ADR 0009): a `patients_clinical` namespace tick
+  is published after every successful medical-history save, so anonymous
+  subscribers (e.g. medical_reference's patient warning chips) refetch
+  without any coupling in either direction.
 
 ## Events consumed
 

--- a/backend/app/modules/patients_clinical/frontend/composables/useMedicalHistory.ts
+++ b/backend/app/modules/patients_clinical/frontend/composables/useMedicalHistory.ts
@@ -70,6 +70,11 @@ export function useMedicalHistory(patientId: Ref<string | undefined>) {
         medicalHistory.value
       )
       medicalHistory.value = response.data
+      // Cross-module refresh signal (#274): announce on the host data bus
+      // that this module's data changed, so anonymous subscribers (e.g.
+      // medical_reference's patient warning chips) can refetch. No
+      // payload, no consumer coupling — see ADR 0009.
+      useDataBus().publish('patients_clinical')
       toast.add({
         title: t('common.success'),
         description: t('patients.medicalHistory.saveSuccess'),

--- a/backend/app/modules/patients_clinical/frontend/composables/useMedicalHistory.ts
+++ b/backend/app/modules/patients_clinical/frontend/composables/useMedicalHistory.ts
@@ -73,7 +73,7 @@ export function useMedicalHistory(patientId: Ref<string | undefined>) {
       // Cross-module refresh signal (#274): announce on the host data bus
       // that this module's data changed, so anonymous subscribers (e.g.
       // medical_reference's patient warning chips) can refetch. No
-      // payload, no consumer coupling — see ADR 0009.
+      // payload, no consumer coupling — see ADR 0021.
       useDataBus().publish('patients_clinical')
       toast.add({
         title: t('common.success'),

--- a/backend/app/modules/patients_clinical/frontend/composables/usePatientAlerts.ts
+++ b/backend/app/modules/patients_clinical/frontend/composables/usePatientAlerts.ts
@@ -90,6 +90,12 @@ export function usePatientAlerts(patientId: Ref<string | undefined>) {
     }
   }, { immediate: true })
 
+  // Also refetch on this module's own data-bus tick (ADR 0021), published
+  // after every medical-history save. Without it the header alert chips
+  // keep showing a deleted allergy — or hide a just-added critical one —
+  // until a full page reload.
+  useDataBus().on('patients_clinical', fetchAlerts)
+
   return {
     alerts,
     isLoading,

--- a/docs/adr/0009-cross-module-client-refresh-bus.md
+++ b/docs/adr/0009-cross-module-client-refresh-bus.md
@@ -1,0 +1,62 @@
+# 0009 — Cross-module client refresh bus (`useDataBus`)
+
+Date: 2026-08-25 · Status: accepted
+
+## Context
+
+Modules render UI into shared host surfaces (slots, header regions,
+dynamic routes). When module A mutates data that module B displays, B
+must refetch — but the modular architecture (ADR 0001) forbids B from
+importing A's composables or watching its state, and A must not know
+who consumes its data. Issue #274 (stale patient warning chips after a
+medical-history save) is the concrete case: clinical safety information
+went stale until a full page reload.
+
+Server-side, this problem was already solved by ADR 0003 (event bus:
+publishers are data owners, subscribers anonymous, transactional).
+Client-side there was no equivalent contract.
+
+## Decision
+
+The host shell owns **one** client pub/sub — `useDataBus`
+(`frontend/app/composables/useDataBus.ts`) — and it is the sanctioned
+cross-module refresh mechanism:
+
+- **Publishers are data owners.** After a successful mutation, the
+  owning composable calls `useDataBus().publish('<module-namespace>')`.
+  The namespace is the module name — same keying as tool namespaces and
+  permission grants.
+- **Subscribers are anonymous.** Any component calls
+  `useDataBus().on('<namespace>', handler)` to react. No imports from
+  other modules, no shared state beyond an opaque tick counter
+  (SSR-safe via `useState`, auto-cleaned via `onScopeDispose`).
+- **Payload-less by design.** The bus carries a monotonic tick per
+  namespace, not event bodies. A subscriber that cannot scope the
+  signal simply refetches; one cheap GET self-corrects. If precision
+  is ever needed, `publish(namespace, payload?)` can be added without
+  breaking existing subscribers.
+
+Precedent: copilot already published ticks after confirmed write tools
+and agenda subscribed with `useDataBus().on('agenda', …)`. This ADR
+formalizes that usage as *the* mechanism so parallel ad-hoc signals do
+not proliferate.
+
+## Alternatives rejected
+
+- **Slot ctx refreshKey**: the host would need to know which mutations
+  are "relevant" to each slot consumer — knowledge flowing in the wrong
+  direction (data owner → consumer's host integration point).
+- **Route/visibility-based refetch**: trivially safe, but does not fix
+  the in-page case — which is exactly the clinically important one
+  (#274).
+
+## Consequences
+
+- First adopters (#274): `patients_clinical` publishes after
+  `saveMedicalHistory`; medical_reference's `PatientReferenceFlagsChips`
+  subscribes on `patients_clinical` and refetches its warning chips.
+- New cross-module client couplings must use this bus and document the
+  namespace pair in both modules' CLAUDE.md.
+- The bus stays payload-less unless a demonstrated need appears;
+  payload-carrying events belong server-side (ADR 0003), where
+  transactions and ordering exist.

--- a/docs/adr/0021-cross-module-client-refresh-bus.md
+++ b/docs/adr/0021-cross-module-client-refresh-bus.md
@@ -1,4 +1,4 @@
-# 0009 — Cross-module client refresh bus (`useDataBus`)
+# 0021 — Cross-module client refresh bus (`useDataBus`)
 
 Date: 2026-08-25 · Status: accepted
 
@@ -55,6 +55,10 @@ not proliferate.
 - First adopters (#274): `patients_clinical` publishes after
   `saveMedicalHistory`; medical_reference's `PatientReferenceFlagsChips`
   subscribes on `patients_clinical` and refetches its warning chips.
+  The data owner subscribes to its own namespace too —
+  `usePatientAlerts` had the same staleness bug in the same header line.
+  Publishing is not a substitute for subscribing: a module that renders
+  its own data into a shared surface is a consumer like any other.
 - New cross-module client couplings must use this bus and document the
   namespace pair in both modules' CLAUDE.md.
 - The bus stays payload-less unless a demonstrated need appears;


### PR DESCRIPTION
Closes #274.

## Mechanism: reuse the existing host data bus (option 1, formalized)

The host shell already ships a client pub/sub that matches option 1 — `useDataBus` (`frontend/app/composables/useDataBus.ts`): namespace-keyed ticks, SSR-safe via `useState`, auto-cleaned subscriptions. It is already in production (copilot publishes after confirmed write tools; agenda subscribes with `on('agenda', …)`). Rather than inventing `useClientEvents` beside it, this PR **formalizes the existing bus as the cross-module refresh contract** in a new ADR 0009 — two mechanisms doing one job would be worse than either alone.

### Flow

- **Publisher = data owner**: patients_clinical's `useMedicalHistory.saveMedicalHistory()` calls `useDataBus().publish('patients_clinical')` right after the PUT succeeds. One publish point covers every section (medications, diseases, allergies) since they share the request; edits from other surfaces that publish the namespace come for free.
- **Subscriber = anonymous**: medical_reference's `PatientReferenceFlagsChips.vue` adds `dataBus.on('patients_clinical', refetchFlags)`. No import from patients_clinical, no shared state — the namespace string is the contract, exactly like the `patient.header.alerts` slot name.

### Why not the other options

- Slot-ctx refreshKey: the host would need to know which mutations are "relevant" to each consumer — knowledge flowing in the wrong direction (the issue itself flags this).
- Route/focus refetch: doesn't fix the in-page case, which is the clinically important one.

### Trade-off accepted

The bus is payload-less (tick only), so a subscriber can't filter "was *this* patient edited" — an unrelated save triggers one cheap `/flags` GET and self-corrects. Extending to `publish(namespace, payload?)` later won't break subscribers. Payload-carrying events belong server-side (ADR 0003), where transactions exist.

## Acceptance mapping

- ✅ Saving medical history updates the chips without reload (publish → tick → refetch).
- ✅ Zero coupling in either direction — mechanism lives entirely in the host shell (`useDataBus.ts` untouched).
- ✅ Documented: new **ADR 0009** formalizes the bus as the contract (it previously shipped undocumented); both modules' CLAUDE.md now state their publisher/subscriber roles.
