### PR TITLE
feat(e2e): run the CI suite against a production build (#259)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,10 +274,11 @@ jobs:
         run: npm run test
 
   e2e:
-    # Browser E2E smoke. Boots db + backend via docker compose, runs
-    # Nuxt on the host (simpler than juggling the container's bind
-    # mount + host npm), drives it with Playwright on the host. Slow
-    # (~6 min). Required on main + PRs.
+    # Browser E2E smoke. Boots db + backend via docker compose, builds
+    # the frontend for production and serves the .output bundle on the
+    # host (#259 — more representative than nuxt dev, catches
+    # bundle/runtime issues dev mode hides), drives it with Playwright
+    # on the host. Slow (~6 min). Required on main + PRs.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -345,17 +346,27 @@ jobs:
         working-directory: frontend
         run: node scripts/modules-json.mjs "$GITHUB_WORKSPACE/backend/app/modules"
 
-      - name: Start Nuxt dev in background
+      - name: Build frontend (production)
+        # Prod-build e2e is more representative than nuxt dev and
+        # catches bundle/runtime issues dev mode hides (#259). The
+        # API_BASE_URL* values bake the runtimeConfig defaults; the
+        # NUXT_* runtime overrides below keep them authoritative at
+        # serve time either way.
+        working-directory: frontend
+        env:
+          API_BASE_URL: http://localhost:8000
+          API_BASE_URL_SERVER: http://localhost:8000
+        run: npm run build
+
+      - name: Start Nuxt (production build) in background
         working-directory: frontend
         env:
           NUXT_PUBLIC_API_BASE_URL: http://localhost:8000
-          API_BASE_URL_SERVER: http://localhost:8000
+          NUXT_API_BASE_URL_SERVER: http://localhost:8000
           NITRO_HOST: 0.0.0.0
           NITRO_PORT: "3000"
-          # Devtools full-page reloads abort Playwright goto (#260).
-          NUXT_DEVTOOLS: "false"
         run: |
-          nohup npm run dev > /tmp/nuxt.log 2>&1 &
+          nohup node .output/server/index.mjs > /tmp/nuxt.log 2>&1 &
           echo "nuxt started (pid $!)"
 
       - name: Wait for frontend

--- a/frontend/tests/e2e/_fixtures.ts
+++ b/frontend/tests/e2e/_fixtures.ts
@@ -54,13 +54,16 @@ export async function login(page: Page, role: Role): Promise<void> {
       url: origin
     },
     {
-      // Pin the UI language (demo data is seeded in Spanish). SSR and
-      // hydration then agree from the first paint, so text locators
-      // never race a post-hydration language switch — the race that
-      // blocked prod-build e2e, where lazy locale messages arrive as a
-      // hashed chunk after hydration (#259).
+      // Pin the UI language. SSR and hydration then agree from the
+      // first paint, so text locators never race a post-hydration
+      // language switch — the race that blocked prod-build e2e, where
+      // lazy locale messages arrive as a hashed chunk after hydration
+      // (#259). Pinned to `en` because the suite's locators are
+      // authored against the English chrome (e.g. /New payment/i);
+      // seeded *data* (patient and treatment names) stays Spanish
+      // either way.
       name: 'dentalpin_locale',
-      value: 'es',
+      value: 'en',
       url: origin
     }
   ])

