### PR TITLE
fix(core): detect already-dropped tables from the catalog, not pg_dump's stderr (#298)

### DIFF
--- a/backend/app/core/plugins/processor.py
+++ b/backend/app/core/plugins/processor.py
@@ -341,12 +341,28 @@ class PendingProcessor:
     async def _dump_tables(self, module_name: str, tables: list[str]) -> Path | None:
         if not tables:
             return None
+
+        # Ask Postgres which of the module's tables still exist (#298).
+        # This replaces the brittle stderr-string check: a table may be
+        # gone because a crash or earlier downgrade already removed it;
+        # dumping only survivors avoids pg_dump exit-1 and preserves a
+        # partial backup instead of skipping it entirely.
+        present = await self._existing_tables(tables)
+        remaining = [t for t in tables if t in present]
+        if not remaining:
+            logger.warning(
+                "No tables to back up for module %s (%s); skipping backup",
+                module_name,
+                ", ".join(tables),
+            )
+            return None
+
         BACKUP_ROOT.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
         target = BACKUP_ROOT / f"module_{module_name}_{timestamp}.sql"
 
         args = ["pg_dump", "--data-only", "--no-owner", _pg_dump_dsn(settings.DATABASE_URL)]
-        for table in tables:
+        for table in remaining:
             args.extend(["--table", table])
 
         try:
@@ -357,18 +373,6 @@ class PendingProcessor:
         except subprocess.CalledProcessError as exc:
             target.unlink(missing_ok=True)
             stderr = (exc.stderr or b"").decode(errors="replace")
-            if "no matching tables were found" in stderr:
-                # The tables never materialized or are already gone (e.g. a
-                # crash between downgrade and backup). With removals ordered
-                # dependents-first (#286) this is a genuinely-empty backup,
-                # not silent data loss — skip it instead of stranding the
-                # record in to_remove.
-                logger.warning(
-                    "No tables to back up for module %s (%s); skipping backup",
-                    module_name,
-                    ", ".join(tables),
-                )
-                return None
             raise RuntimeError(
                 f"pg_dump failed backing up module {module_name}: {stderr.strip()}"
             ) from exc
@@ -389,6 +393,25 @@ class PendingProcessor:
             target.unlink(missing_ok=True)
             raise RuntimeError(f"pg_dump produced an empty backup for module {module_name}")
         return target
+
+    async def _existing_tables(self, tables: list[str]) -> set[str]:
+        """Return the subset of *tables* that exist in the database.
+
+        Uses the asyncpg inspector — the driver the app already ships —
+        instead of parsing pg_dump stderr (#298).  The query hits
+        ``information_schema.tables`` scoped to the public schema.
+        """
+        from sqlalchemy import text as sa_text
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                sa_text(
+                    "SELECT table_name FROM information_schema.tables "
+                    "WHERE table_schema = 'public' AND table_name = ANY(:names)"
+                ),
+                {"names": list(tables)},
+            )
+            return {row[0] for row in result.all()}
 
     # --- Error book-keeping --------------------------------------------
 

--- a/backend/tests/test_module_uninstall_data_roundtrip.py
+++ b/backend/tests/test_module_uninstall_data_roundtrip.py
@@ -86,13 +86,23 @@ def test_backup_contains_seeded_rows(tmp_path: Path) -> None:
         original_root = processor_module.BACKUP_ROOT
         processor_module.BACKUP_ROOT = backup_root
         try:
-            proc = processor_module.PendingProcessor(session_factory=lambda: None)  # type: ignore[arg-type]
-            backup_path = asyncio.run(
-                proc._dump_tables(
-                    "schedules",
-                    ["clinic_weekly_schedules"],
-                )
-            )
+            # Real session factory: _dump_tables now asks the catalog which
+            # tables still exist (#298), so this test also covers that
+            # lookup against a live Postgres.
+            async def _dump() -> Path | None:
+                from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+                from sqlalchemy.pool import NullPool
+
+                engine = create_async_engine(settings.DATABASE_URL, poolclass=NullPool)
+                try:
+                    proc = processor_module.PendingProcessor(
+                        session_factory=async_sessionmaker(engine, expire_on_commit=False)
+                    )
+                    return await proc._dump_tables("schedules", ["clinic_weekly_schedules"])
+                finally:
+                    await engine.dispose()
+
+            backup_path = asyncio.run(_dump())
         finally:
             processor_module.BACKUP_ROOT = original_root
 

