### PR TITLE
fix(core/modules): batch uninstall of a dependency pair strands the dependent (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ frontend as a Nuxt layer under its own Python package.
 
 ## [Unreleased]
 
+### Fixed
+
+- Batch uninstall of a dependency pair no longer strands the dependent
+  in `to_remove` (#286): the pending processor now runs removals in
+  reverse topological order (dependents first), after installs and
+  upgrades, so the dependent's backup runs while its tables still
+  exist. `pg_dump`'s "no matching tables were found" is additionally
+  treated as a skipped (empty) backup rather than a failure, so a
+  crash between downgrade and backup can't wedge the record either.
+
 ## [2.4.0] - 2026-08-24
 
 ### Added

--- a/backend/app/core/plugins/processor.py
+++ b/backend/app/core/plugins/processor.py
@@ -128,18 +128,34 @@ class PendingProcessor:
             return list(result.scalars())
 
     def _order_pending(self, records: list[ModuleRecord]) -> list[ModuleRecord]:
-        """Topological order so dependencies install first, removes last."""
-        by_name = {r.name: r for r in records}
-        # Filter unknown deps: a pending record may depend on already-
-        # installed modules outside this batch — those don't need
-        # ordering here.
-        return topological_sort(
-            records,
-            key=lambda r: r.name,
-            deps_of=lambda r: (
-                d for d in ((r.manifest_snapshot or {}).get("depends", []) or []) if d in by_name
-            ),
-        )
+        """Order the batch: installs dependencies-first, removals dependents-first.
+
+        Removals must run in *reverse* topological order (#286): tearing
+        the dependency down first drags the dependent's Alembic branch
+        down with it (``depends_on``), so by the time the dependent is
+        processed its tables are gone and the ``pg_dump`` backup step
+        fails — stranding the record in ``to_remove``. Installs/upgrades
+        keep the dependencies-first order and run before removals.
+        """
+
+        def topo(recs: list[ModuleRecord]) -> list[ModuleRecord]:
+            by_name = {r.name: r for r in recs}
+            # Filter unknown deps: a pending record may depend on already-
+            # installed modules outside this group — those don't need
+            # ordering here.
+            return topological_sort(
+                recs,
+                key=lambda r: r.name,
+                deps_of=lambda r: (
+                    d
+                    for d in ((r.manifest_snapshot or {}).get("depends", []) or [])
+                    if d in by_name
+                ),
+            )
+
+        removals = [r for r in records if r.state == ModuleState.TO_REMOVE.value]
+        others = [r for r in records if r.state != ModuleState.TO_REMOVE.value]
+        return topo(others) + list(reversed(topo(removals)))
 
     # --- Dispatch -------------------------------------------------------
 
@@ -337,7 +353,25 @@ class PendingProcessor:
             with target.open("w") as fh:
                 # 5 min cap so a locked / oversized table can't hang
                 # lifespan startup or an admin-triggered uninstall.
-                subprocess.run(args, stdout=fh, check=True, timeout=300)
+                subprocess.run(args, stdout=fh, stderr=subprocess.PIPE, check=True, timeout=300)
+        except subprocess.CalledProcessError as exc:
+            target.unlink(missing_ok=True)
+            stderr = (exc.stderr or b"").decode(errors="replace")
+            if "no matching tables were found" in stderr:
+                # The tables never materialized or are already gone (e.g. a
+                # crash between downgrade and backup). With removals ordered
+                # dependents-first (#286) this is a genuinely-empty backup,
+                # not silent data loss — skip it instead of stranding the
+                # record in to_remove.
+                logger.warning(
+                    "No tables to back up for module %s (%s); skipping backup",
+                    module_name,
+                    ", ".join(tables),
+                )
+                return None
+            raise RuntimeError(
+                f"pg_dump failed backing up module {module_name}: {stderr.strip()}"
+            ) from exc
         except FileNotFoundError as exc:
             target.unlink(missing_ok=True)
             raise RuntimeError(

--- a/backend/tests/test_processor_pending_order.py
+++ b/backend/tests/test_processor_pending_order.py
@@ -1,0 +1,114 @@
+"""Batch ordering and backup tolerance in the pending processor (#286).
+
+Removing a dependency pair in one "Apply changes" batch used to process
+the dependency first: its Alembic downgrade dragged the dependent's
+branch down (``depends_on``), so the dependent's tables were gone by the
+time its own ``pg_dump`` backup ran — exit 1, record stranded in
+``to_remove``. Removals must run dependents-first; installs keep the
+dependencies-first order.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from app.core.plugins.db_models import ModuleRecord
+from app.core.plugins.processor import PendingProcessor
+from app.core.plugins.state import ModuleState
+
+
+def _record(name: str, state: ModuleState, depends: list[str] | None = None) -> ModuleRecord:
+    return ModuleRecord(
+        name=name,
+        version="0.1.0",
+        state=state.value,
+        category="official",
+        removable=True,
+        auto_install=False,
+        manifest_snapshot={"name": name, "depends": depends or []},
+    )
+
+
+@pytest.fixture
+def processor() -> PendingProcessor:
+    # _order_pending and _dump_tables never touch the session factory.
+    return PendingProcessor(session_factory=None)  # type: ignore[arg-type]
+
+
+def test_removals_run_dependents_first(processor: PendingProcessor) -> None:
+    """The #286 repro: inventory + treatment_consumables in one batch."""
+    inventory = _record("inventory", ModuleState.TO_REMOVE)
+    consumables = _record("treatment_consumables", ModuleState.TO_REMOVE, ["catalog", "inventory"])
+
+    ordered = processor._order_pending([inventory, consumables])
+    assert [r.name for r in ordered] == ["treatment_consumables", "inventory"]
+
+    # Input order must not matter.
+    ordered = processor._order_pending([consumables, inventory])
+    assert [r.name for r in ordered] == ["treatment_consumables", "inventory"]
+
+
+def test_installs_keep_dependencies_first_and_run_before_removals(
+    processor: PendingProcessor,
+) -> None:
+    foo = _record("foo", ModuleState.TO_INSTALL)
+    bar = _record("bar", ModuleState.TO_INSTALL, ["foo"])
+    inventory = _record("inventory", ModuleState.TO_REMOVE)
+    consumables = _record("treatment_consumables", ModuleState.TO_REMOVE, ["inventory"])
+
+    ordered = processor._order_pending([consumables, bar, inventory, foo])
+    assert [r.name for r in ordered] == [
+        "foo",
+        "bar",
+        "treatment_consumables",
+        "inventory",
+    ]
+
+
+def test_removal_chain_of_three_reverses_fully(processor: PendingProcessor) -> None:
+    a = _record("a", ModuleState.TO_REMOVE)
+    b = _record("b", ModuleState.TO_REMOVE, ["a"])
+    c = _record("c", ModuleState.TO_REMOVE, ["b"])
+
+    ordered = processor._order_pending([a, c, b])
+    assert [r.name for r in ordered] == ["c", "b", "a"]
+
+
+@pytest.mark.asyncio
+async def test_dump_tables_skips_when_tables_are_gone(
+    processor: PendingProcessor, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """pg_dump's 'no matching tables' is a skipped backup, not a failure."""
+    from app.core.plugins import processor as processor_module
+
+    monkeypatch.setattr(processor_module, "BACKUP_ROOT", tmp_path)
+
+    def fake_run(args, **kwargs):  # noqa: ANN001, ANN003
+        raise subprocess.CalledProcessError(
+            1, args, stderr=b"pg_dump: error: no matching tables were found\n"
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = await processor._dump_tables("ghost", ["ghost_table"])
+    assert result is None
+    assert list(tmp_path.iterdir()) == []  # no empty backup file left behind
+
+
+@pytest.mark.asyncio
+async def test_dump_tables_still_raises_on_other_pg_dump_errors(
+    processor: PendingProcessor, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    from app.core.plugins import processor as processor_module
+
+    monkeypatch.setattr(processor_module, "BACKUP_ROOT", tmp_path)
+
+    def fake_run(args, **kwargs):  # noqa: ANN001, ANN003
+        raise subprocess.CalledProcessError(
+            1, args, stderr=b"pg_dump: error: connection to server failed\n"
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="connection to server failed"):
+        await processor._dump_tables("mod", ["mod_table"])

--- a/backend/tests/test_uninstall_roundtrip.py
+++ b/backend/tests/test_uninstall_roundtrip.py
@@ -220,7 +220,7 @@ def test_dump_tables_hard_fails_on_empty_output(
 
     monkeypatch.setattr(processor_module, "BACKUP_ROOT", tmp_path / "backups")
 
-    def _fake_run(args, *, stdout, check, timeout=None):  # noqa: ARG001
+    def _fake_run(args, *, stdout, check, timeout=None, stderr=None):  # noqa: ARG001
         # stdout is the open file handle; write nothing → zero bytes.
         return subprocess.CompletedProcess(args, 0)
 


### PR DESCRIPTION
Fixes #286 — both parts of the suggested fix.

## Ordering (the root cause)

`_order_pending`'s docstring promised *"removes last"* but nothing implemented it. The batch is now ordered in two phases:

- **installs/upgrades**: dependencies-first topological order, unchanged, run first;
- **removals**: **reverse** topological order (dependents first) — `treatment_consumables` before `inventory` — so the dependent's `pg_dump` backup runs while its tables still exist, and by the time the dependency's `alembic downgrade` runs, the dependent's branch is already at base.

Cross-phase deps don't order against each other (each phase filters to its own group), matching the service-layer guarantees the issue notes (`uninstall` refuses to remove a dependency alone unless forced).

## Backup tolerance (the hardening the issue asks to pair with it)

`_dump_tables` now captures stderr and treats pg_dump's `no matching tables were found` as a **skipped (empty) backup** — warning logged, no stranded record, no empty file left behind. Exactly as the issue argues, this lands *together with* the ordering fix so it can't hide data loss: post-fix it only fires when there is genuinely nothing to back up (e.g. a crash between downgrade and backup). Any other pg_dump failure now surfaces stderr in the error instead of a bare `exit status 1`.

## Tests (no DB needed — **5/5 ran locally**)

- the exact #286 repro pair (`inventory` + `treatment_consumables`) orders dependent-first, regardless of input order
- a mixed batch: installs deps-first (`foo → bar`), then removals reversed (`treatment_consumables → inventory`)
- a three-deep removal chain fully reverses
- missing-tables pg_dump → `None`, no empty backup file left in `BACKUP_ROOT`
- other pg_dump errors still raise, with stderr attached

## On the #280 note (`inventory` round-trip expectation)

Unchanged here deliberately: downgrading `inventory` **alone** still drags `tc_0001` down — that's inherent to Alembic `depends_on`, and the single-module path is guarded by the service-layer reverse-dependency check. What this fix guarantees is that the **batch** path never relies on that behaviour; the amended test in #280 remains an accurate description of the single-module case. Happy to revisit if you'd rather restore the branch-scoped wording differently.

`ruff check`/`format` clean; root `CHANGELOG.md` entry under Unreleased. Full suite via CI (no local Postgres).