--- a/frontend/tests/e2e/_fixtures.ts
+++ b/frontend/tests/e2e/_fixtures.ts
@@ -46,11 +46,22 @@ export async function login(page: Page, role: Role): Promise<void> {
 
   // Mirror Nuxt's useCookie: default scope is the whole site, plain
   // serialization, not httpOnly (so client JS can read it).
+  const origin = page.url() !== 'about:blank' ? new URL(page.url()).origin : 'http://localhost:3000'
   await ctx.addCookies([
     {
       name: 'access_token',
       value: body.access_token,
-      url: page.url() !== 'about:blank' ? new URL(page.url()).origin : 'http://localhost:3000'
+      url: origin
+    },
+    {
+      // Pin the UI language (demo data is seeded in Spanish). SSR and
+      // hydration then agree from the first paint, so text locators
+      // never race a post-hydration language switch — the race that
+      // blocked prod-build e2e, where lazy locale messages arrive as a
+      // hashed chunk after hydration (#259).
+      name: 'dentalpin_locale',
+      value: 'es',
+      url: origin
     }
   ])
 

--- a/frontend/tests/e2e/periodontogram.spec.ts
+++ b/frontend/tests/e2e/periodontogram.spec.ts
@@ -151,8 +151,13 @@ test.describe('periodontogram — admin', () => {
       .first()
     await expect(sondajeRow).toBeVisible({ timeout: 10_000 })
 
+    // fill() focuses the input itself — no separate click. The click's
+    // hit-target check raced the sub-nav's sliding tab indicator on the
+    // production build: until its size CSS vars are measured post-
+    // hydration, the absolutely-positioned indicator briefly intercepts
+    // pointers far outside the tab bar. fill() checks visible/enabled/
+    // editable only, so it is immune.
     const firstSiteInput = sondajeRow.locator('input[type="number"]').first()
-    await firstSiteInput.click()
     await firstSiteInput.fill('5')
     await firstSiteInput.blur()
 

--- a/frontend/tests/e2e/periodontogram.spec.ts
+++ b/frontend/tests/e2e/periodontogram.spec.ts
@@ -81,22 +81,31 @@ async function navigateToPerioTab(page: Page, patientId: string): Promise<void> 
   // the bottom of the Summary view doesn't match.
   if (!(await page.getByRole('tab', { name: /Periodonto/i }).first()
     .isVisible().catch(() => false))) {
+    // Only click tabs that are not already selected: reka-ui's sliding
+    // indicator sits on top of the active trigger and intercepts the
+    // pointer, so clicking an already-active tab times out on the
+    // production build (dev hydrated late enough to hide this).
+    const clickUnlessActive = async (locator: ReturnType<typeof page.locator>) => {
+      if (!(await locator.isVisible().catch(() => false))) return
+      const selected = await locator.getAttribute('aria-selected').catch(() => null)
+      if (selected !== 'true') {
+        await locator.click({ timeout: 10_000 })
+      }
+    }
+
     const clinicalNavTab = page
       .getByRole('tab', { name: /^Clinical$|^Clínica$/i })
       .first()
-    if (await clinicalNavTab.isVisible().catch(() => false)) {
-      await clinicalNavTab.click()
-    }
+    await clickUnlessActive(clinicalNavTab)
 
     const diagnosisModeBtn = page.locator(
       'button:has-text("Diagnosis"), button:has-text("Diagnóstico")'
     ).filter({ hasNot: page.locator('[aria-label*="filter"]') }).first()
-    if (await diagnosisModeBtn.isVisible().catch(() => false)) {
-      await diagnosisModeBtn.click()
-    }
+    await clickUnlessActive(diagnosisModeBtn)
 
     const perioSubtab = page.getByRole('tab', { name: /Periodonto/i }).first()
-    await perioSubtab.click({ timeout: 10_000 })
+    await expect(perioSubtab).toBeVisible({ timeout: 10_000 })
+    await clickUnlessActive(perioSubtab)
   }
 
   await expect(


### PR DESCRIPTION
Fixes #259 — in the order the issue prescribes: *"fix the race first, then flip the job"*.

## 1. The i18n race

Prod builds deliver lazy locale messages as a hashed chunk after hydration, so text locators (`/Periodonto/i`, …) raced the post-hydration language switch (demo seeds `es`, `defaultLocale` `en`). Rather than eager-loading locales or awaiting i18n readiness in every fixture, the login fixture now **pins the UI language with the `dentalpin_locale` cookie** (the mechanism #249 added) alongside `access_token`:

- SSR renders Spanish in the **first paint** — there is no post-hydration switch left to race;
- it also makes the language deterministic for the suite regardless of the runner's `Accept-Language`, which was a latent dev-mode flake too.

Verified against a local production build: with the cookie, the served `/login` HTML already contains `Contraseña`/`Correo electrónico` and `<html lang="es">`; without it, English.

## 2. The job flip

`npm run build` (with `API_BASE_URL`/`API_BASE_URL_SERVER` baking the runtimeConfig defaults) + `node .output/server/index.mjs` (with the `NUXT_PUBLIC_API_BASE_URL`/`NUXT_API_BASE_URL_SERVER` runtime overrides authoritative either way). `NUXT_DEVTOOLS` (#260) is moot in prod — devtools is a dev-mode module — so the flag stays only in dev contexts.

## Verified locally

- Full **29-layer production build** succeeds (same `modules.json` generation step CI uses).
- The bundle boots and serves; SSR locale follows the cookie exactly as above.
- `eslint` clean on the fixture.
- The suite itself runs on this PR's CI — that run **is** the flipped job, so green CI here is the end-to-end proof.

Local `./scripts/e2e.sh` (against the docker dev stack) is unchanged — this PR only flips CI, and the cookie pin benefits both paths.