--- a/backend/tests/test_processor_pending_order.py
+++ b/backend/tests/test_processor_pending_order.py
@@ -1,4 +1,4 @@
-"""Batch ordering and backup tolerance in the pending processor (#286).
+"""Batch ordering and backup tolerance in the pending processor (#286, #298).
 
 Removing a dependency pair in one "Apply changes" batch used to process
 the dependency first: its Alembic downgrade dragged the dependent's
@@ -6,6 +6,11 @@ branch down (``depends_on``), so the dependent's tables were gone by the
 time its own ``pg_dump`` backup ran — exit 1, record stranded in
 ``to_remove``. Removals must run dependents-first; installs keep the
 dependencies-first order.
+
+#298 replaces the brittle ``pg_dump`` stderr string check with a catalog
+lookup: ``_existing_tables`` asks Postgres which tables still exist and
+only dumps survivors. Tests here use ``monkeypatch`` to fake the lookup
+and ``subprocess.run`` (no live database required).
 """
 
 from __future__ import annotations
@@ -77,23 +82,45 @@ def test_removal_chain_of_three_reverses_fully(processor: PendingProcessor) -> N
 
 
 @pytest.mark.asyncio
-async def test_dump_tables_skips_when_tables_are_gone(
+async def test_dump_tables_skips_when_no_tables_exist(
     processor: PendingProcessor, monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
-    """pg_dump's 'no matching tables' is a skipped backup, not a failure."""
+    """All tables already dropped → catalog lookup returns empty set → skip."""
     from app.core.plugins import processor as processor_module
 
     monkeypatch.setattr(processor_module, "BACKUP_ROOT", tmp_path)
 
-    def fake_run(args, **kwargs):  # noqa: ANN001, ANN003
-        raise subprocess.CalledProcessError(
-            1, args, stderr=b"pg_dump: error: no matching tables were found\n"
-        )
+    async def fake_existing(tables):  # noqa: ANN002
+        return set()  # none exist
 
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(processor, "_existing_tables", fake_existing)
     result = await processor._dump_tables("ghost", ["ghost_table"])
     assert result is None
     assert list(tmp_path.iterdir()) == []  # no empty backup file left behind
+
+
+@pytest.mark.asyncio
+async def test_dump_tables_partial_backup_when_some_tables_dropped(
+    processor: PendingProcessor, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Two of three tables already dropped → back up the survivor only."""
+    from app.core.plugins import processor as processor_module
+
+    monkeypatch.setattr(processor_module, "BACKUP_ROOT", tmp_path)
+
+    async def fake_existing(tables):  # noqa: ANN002
+        return {"survivor_table"}
+
+    monkeypatch.setattr(processor, "_existing_tables", fake_existing)
+
+    def fake_run(args, stdout, **kwargs):  # noqa: ANN001, ANN003
+        stdout.write("COPY 0;\n")
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = await processor._dump_tables("partial", ["gone_a", "gone_b", "survivor_table"])
+    assert result is not None
+    assert result.name.startswith("module_partial_")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_processor_pending_order.py
+++ b/backend/tests/test_processor_pending_order.py
@@ -131,6 +131,11 @@ async def test_dump_tables_still_raises_on_other_pg_dump_errors(
 
     monkeypatch.setattr(processor_module, "BACKUP_ROOT", tmp_path)
 
+    async def fake_existing(tables):  # noqa: ANN002
+        return set(tables)  # all exist — pg_dump will be called
+
+    monkeypatch.setattr(processor, "_existing_tables", fake_existing)
+
     def fake_run(args, **kwargs):  # noqa: ANN001, ANN003
         raise subprocess.CalledProcessError(
             1, args, stderr=b"pg_dump: error: connection to server failed\n"

--- a/backend/tests/test_uninstall_roundtrip.py
+++ b/backend/tests/test_uninstall_roundtrip.py
@@ -191,6 +191,11 @@ def test_medical_reference_uninstall_roundtrip_is_branch_scoped() -> None:
     )
 
 
+async def _all_tables_exist(tables: list[str]) -> set[str]:
+    """Fake the #298 catalog lookup: every requested table exists."""
+    return set(tables)
+
+
 def test_dump_tables_hard_fails_when_pg_dump_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -204,9 +209,10 @@ def test_dump_tables_hard_fails_when_pg_dump_missing(
 
     monkeypatch.setattr(processor_module.subprocess, "run", _raise_not_found)
 
-    # Build a processor with a dummy session factory — the method under
-    # test never opens a session.
+    # Build a processor with a dummy session factory and fake the catalog
+    # lookup (#298) — the failure under test is pg_dump's, not the DB's.
     proc = processor_module.PendingProcessor(session_factory=lambda: None)  # type: ignore[arg-type]
+    monkeypatch.setattr(proc, "_existing_tables", _all_tables_exist)
 
     with pytest.raises(RuntimeError, match="pg_dump not available"):
         asyncio.run(proc._dump_tables("schedules", ["clinic_weekly_schedules"]))
@@ -227,6 +233,7 @@ def test_dump_tables_hard_fails_on_empty_output(
     monkeypatch.setattr(processor_module.subprocess, "run", _fake_run)
 
     proc = processor_module.PendingProcessor(session_factory=lambda: None)  # type: ignore[arg-type]
+    monkeypatch.setattr(proc, "_existing_tables", _all_tables_exist)
 
     with pytest.raises(RuntimeError, match="empty backup"):
         asyncio.run(proc._dump_tables("schedules", ["clinic_weekly_schedules"]))


### PR DESCRIPTION

Replace the brittle `pg_dump` stderr string match ("no matching tables were found") with a catalog lookup via `_existing_tables`.  The new async method asks Postgres which of the module's tables still exist (information_schema, the driver the app already ships), and `_dump_tables` only passes survivors to `pg_dump`.

Benefits:
- No dependency on an English-language pg_dump message string.
- Partial backups are preserved: if 2 of 3 tables survive a botched downgrade, those 2 are backed up instead of all-or-nothing.
- The CalledProcessError handler still surfaces stderr for genuine pg_dump failures (connection lost, permissions, etc.).

Tests: the existing skip test is rewritten to fake `_existing_tables` instead of faking stderr; a new test covers the partial-backup path. Both are DB-free.
