### PR TITLE
fix(infra): resolve the module_layers symlink inside the frontend container (#261)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,13 @@ services:
       # The backend writes absolute paths under this mount into
       # `frontend/modules.json`.
       - ./backend/app/modules:/module_layers:ro
+      # Same source, mounted where the tracked `frontend/module_layers`
+      # symlink (-> ../backend/app/modules) resolves inside the
+      # container (/app/module_layers -> /backend/app/modules). Without
+      # it the symlink dangles and anything resolving through it
+      # in-container — ESLint's `eslint . module_layers`, editors —
+      # fails (#261). Read-only like the mount above.
+      - ./backend/app/modules:/backend/app/modules:ro
       - /app/node_modules
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]


### PR DESCRIPTION
Fixes #261 with the first of the issue's two options — the mount strategy, but **owned and documented** rather than papered over.

## The fix

`frontend/module_layers` is a tracked symlink to `../backend/app/modules`. In-container, `/app` is the bind-mounted `./frontend`, so the link resolves to `/backend/app/modules` — which didn't exist. One additional read-only mount makes the symlink's *target* exist:

```yaml
- ./backend/app/modules:/backend/app/modules:ro
```

Compared to the reverted #210 hunk (`./backend/app/modules:/app/module_layers:ro`), this doesn't mount **over** a symlink that lives inside another bind mount — the link stays a link and behaves identically on the host and in the container, so ESLint's `eslint . module_layers`, editors attached to the container, and anything else resolving through it just work. Same source and `:ro` as the existing `/module_layers` mount, so no new writable surface.

Not taken: the `#module-layers`-alias tooling option — it would fix vitest only and leave every other resolver (ESLint's positional arg, editors) broken.

## Verification caveat

I don't have Docker in this environment, so I can't boot the container to demonstrate it — the change is declarative and the symlink arithmetic is shown above (`/app/module_layers` → `../backend/app/modules` → `/backend/app/modules` = the new mountpoint). A quick `docker compose up -d frontend && docker compose exec frontend ls module_layers/` on your side would confirm it end-to-end.