### PR TITLE
docs(adr): the directory listing is the index; CI enforces the numbering contract (#299, #300)

### DIFF
--- a/docs/adr/0012-multi-tenancy-brief.md
+++ b/docs/adr/0012-multi-tenancy-brief.md
@@ -1,4 +1,4 @@
-# Multi-tenancy en Dentalpin core — brief de implementación
+# 0012 — Multi-tenancy en Dentalpin core (brief de implementación)
 
 > **Audiencia**: agentes Claude Code que vayan a implementar estos cambios.
 > **Estado**: propuesta de arquitectura, pendiente de ejecución por fases.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,6 +11,7 @@ Why we record decisions here:
 ## Convention
 
 - Filename: `NNNN-kebab-title.md` — zero-padded sequence, never reused.
+- First line: `# NNNN — Title`, with the number matching the filename.
 - One decision per file. Short. ≤1 page when possible.
 - Every ADR uses the same structure: see `TEMPLATE.md`.
 - Status: `proposed` → `accepted` → optionally `superseded by NNNN` /
@@ -43,11 +44,16 @@ Triggers (any one):
 
 ## Index
 
-| #    | Title | Status | Date |
-|------|-------|--------|------|
-| 0001 | [Modular plugin architecture](0001-modular-plugin-architecture.md) | accepted | 2026-04-27 |
-| 0002 | [Per-module Alembic branches](0002-per-module-alembic-branches.md) | accepted | 2026-04-27 |
-| 0003 | [Event bus over direct cross-module imports](0003-event-bus-over-direct-imports.md) | accepted | 2026-04-27 |
-| 0004 | [BSL 1.1 license, Apache 2.0 after 4 years](0004-bsl-license.md) | accepted | 2026-04-27 |
-| 0005 | [Relative permissions, registry-prefixed namespacing](0005-relative-permissions.md) | accepted | 2026-04-27 |
-| 0006 | [Budget public link two-factor authentication](0006-budget-public-link-2-factor-auth.md) | accepted | 2026-04-28 |
+There is deliberately no index table here. The one this section used
+to hold rotted silently — it stopped at 0006 while the directory held
+21 files (issue #300) — and an index that reads as complete while
+covering a fraction of the decisions invites re-litigating what was
+already locked in.
+
+**The directory listing is the index.** Filenames carry number and
+title (`ls docs/adr/` reads as a table of contents), the first line of
+each file repeats them, and `status`/date live inside the file. CI's
+`docs-layout` job enforces the invariants that keep the listing
+trustworthy: strict `NNNN-kebab-title.md` names, no duplicate and no
+skipped numbers, and a first-line heading that matches the filename
+(issue #299, `scripts/check_docs_layout.py::check_adrs`).

--- a/scripts/check_docs_layout.py
+++ b/scripts/check_docs_layout.py
@@ -7,6 +7,11 @@ CI fails if any of the following is violated:
 2. A folder exists directly under `docs/` that is NOT in the folder allowlist.
 3. An image asset (`.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`, `.webp`) lives
    anywhere under `docs/` outside `docs/screenshots/` or `docs/diagrams/`.
+4. `docs/adr/` breaks its numbering contract (issue #299): a file that
+   doesn't match ``NNNN-kebab-title.md``, two ADRs sharing a number
+   (PR #291 shipped a second 0009 and every check stayed green), a gap
+   in the sequence (ADRs are never deleted, only superseded), or a
+   first-line heading whose number disagrees with the filename.
 
 The taxonomy + routing rule is documented in:
 - root `CLAUDE.md` ("Documentation policy")
@@ -23,6 +28,7 @@ Mirrors the read-only posture of ``backend/scripts/generate_catalogs.py``.
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -60,6 +66,72 @@ IMAGE_EXTS: frozenset[str] = frozenset(
     {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
 )
 IMAGE_FOLDERS: frozenset[str] = frozenset({"screenshots", "diagrams"})
+
+ADR_NON_NUMBERED: frozenset[str] = frozenset({"README.md", "TEMPLATE.md"})
+ADR_FILENAME = re.compile(r"^(\d{4})-[a-z0-9-]+\.md$")
+# First line of every ADR: "# NNNN — Title" (em dash, per TEMPLATE.md).
+ADR_HEADING = re.compile(r"^# (\d{4}) — \S")
+
+
+def check_adrs(adr_dir: Path) -> list[str]:
+    """The `docs/adr/` numbering contract (issue #299).
+
+    The README states it ("zero-padded sequence, never reused; never
+    delete an ADR, supersede it") and PR #291 proved nothing enforced
+    it: a second 0009 merged cleanly because the *filenames* differed.
+    Since #300 removed the hand-maintained index, the directory listing
+    IS the index — these invariants are what keep it trustworthy.
+    """
+    violations: list[str] = []
+    if not adr_dir.is_dir():
+        return [f"{adr_dir} is not a directory — nothing to check."]
+
+    by_number: dict[int, list[str]] = {}
+    for entry in sorted(adr_dir.iterdir()):
+        if entry.name.startswith(".") or entry.name in ADR_NON_NUMBERED:
+            continue
+        match = ADR_FILENAME.match(entry.name)
+        if entry.is_dir() or not match:
+            violations.append(
+                f"docs/adr/{entry.name}: does not match NNNN-kebab-title.md "
+                "(zero-padded number, lowercase kebab-case, .md)."
+            )
+            continue
+        number = int(match.group(1))
+        by_number.setdefault(number, []).append(entry.name)
+
+        heading = entry.read_text(encoding="utf-8").split("\n", 1)[0]
+        heading_match = ADR_HEADING.match(heading)
+        if not heading_match:
+            violations.append(
+                f"docs/adr/{entry.name}: first line must be "
+                f"'# {match.group(1)} — <title>', found {heading!r}."
+            )
+        elif heading_match.group(1) != match.group(1):
+            violations.append(
+                f"docs/adr/{entry.name}: heading number "
+                f"{heading_match.group(1)} disagrees with the filename. "
+                "One of them is wrong — check which number is actually free."
+            )
+
+    for number, names in sorted(by_number.items()):
+        if len(names) > 1:
+            violations.append(
+                f"docs/adr/: number {number:04d} is used by {len(names)} "
+                f"files ({', '.join(names)}). ADR numbers are never reused — "
+                "renumber the newest to the next free number."
+            )
+
+    if by_number:
+        expected = set(range(1, max(by_number) + 1))
+        for missing in sorted(expected - set(by_number)):
+            violations.append(
+                f"docs/adr/: number {missing:04d} is missing from the "
+                "sequence. ADRs are never deleted — supersede instead "
+                "(see docs/adr/README.md)."
+            )
+
+    return violations
 
 
 def check() -> list[str]:
@@ -101,6 +173,8 @@ def check() -> list[str]:
                 f"docs/{rel.as_posix()}: image outside docs/screenshots/ "
                 "or docs/diagrams/."
             )
+
+    violations.extend(check_adrs(DOCS / "adr"))
 
     return violations
 


### PR DESCRIPTION
Fixes #300, fixes #299 — in that order, as #300 asked.

## #300 — the index

Went with the issue's leaning (**option 2, delete it**): the table rotted once (stale at 0006 with 21 files on disk) and any hand-maintained copy will again. The Index section now states the invariant instead: **the directory listing is the index** — filenames carry number+title, the first line of each file repeats them, status/date live inside. Nothing to regenerate, nothing to go stale.

## #299 — the enforcement

`scripts/check_docs_layout.py` (already wired into the 7-second `docs-layout` job) gains `check_adrs()`:

- every file matches `NNNN-kebab-title.md` (`README.md`/`TEMPLATE.md` exempt),
- **no two ADRs share a number** — the exact PR #291 failure mode: a second 0009 merged cleanly because the filenames differed,
- no gaps from 0001 (ADRs are never deleted, only superseded — the message points at the README),
- the first-line `# NNNN — Title` heading matches the filename's number (#291 got the heading wrong too).

The fifth check the issue floated ("listed in the README index") is moot with the table gone.

**Exercised all four failure modes by hand:**

```
docs/adr/: number 0009 is used by 2 files (0009-anything.md, 0009-documentation-portal.md). ADR numbers are never reused — …
docs/adr/: number 0005 is missing from the sequence. ADRs are never deleted — supersede instead …
docs/adr/0022-heading-mismatch.md: heading number 0099 disagrees with the filename. …
docs/adr/0022-bad-heading.md: first line must be '# 0022 — <title>', found 'Bad Heading'.
```

## One content fix

`0012-multi-tenancy-brief.md` was the only ADR whose first line lacked the number prefix (`# Multi-tenancy en Dentalpin core — …`) — it now reads `# 0012 — …`, and the heading convention is stated explicitly in the README's Convention list. Current tree passes; ruff clean.