### PR TITLE
docs: nine-language READMEs, refreshed claims, contributors credit (#313)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -492,3 +492,17 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 ## Thank You!
 
 Every contribution matters — from fixing typos to adding major features. We appreciate your time and effort in making DentalPin better for the dental community.
+
+### Contributors
+
+DentalPin is what it is thanks to everyone who has shipped code, reviewed changes, reported what's broken and translated the product:
+
+- [@martinezsalmeron](https://github.com/martinezsalmeron) — creator and maintainer
+- [@lamanji](https://github.com/lamanji) — contacts, tasks, activity journal, inventory, medication catalog and the practice-management module chain
+- [@ZoliQua](https://github.com/ZoliQua) — i18n (de/hu/pl/it and module-layer coverage), onboarding, notifications channels, a11y and audit sweeps
+- [@tresundios](https://github.com/tresundios) — India GST compliance module and the Tamil localization
+- [@hirad121](https://github.com/hirad121) — public integrations API / webhooks (phase 1) and security hardening
+- [@javier-delacruz](https://github.com/javier-delacruz)
+- [@ermix3](https://github.com/ermix3)
+
+(Ordering by merged contributions; add yourself here in your first PR if we forgot you.)

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,323 @@
+# DentalPin
+
+[![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
+[![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
+[![fr](https://img.shields.io/badge/lang-fr-blue.svg)](./README.fr.md)
+[![pt](https://img.shields.io/badge/lang-pt-brightgreen.svg)](./README.pt.md)
+[![ta](https://img.shields.io/badge/lang-ta-green.svg)](./README.ta.md)
+[![de](https://img.shields.io/badge/lang-de-black.svg)](./README.de.md)
+[![hu](https://img.shields.io/badge/lang-hu-orange.svg)](./README.hu.md)
+[![pl](https://img.shields.io/badge/lang-pl-lightgrey.svg)](./README.pl.md)
+[![it](https://img.shields.io/badge/lang-it-blueviolet.svg)](./README.it.md)
+
+**Open-Source-Software für die Verwaltung von Zahnarztpraxen.** Patienten, Zahnschema,
+Terminplanung, Behandlungspläne, Abrechnung und ein integrierter KI-Copilot — modular,
+self-hosted, API-first.
+
+### ▶ [**Live-Demo ausprobieren**](https://demo.dentalpin.com)
+
+Melden Sie sich mit `admin@demo.clinic` / `demo1234` an — voller Admin-Zugriff auf eine
+Praxis mit Beispieldaten. Wird jede Nacht zurückgesetzt, probieren Sie also alles aus.
+
+[![DentalPin — Patientenakte mit Zahnschema](docs/screenshots/patients.png)](https://demo.dentalpin.com)
+
+<sub>[Website](https://www.dentalpin.com) · [Doku](https://docs.dentalpin.com) · [Telegram](https://t.me/dentalpin) · [Weitere Screenshots ↓](#screenshots)</sub>
+
+## Warum DentalPin?
+
+Zahnarztpraxen auf der ganzen Welt teilen dieselben grundlegenden Bedürfnisse: Patienten verwalten, Termine planen, Behandlungen nachverfolgen und die Praxis effizient führen. Doch die Softwarelandschaft ist in Dutzende lokalisierte Closed-Source-Lösungen zersplittert, die Praxen an teure Verträge und veraltete Technologie binden.
+
+**Wir glauben, es ist Zeit für einen Wandel.**
+
+DentalPin beruht auf einer einfachen Prämisse: **eine offene Plattform für Zahnarztpraxen überall**. Keine weitere regionale Lösung, sondern ein globales Fundament, das jede Praxis übernehmen, jeder Entwickler erweitern und jede Community lokalisieren kann.
+
+### Warum jetzt?
+
+KI hat grundlegend verändert, was kleine Teams bauen können. Funktionen, die früher große Entwicklungsabteilungen erforderten, lassen sich heute in Tagen umsetzen. Das ist unser Zeitfenster, um die Open-Source-Dentalsoftware zu schaffen, die es schon vor Jahren hätte geben sollen — bevor Praxen in Altsystemen gefangen sind, aus denen sie nicht mehr herauskommen.
+
+### Unsere Prinzipien
+
+- **Open Source** — Die Daten Ihrer Praxis gehören Ihnen. Ihre Software sollte es auch.
+- **Modular** — Starten Sie einfach, ergänzen Sie, was Sie brauchen. Zahlen Sie nicht für Funktionen, die Sie nie nutzen werden.
+- **Global by Design** — Von Tag eins für Lokalisierung gebaut. Derselbe Kern, jede Sprache, jedes Land.
+- **API-First** — Jede Funktion ist eine API. Integrieren Sie alles, automatisieren Sie alles.
+- **Bereit für KI** — Strukturiert für das KI-Zeitalter. Bereit für intelligente Terminplanung, klinische Entscheidungsunterstützung und Workflow-Automatisierung.
+
+### Die Vision
+
+Wir bauen nicht nur Software — wir bauen das Fundament für ein Ökosystem. Eine Plattform, auf der Entwickler Module beisteuern, Praxen Verbesserungen teilen und die gesamte Dental-Community von kollektiver Innovation profitiert.
+
+Praxen verdienen Besseres als geschlossene, teure Software aus dem letzten Jahrzehnt. DentalPin ist die offene Alternative.
+
+## ✨ KI-Copilot
+
+DentalPin wird mit einem integrierten **agentischen KI-Assistenten** ausgeliefert, der die ganze Praxis in etwas verwandelt, mit dem Sie einfach reden können. Bitten Sie ihn, einen Patienten zu finden, einen Termin freizuräumen, einem unbeantworteten Kostenvoranschlag nachzugehen oder Sie über den anstehenden Tag zu briefen — in ganz normalem Spanisch oder Englisch — und er handelt auf Ihren echten Daten.
+
+![AI Copilot](docs/screenshots/ia.png)
+
+Das ist kein aufgesetzter Chatbot. Der Copilot ist ein echter Agent, der **mehrstufige Aufgaben plant und ausführt**, indem er dieselben Operationen aufruft wie die Oberfläche — über Patienten, Terminkalender, Recalls, Kostenvoranschläge, Zahlungen und Berichte hinweg.
+
+- **Er handelt, statt nur zu antworten.** Der Agent führt echte Tools aus — Patienten suchen, Termine buchen oder verschieben, eine Zahlung erfassen, die Einnahmen des Monats abrufen — und verkettet sie, um eine Aufgabe von Anfang bis Ende zu erledigen.
+- **Er kann Ihre Rolle nie überschreiten.** Jeder Tool-Aufruf wird am Kontrollpunkt der Ausführung erneut gegen die RBAC-Berechtigungen des aufrufenden Benutzers geprüft. Der Copilot kann *genau* das sehen und tun, was dieser Benutzer über die Oberfläche könnte — nicht mehr, begrenzt auf seine Praxis.
+- **Ihre Daten sind geschützt.** Gesundheitsdaten (PHI) werden geschwärzt, bevor irgendetwas den LLM-Anbieter erreicht: Patientennamen, Telefonnummern, E-Mails und IDs werden durch deterministische Token ersetzt, und klinische Freitext-Tools sind vom Cloud-Pfad vollständig ausgeschlossen. Die Schwärzung ist standardmäßig aktiv.
+- **Schreibzugriffe fragen zuerst.** Jede Aktion, die Daten verändert (Buchungen, Zahlungen, Bearbeitungen), pausiert mitten im Gespräch für Ihre ausdrückliche Bestätigung, bevor sie ausgeführt wird.
+- **Geführte Workflows.** Fertige Playbooks — *Tagesbriefing*, *Besuch vorbereiten*, *Lücke füllen*, *Fällige Recalls*, *Unbeantwortete Kostenvoranschläge* — starten häufige mehrstufige Aufgaben mit einem Fingertipp.
+- **Proaktive Briefings.** Aktivieren Sie optional einen deterministischen Morgen-Digest per E-Mail an Ihr Team, der den Terminplan des Tages, fällige Recalls und offene Kostenvoranschläge zusammenfasst — ohne LLM, ohne PHI außer Haus.
+- **Modular by Design.** Der Copilot nutzt Tools, die jedes Modul über eine gemeinsame Registry veröffentlicht; jedes Modul steuert eigene Fähigkeiten bei, sodass der Agent automatisch mitwächst, wenn neue Module installiert werden.
+
+Unter der Haube anbieterunabhängig (eine LLM-Provider-Abstraktion), mit pro Deployment konfigurierbarem Anbieter, Modell und Token-Budgets pro Praxis. Architektur: [docs/technical/copilot-agentic-architecture.md](docs/technical/copilot-agentic-architecture.md).
+
+## Website
+
+Besuchen Sie [**dentalpin.com**](https://www.dentalpin.com) für Produktinformationen, Funktionen und kommerzielle Details.
+
+## Community
+
+Treten Sie unserem [**Telegram-Kanal**](https://t.me/dentalpin) bei — für Support, Hilfe bei der Installation und Fragen.
+
+## Screenshots
+
+### Dashboard
+![Dashboard](docs/screenshots/home.png)
+
+### Patientenverwaltung
+![Patients](docs/screenshots/patients.png)
+
+### Wochenkalender
+![Weekly Schedule](docs/screenshots/schedule-week.png)
+
+### Kanban-Terminplan
+![Kanban Schedule](docs/screenshots/schedule-canban.png)
+
+### Zahlungsdiagramm
+![Payments Chart](docs/screenshots/payments-chart.png)
+
+### Einstellungen
+![Settings](docs/screenshots/settings.png)
+
+## Installation
+
+Vorgefertigte Images, kein Clone, kein Build. Auf jedem Server mit Docker:
+
+```bash
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/Caddyfile
+curl -o .env https://raw.githubusercontent.com/dentalpin/dentalpin/main/.env.prod.example
+
+# PUBLIC_URL, POSTGRES_PASSWORD und SECRET_KEY in .env setzen, dann:
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Richten Sie eine Domain auf den Server, setzen Sie `PUBLIC_URL=https://your-domain`,
+und TLS wird beim ersten Start automatisch eingerichtet — Caddy steht vor beiden
+Diensten auf einem einzigen Origin, es gibt also kein CORS und kein Zertifikat zu
+erneuern. Setzen Sie `SEED_ON_STARTUP=1`, um die Demo-Praxis zu laden und sich
+umzusehen, bevor Sie live gehen.
+
+Images: [`dentalpin-backend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-backend) ·
+[`dentalpin-frontend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-frontend)
+
+## Schnellstart (Entwicklung)
+
+Baut aus dem Quellcode, mit Hot Reload:
+
+```bash
+# Dienste starten
+docker-compose up -d
+
+# Demo-Daten einspielen (standardmäßig Englisch)
+./scripts/seed-demo.sh
+
+# Oder auf Spanisch einspielen
+./scripts/seed-demo.sh --lang es
+
+# Indien-GST-Demo-Praxis (Tamil-UI, oder englische UI mit --country in)
+./scripts/seed-demo.sh --lang ta
+```
+
+Öffnen Sie http://localhost:3000
+
+### Demo-Zugangsdaten
+
+Alle Benutzer haben das Passwort: `demo1234`
+
+| E-Mail | Rolle | Name (EN) | Name (ES) |
+|--------|-------|-----------|-----------|
+| admin@demo.clinic | admin | Admin Demo | Admin Demo |
+| dentist@demo.clinic | dentist | Dr. Sarah Johnson | Dra. María García López |
+| hygienist@demo.clinic | hygienist | Michael Williams | Carlos López Martínez |
+| assistant@demo.clinic | assistant | Emily Davis | Ana Martínez Ruiz |
+| receptionist@demo.clinic | receptionist | Jessica Brown | Laura Sánchez Pérez |
+
+Alle Details zu den Demo-Daten finden Sie in [docs/user-manual/en/demo.md](docs/user-manual/en/demo.md).
+
+## Tech-Stack
+
+| Ebene | Technologie |
+|-------|------------|
+| Backend | FastAPI (Python 3.11+) |
+| Frontend | Nuxt 3 + Nuxt UI |
+| Datenbank | PostgreSQL 15 |
+| Auth | JWT mit Refresh-Tokens |
+
+## Funktionen
+
+### KI-Copilot
+- **Agentischer Assistent** — Konversationsagent, der mehrstufige Aufgaben über Patienten, Terminkalender, Recalls, Kostenvoranschläge, Zahlungen und Berichte hinweg plant und ausführt, indem er echte Operationen aufruft
+- **RBAC-Parität** — Jede Aktion wird erneut gegen die Berechtigungen des Benutzers geprüft; der Agent kann nur tun, was dieser Benutzer über die Oberfläche könnte, begrenzt auf seine Praxis
+- **PHI-Schwärzung** — Patientenidentifikatoren werden tokenisiert, bevor sie das LLM erreichen; klinische Freitextdaten bleiben dem Cloud-Pfad fern. Standardmäßig aktiv
+- **Bestätigte Schreibzugriffe** — Datenändernde Aktionen pausieren mitten im Gespräch für die ausdrückliche Bestätigung des Benutzers
+- **Workflows & Digest** — Playbooks per Fingertipp (Tagesbriefing, Besuch vorbereiten, Lücke füllen) plus ein optionaler proaktiver Morgen-Digest per E-Mail
+- **Mehrsprachig & anbieterunabhängig** — Spricht mit Ihnen in der Sprache Ihrer Oberfläche; LLM-Anbieter, Modell und Token-Budget pro Praxis konfigurierbar
+
+### Klinische Verwaltung
+- **Patientenakten** — Vollständige Patientenprofile mit persönlichen Daten, Kontaktinformationen, Anamnese und Notizen
+- **Zahnschema (Odontogramm)** — Interaktives Zahndiagramm mit Behandlungsverfolgung pro Zahn/Fläche
+- **Terminkalender** — Wochen- und Tagesansicht mit Drag & Drop, Spalten je Behandler, Konflikterkennung
+- **Behandlungskatalog** — Anpassbarer Katalog mit Codes, Preisen, Mehrwertsteuersätzen und Kategorien
+
+### Finanzverwaltung
+- **Kostenvoranschläge** — Behandlungs-Kostenvoranschläge erstellen, Freigabe-Workflow verfolgen (Entwurf → ausstehend → genehmigt/abgelehnt), Patientenunterschrift erfassen, PDF-Generierung
+- **Rechnungen** — Rechnungen aus Kostenvoranschlägen oder eigenständig erzeugen, automatische Nummerierung, mehrere Zahlungsarten, PDF-Export
+- **Zahlungen** — Teilzahlungen verfolgen, Zahlungshistorie, Saldoberechnung
+
+### Praxisverwaltung
+- **Rollenbasierte Zugriffskontrolle** — Fünf Rollen (Admin, Zahnarzt, Dentalhygieniker, Assistenz, Rezeption) mit granularen Berechtigungen
+- **Behandlungszimmer-Verwaltung** — Behandlungszimmer mit Zeitplänen und Farben definieren
+- **Behandler-Verwaltung** — Termine bestimmten Zahnärzten/Dentalhygienikern zuweisen
+
+### Benutzererlebnis
+- **Visuelle Auswahlfelder** — Intelligente Dropdowns mit zuletzt aufgerufenen Patienten und häufig genutzten Behandlungen
+- **Oberfläche in neun Sprachen** — Englisch, Spanisch, Französisch, Portugiesisch, Tamil, Deutsch, Ungarisch, Polnisch und Italienisch — Kern-App und jedes Modul
+- **Dark Mode** — Themenwechsel entsprechend der Systemeinstellung
+- **Responsives Design** — Funktioniert auf Desktop und Tablet
+
+### Technische Funktionen
+- **Modulare Architektur** — Plugin-basiertes System für einfache Erweiterbarkeit
+- **Event-Bus** — Kommunikation zwischen Modulen für Benachrichtigungen und Integrationen
+- **REST-API** — Vollständige API mit OpenAPI-Dokumentation
+- **Echtzeit-Updates** — Reaktive Oberfläche mit optimistischen Updates
+
+## Sprachen
+
+Die Oberfläche wird in **neun Sprachen** ausgeliefert — English, Español, Français,
+Português, தமிழ் (Tamil), Deutsch, Magyar, Polski und Italiano — und deckt die Kern-App
+**und jede Modulebene** ab, mit einem in der CI erzwungenen Key-Paritätstest, damit
+Locales nicht unbemerkt auseinanderlaufen. Polnisch nutzt seine vollständigen
+Pluralregeln mit drei Formen.
+
+Patientengerichtete Kommunikation (E-Mail-Vorlagen, PDFs) wird derzeit in
+**fünf Sprachen** gerendert (es, en, fr, pt, ta); jede Praxis wählt ihre
+Kommunikationssprache unabhängig von der UI-Sprache des Teams.
+
+Ihre Sprache fehlt? Eine Sprache hinzuzufügen ist ein reiner Übersetzungsbeitrag —
+sehen Sie sich die [i18n-Issues](https://github.com/dentalpin/dentalpin/issues?q=label%3Ai18n)
+an oder eröffnen Sie ein neues.
+
+## Entwicklung
+
+### Voraussetzungen
+
+- Docker und Docker Compose
+- Python 3.11+ (für lokale Backend-Entwicklung)
+- Node.js 18+ (für lokale Frontend-Entwicklung)
+
+### Lokal ausführen
+
+```bash
+# Alle Dienste starten
+docker-compose up
+
+# Oder das Backend separat ausführen
+cd backend
+pip install -e ".[dev]"
+uvicorn app.main:app --reload
+
+# Oder das Frontend separat ausführen
+cd frontend
+npm install
+npm run dev
+```
+
+### Datenbankverwaltung
+
+```bash
+# Datenbank zurücksetzen und Migrationen ausführen
+./scripts/reset-db.sh
+
+# Demo-Daten einspielen (Englisch — Standard)
+./scripts/seed-demo.sh
+
+# Demo-Daten einspielen (Spanisch)
+./scripts/seed-demo.sh --lang es
+
+# Komplette Einrichtung (Reset + Seed in einem Befehl)
+./scripts/setup-demo.sh
+```
+
+### Tests ausführen
+
+```bash
+# Backend-Unit- + Integrationstests (in Docker)
+docker-compose exec backend python -m pytest -v
+
+# Langsamer Alembic-Round-Trip (opt-in, siehe docs/technical/creating-modules.md)
+docker-compose exec backend python -m pytest -v -m alembic_roundtrip
+
+# Frontend-Unit-Tests (vitest)
+cd frontend
+npm run test
+```
+
+**Browser-E2E (Playwright)** liegt in `frontend/tests/e2e/` und steuert den
+vollen Stack unter `localhost:3000` → `:8000`. Läuft auf dem Host, weil der
+Alpine-Frontend-Container kein Chromium starten kann.
+
+```bash
+# Einmalige Einrichtung
+(cd frontend && npm install && npx playwright install chromium)
+
+# Der Stack muss zuerst laufen und geseedet sein
+docker-compose up -d
+./scripts/seed-demo.sh
+
+# Komplette E2E-Suite (Nav + RBAC + Patientendetail-Smoke-Test)
+./scripts/e2e.sh
+
+# Einzelne Datei
+./scripts/e2e.sh rbac
+
+# Interaktive UI
+./scripts/e2e.sh --ui
+```
+
+Vollständiges Runbook + Fixture-Referenz: [docs/technical/e2e-testing.md](docs/technical/e2e-testing.md).
+
+## Architektur
+
+DentalPin nutzt eine modulare Plugin-Architektur. Jede Funktion ist ein in sich geschlossenes Modul, das:
+- seine SQLAlchemy-Modelle deklariert
+- einen FastAPI-Router bereitstellt
+- Events anderer Module abonnieren kann
+
+Details finden Sie in [docs/adr/0001-modular-plugin-architecture.md](docs/adr/0001-modular-plugin-architecture.md).
+
+## Lizenz
+
+Business Source License 1.1 (BSL 1.1)
+
+**Zusätzliche Nutzungsgewährung:** Sie dürfen DentalPin in Produktion einsetzen, solange Sie es nicht als kommerzielles SaaS für die Verwaltung von Zahnarztpraxen anbieten.
+
+**Änderungsdatum:** 4 Jahre ab Veröffentlichung
+
+**Änderungslizenz:** Apache 2.0
+
+Die vollständigen Bedingungen finden Sie in [LICENSE](LICENSE).
+
+## Mitwirken
+
+Richtlinien finden Sie in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+Unterstützt von [Dentaltix](https://www.dentaltix.com)

--- a/README.es.md
+++ b/README.es.md
@@ -3,7 +3,12 @@
 [![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
 [![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
 [![fr](https://img.shields.io/badge/lang-fr-blue.svg)](./README.fr.md)
+[![pt](https://img.shields.io/badge/lang-pt-brightgreen.svg)](./README.pt.md)
 [![ta](https://img.shields.io/badge/lang-ta-green.svg)](./README.ta.md)
+[![de](https://img.shields.io/badge/lang-de-black.svg)](./README.de.md)
+[![hu](https://img.shields.io/badge/lang-hu-orange.svg)](./README.hu.md)
+[![pl](https://img.shields.io/badge/lang-pl-lightgrey.svg)](./README.pl.md)
+[![it](https://img.shields.io/badge/lang-it-blueviolet.svg)](./README.it.md)
 
 **Software open source de gestión de clínicas dentales.** Pacientes, odontograma,
 agenda, planes de tratamiento, facturación y un copiloto de IA integrado — modular,
@@ -28,7 +33,7 @@ DentalPin se construye sobre una premisa simple: **una plataforma abierta para c
 
 ### ¿Por qué ahora?
 
-La IA ha cambiado fundamentalmente lo que los equipos pequeños pueden construir. Funcionalidades que antes requerían grandes departamentos de desarrollo ahora pueden implementarse en días. Esta es nuestra ventana para crear el software dental de código cerrado que debería haber existido hace años — antes de que las clínicas quedaran encerradas en sistemas legacy de los que no pueden escapar.
+La IA ha cambiado fundamentalmente lo que los equipos pequeños pueden construir. Funcionalidades que antes requerían grandes departamentos de desarrollo ahora pueden implementarse en días. Esta es nuestra ventana para crear el software dental de código abierto que debería haber existido hace años — antes de que las clínicas quedaran encerradas en sistemas legacy de los que no pueden escapar.
 
 ### Nuestros principios
 
@@ -57,7 +62,7 @@ Esto no es un chatbot añadido a posteriori. El Copiloto es un agente real que *
 - **Sus datos están protegidos.** Los datos de salud se enmascaran antes de enviarlos al proveedor LLM: nombres, teléfonos, correos electrónicos e identificadores se reemplazan por tokens deterministas, y las herramientas clínicas de texto libre se excluyen del camino cloud. El enmascaramiento está activado por defecto.
 - **Las escrituras preguntan primero.** Cualquier acción que modifique datos (reservas, pagos, ediciones) hace una pausa en medio de la conversación para su confirmación explícita antes de ejecutarse.
 - **Flujos de trabajo guiados.** Playbooks listos para usar — *Resumen matinal*, *Preparar una consulta*, *Llenar un espacio*, *Recordatorios pendientes*, *Presupuestos sin respuesta* — inician tareas multi-paso comunes con un solo clic.
-- **Briefings proactivos.** Elija recibir un resumen matinal determinista enviado por correo electrónico a su equipo, resumiendo el agenda del día, recordatorios pendientes y presupuestos abiertos — sin LLM, sin datos de salud fuera del sitio.
+- **Briefings proactivos.** Elija recibir un resumen matinal determinista enviado por correo electrónico a su equipo, resumiendo la agenda del día, recordatorios pendientes y presupuestos abiertos — sin LLM, sin datos de salud fuera del sitio.
 - **Modular por diseño.** El Copiloto consume herramientas publicadas por cada módulo a través de un registro compartido; cada módulo contribuye sus propias capacidades, por lo que el agente crece automáticamente a medida que se instalan nuevos módulos.
 
 Agnóstico al proveedor en las capas internas (abstracción del proveedor LLM), con proveedor, modelo y presupuestos de tokens por clínica configurables por despliegue. Arquitectura: [docs/technical/copilot-agentic-architecture.md](docs/technical/copilot-agentic-architecture.md).
@@ -90,7 +95,30 @@ Visite [**dentalpin.com**](https://www.dentalpin.com) para información del prod
 ### Configuración
 ![Settings](docs/screenshots/settings.png)
 
-## Inicio rápido
+## Instalación
+
+Imágenes preconstruidas, sin clonar ni compilar. En cualquier servidor con Docker:
+
+```bash
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/Caddyfile
+curl -o .env https://raw.githubusercontent.com/dentalpin/dentalpin/main/.env.prod.example
+
+# Configure PUBLIC_URL, POSTGRES_PASSWORD y SECRET_KEY en .env, y luego:
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Apunte un dominio al servidor, configure `PUBLIC_URL=https://your-domain`, y el TLS
+se aprovisiona en el primer arranque — Caddy sirve ambos servicios desde un único
+origen, así que no hay CORS ni certificados que renovar. Configure `SEED_ON_STARTUP=1`
+para cargar la clínica de demostración y explorar antes de pasar a producción.
+
+Imágenes: [`dentalpin-backend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-backend) ·
+[`dentalpin-frontend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-frontend)
+
+## Inicio rápido (desarrollo)
+
+Compila desde el código fuente con recarga en caliente:
 
 ```bash
 # Iniciar servicios
@@ -104,6 +132,9 @@ docker-compose up -d
 
 # O sembrar en francés
 ./scripts/seed-demo.sh --lang fr
+
+# Clínica demo India GST (interfaz en tamil, o en inglés con --country in)
+./scripts/seed-demo.sh --lang ta
 ```
 
 Abrir http://localhost:3000
@@ -120,7 +151,7 @@ Todos los usuarios tienen contraseña: `demo1234`
 | assistant@demo.clinic | assistant | Emily Davis | Ana Martínez Ruiz |
 | receptionist@demo.clinic | receptionist | Jessica Brown | Laura Sánchez Pérez |
 
-Consulte [docs/user-manual/demo.md](docs/user-manual/demo.md) para detalles completos sobre los datos de demostración.
+Consulte [docs/user-manual/en/demo.md](docs/user-manual/en/demo.md) para detalles completos sobre los datos de demostración.
 
 ## Stack tecnológico
 
@@ -139,7 +170,7 @@ Consulte [docs/user-manual/demo.md](docs/user-manual/demo.md) para detalles comp
 - **Enmascaramiento de datos de salud** — Identificadores de pacientes tokenizados antes de llegar al LLM; los datos clínicos de texto libre permanecen fuera del camino cloud. Activado por defecto
 - **Escrituras confirmadas** — Las acciones que modifican datos hacen una pausa para confirmación explícita del usuario en medio de la conversación
 - **Flujos de trabajo y resumen** — Playbooks con un clic (resumen matinal, preparar una consulta, llenar un espacio) más un resumen matinal por correo electrónico proactivo opcional
-- **Bilingüe y agnóstico al proveedor** — Funciona en español, francés e inglés; proveedor LLM, modelo y presupuesto de tokens por clínica configurables
+- **Multilingüe y agnóstico al proveedor** — Le habla en el idioma de su interfaz; proveedor LLM, modelo y presupuesto de tokens por clínica configurables
 
 ### Gestión clínica
 - **Historiales de pacientes** — Perfiles completos con datos personales, información de contacto, historial médico y notas
@@ -159,7 +190,7 @@ Consulte [docs/user-manual/demo.md](docs/user-manual/demo.md) para detalles comp
 
 ### Experiencia de usuario
 - **Selectores visuales** — Menús desplegables inteligentes mostrando pacientes recientes y tratamientos populares
-- **Interfaz bilingüe** — Localización completa en español, francés e inglés
+- **Interfaz en nueve idiomas** — Inglés, español, francés, portugués, tamil, alemán, húngaro, polaco e italiano — el núcleo de la aplicación y todos los módulos
 - **Modo oscuro** — Cambio de tema adaptado al sistema
 - **Diseño responsive** — Funciona en escritorio y tableta
 
@@ -168,6 +199,22 @@ Consulte [docs/user-manual/demo.md](docs/user-manual/demo.md) para detalles comp
 - **Bus de eventos** — Comunicación entre módulos para notificaciones e integraciones
 - **API REST** — API completa con documentación OpenAPI
 - **Actualizaciones en tiempo real** — Interfaz reactiva con actualizaciones optimistas
+
+## Idiomas
+
+La interfaz está disponible en **nueve idiomas** — English, Español, Français, Português,
+தமிழ் (Tamil), Deutsch, Magyar, Polski e Italiano — cubriendo el núcleo de la aplicación
+**y todas las capas de módulos**, con un test de paridad de claves aplicado en CI para
+que las traducciones no puedan desincronizarse silenciosamente. El polaco usa sus reglas
+completas de plural de tres formas.
+
+Las comunicaciones dirigidas al paciente (plantillas de email, PDFs) se generan
+actualmente en **cinco idiomas** (es, en, fr, pt, ta); cada clínica elige su idioma de
+comunicación con independencia del idioma de la interfaz del personal.
+
+¿Quiere su idioma? Añadir uno es una contribución solo de traducción — consulte los
+[issues de i18n](https://github.com/dentalpin/dentalpin/issues?q=label%3Ai18n) o abra
+uno nuevo.
 
 ## Desarrollo
 
@@ -258,7 +305,7 @@ DentalPin utiliza una arquitectura modular tipo plugin. Cada funcionalidad es un
 - Proporciona un router FastAPI
 - Puede suscribirse a eventos de otros módulos
 
-Consulte [docs/architecture.md](docs/architecture.md) para más detalles.
+Consulte [docs/adr/0001-modular-plugin-architecture.md](docs/adr/0001-modular-plugin-architecture.md) para más detalles.
 
 ## Licencia
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -3,7 +3,12 @@
 [![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
 [![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
 [![fr](https://img.shields.io/badge/lang-fr-blue.svg)](./README.fr.md)
+[![pt](https://img.shields.io/badge/lang-pt-brightgreen.svg)](./README.pt.md)
 [![ta](https://img.shields.io/badge/lang-ta-green.svg)](./README.ta.md)
+[![de](https://img.shields.io/badge/lang-de-black.svg)](./README.de.md)
+[![hu](https://img.shields.io/badge/lang-hu-orange.svg)](./README.hu.md)
+[![pl](https://img.shields.io/badge/lang-pl-lightgrey.svg)](./README.pl.md)
+[![it](https://img.shields.io/badge/lang-it-blueviolet.svg)](./README.it.md)
 
 **Logiciel open source de gestion de cliniques dentaires.** Patients, odontogramme,
 agenda, plans de traitement, facturation et un copilote IA intégré — modulaire,
@@ -90,7 +95,31 @@ Rejoignez notre [**chaîne Telegram**](https://t.me/dentalpin) pour du support, 
 ### Paramètres
 ![Settings](docs/screenshots/settings.png)
 
-## Démarrage rapide
+## Installation
+
+Images préconstruites, pas de clone, pas de build. Sur n'importe quel serveur avec Docker :
+
+```bash
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/Caddyfile
+curl -o .env https://raw.githubusercontent.com/dentalpin/dentalpin/main/.env.prod.example
+
+# Définissez PUBLIC_URL, POSTGRES_PASSWORD et SECRET_KEY dans .env, puis :
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Pointez un domaine vers le serveur, définissez `PUBLIC_URL=https://your-domain`, et le
+TLS est provisionné au premier démarrage — Caddy sert les deux services depuis une
+origine unique, donc pas de CORS et aucun certificat à renouveler. Définissez
+`SEED_ON_STARTUP=1` pour charger la clinique de démonstration et explorer avant la mise
+en production.
+
+Images : [`dentalpin-backend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-backend) ·
+[`dentalpin-frontend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-frontend)
+
+## Démarrage rapide (développement)
+
+Compile depuis les sources avec rechargement à chaud :
 
 ```bash
 # Démarrer les services
@@ -104,6 +133,9 @@ docker-compose up -d
 
 # Ou en français
 ./scripts/seed-demo.sh --lang fr
+
+# Clinique démo India GST (interface en tamoul, ou en anglais avec --country in)
+./scripts/seed-demo.sh --lang ta
 ```
 
 Ouvrir http://localhost:3000
@@ -120,7 +152,7 @@ Tous les utilisateurs ont le mot de passe : `demo1234`
 | assistant@demo.clinic | assistant | Emily Davis | Ana Martínez Ruiz | Camille Petit |
 | receptionist@demo.clinic | receptionist | Jessica Brown | Laura Sánchez Pérez | Julie Bernard |
 
-Voir [docs/user-manual/demo.md](docs/user-manual/demo.md) pour les détails complets sur les données démo.
+Voir [docs/user-manual/en/demo.md](docs/user-manual/en/demo.md) pour les détails complets sur les données démo.
 
 ## Stack technique
 
@@ -139,7 +171,7 @@ Voir [docs/user-manual/demo.md](docs/user-manual/demo.md) pour les détails comp
 - **Masquage des données de santé** — Identifiants des patients tokenisés avant d'atteindre le LLM ; les données cliniques en texte libre restent hors du chemin cloud. Activé par défaut
 - **Écritures confirmées** — Les actions modifiant des données font une pause pour confirmation explicite de l'utilisateur en milieu de conversation
 - **Flux de travail et digest** — Playbooks en un tap (briefing matinal, préparer une consultation, remplir un créneau) plus un digest matinal par e-mail proactif optionnel
-- **Bilingue et agnostique au fournisseur** — Fonctionne en français, espagnol et anglais ; fournisseur LLM, modèle et budget de jetons par clinique configurables
+- **Multilingue et agnostique au fournisseur** — Vous parle dans la langue de votre interface ; fournisseur LLM, modèle et budget de jetons par clinique configurables
 
 ### Gestion clinique
 - **Dossiers patients** — Profils complets avec données personnelles, coordonnées, antécédents médicaux et notes
@@ -154,12 +186,12 @@ Voir [docs/user-manual/demo.md](docs/user-manual/demo.md) pour les détails comp
 
 ### Gestion de la pratique
 - **Contrôle d'accès basé sur les rôles** — Cinq rôles (admin, dentiste, hygiéniste, assistant, réceptionniste) avec permissions granulaires
-- **Gestion des cabinets/cabinets** — Définition des salles de traitement avec emplois du temps et couleurs
-- **Gestion des professionnels** — Attribution des rendez-vous à des dentistes/hygénistes spécifiques
+- **Gestion des cabinets/salles** — Définition des salles de traitement avec emplois du temps et couleurs
+- **Gestion des professionnels** — Attribution des rendez-vous à des dentistes/hygiénistes spécifiques
 
 ### Expérience utilisateur
 - **Sélecteurs visuels** — Menus déroulants intelligents affichant les patients récents et les traitements populaires
-- **Interface bilingue** — Localisation complète en français, espagnol et anglais
+- **Interface en neuf langues** — Anglais, espagnol, français, portugais, tamoul, allemand, hongrois, polonais et italien — le cœur de l'application et chaque module
 - **Mode sombre** — Basculement de thème adapté au système
 - **Design réactif** — Fonctionne sur ordinateur et tablette
 
@@ -168,6 +200,22 @@ Voir [docs/user-manual/demo.md](docs/user-manual/demo.md) pour les détails comp
 - **Bus d'événements** — Communication inter-modules pour les notifications et intégrations
 - **API REST** — API complète avec documentation OpenAPI
 - **Mises à jour en temps réel** — Interface réactive avec mises à jour optimistes
+
+## Langues
+
+L'interface est disponible en **neuf langues** — English, Español, Français, Português,
+தமிழ் (Tamil), Deutsch, Magyar, Polski et Italiano — couvrant le cœur de l'application
+**et chaque couche de module**, avec un test de parité des clés imposé en CI pour que
+les locales ne puissent pas dériver silencieusement. Le polonais utilise ses règles
+complètes de pluriel à trois formes.
+
+Les communications destinées aux patients (modèles d'e-mail, PDF) sont actuellement
+générées en **cinq langues** (es, en, fr, pt, ta) ; chaque clinique choisit sa langue
+de communication indépendamment de la langue de l'interface du personnel.
+
+Vous voulez votre langue ? En ajouter une est une contribution de traduction uniquement —
+consultez les [issues i18n](https://github.com/dentalpin/dentalpin/issues?q=label%3Ai18n)
+ou ouvrez-en une nouvelle.
 
 ## Développement
 
@@ -258,7 +306,7 @@ DentalPin utilise une architecture modulaire de type plugin. Chaque fonctionnali
 - Fournit un routeur FastAPI
 - Peut s'abonner aux événements d'autres modules
 
-Voir [docs/architecture.md](docs/architecture.md) pour les détails.
+Voir [docs/adr/0001-modular-plugin-architecture.md](docs/adr/0001-modular-plugin-architecture.md) pour les détails.
 
 ## Licence
 

--- a/README.hu.md
+++ b/README.hu.md
@@ -1,0 +1,324 @@
+# DentalPin
+
+[![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
+[![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
+[![fr](https://img.shields.io/badge/lang-fr-blue.svg)](./README.fr.md)
+[![pt](https://img.shields.io/badge/lang-pt-brightgreen.svg)](./README.pt.md)
+[![ta](https://img.shields.io/badge/lang-ta-green.svg)](./README.ta.md)
+[![de](https://img.shields.io/badge/lang-de-black.svg)](./README.de.md)
+[![hu](https://img.shields.io/badge/lang-hu-orange.svg)](./README.hu.md)
+[![pl](https://img.shields.io/badge/lang-pl-lightgrey.svg)](./README.pl.md)
+[![it](https://img.shields.io/badge/lang-it-blueviolet.svg)](./README.it.md)
+
+**Nyílt forráskódú fogászati rendelőirányító szoftver.** Páciensek, fogtérkép,
+időpontkezelés, kezelési tervek, számlázás és beépített AI copilot — moduláris,
+self-hosted, API-first.
+
+### ▶ [**Próbálja ki az élő demót**](https://demo.dentalpin.com)
+
+Jelentkezzen be az `admin@demo.clinic` / `demo1234` adatokkal — teljes rendszergazdai
+hozzáférés egy demóadatokkal feltöltött rendelőhöz. Minden éjjel visszaáll, így bátran
+kipróbálhat bármit.
+
+[![DentalPin — páciens adatlap fogtérképpel](docs/screenshots/patients.png)](https://demo.dentalpin.com)
+
+<sub>[Weboldal](https://www.dentalpin.com) · [Dokumentáció](https://docs.dentalpin.com) · [Telegram](https://t.me/dentalpin) · [További képernyőképek ↓](#képernyőképek)</sub>
+
+## Miért a DentalPin?
+
+A fogorvosi rendelőknek világszerte ugyanazok az alapvető igényeik: a páciensek kezelése, az időpontok szervezése, a kezelések nyomon követése és a rendelő hatékony működtetése. A szoftverpiac mégis tucatnyi lokalizált, zárt forráskódú megoldásra tagolódik, amelyek drága szerződésekbe és elavult technológiába zárják a rendelőket.
+
+**Úgy gondoljuk, ideje változtatni.**
+
+A DentalPin egyszerű alapvetésre épül: **egyetlen nyílt platform a fogorvosi rendelők számára, bárhol a világon**. Nem egy újabb regionális megoldás, hanem globális alap, amelyet bármely rendelő bevezethet, bármely fejlesztő bővíthet, és bármely közösség lokalizálhat.
+
+### Miért most?
+
+Az MI alapjaiban változtatta meg, hogy mire képesek a kis csapatok. Azok a funkciók, amelyekhez korábban nagy fejlesztői részlegek kellettek, ma napok alatt megvalósíthatók. Ez a mi lehetőségünk arra, hogy megalkossuk azt a nyílt forráskódú fogászati szoftvert, amelynek már évekkel ezelőtt léteznie kellett volna — mielőtt a rendelők olyan örökölt rendszerekbe záródtak, amelyekből nincs kiút.
+
+### Alapelveink
+
+- **Nyílt forráskód** — A rendelője adatai Önt illetik. A szoftverének is így kellene lennie.
+- **Moduláris** — Kezdje egyszerűen, és adja hozzá, amire szüksége van. Ne fizessen olyan funkciókért, amelyeket soha nem fog használni.
+- **Alapból globális** — Az első naptól lokalizációra tervezve. Ugyanaz a mag, bármely nyelven, bármely országban.
+- **API-first** — Minden funkció egy API. Integrálható bármivel, automatizálható minden.
+- **MI-re kész** — Az MI korszakára strukturálva. Készen áll az intelligens időpontszervezésre, a klinikai döntéstámogatásra és a munkafolyamatok automatizálására.
+
+### A jövőkép
+
+Nem csupán szoftvert építünk — egy ökoszisztéma alapjait rakjuk le. Egy platformot, ahol a fejlesztők modulokkal járulnak hozzá, a rendelők megosztják egymással a fejlesztéseiket, és az egész fogászati közösség profitál a közös innovációból.
+
+A rendelők jobbat érdemelnek az elmúlt évtized zárt és drága szoftvereinél. A DentalPin a nyílt alternatíva.
+
+## ✨ AI Copilot
+
+A DentalPin beépített **agentikus MI-asszisztenssel** érkezik, amely az egész rendelőt olyasvalamivé alakítja, amivel egyszerűen beszélgetni lehet. Kérje meg, hogy keressen meg egy pácienst, szabadítson fel egy időpontot, kövessen fel egy megválaszolatlan árajánlatot, vagy foglalja össze az Ön előtt álló napot — közérthető spanyol vagy angol nyelven — és a valós adatain cselekszik.
+
+![AI Copilot](docs/screenshots/ia.png)
+
+Ez nem egy utólag ráépített chatbot. A Copilot valódi ágens, amely **többlépéses feladatokat tervez meg és hajt végre** ugyanazokat a műveleteket meghívva, mint a felhasználói felület — a páciensek, a naptár, a visszahívások, az árajánlatok, a befizetések és a riportok területén.
+
+- **Cselekszik, nem csak válaszol.** Az ágens valódi eszközöket futtat — páciensek keresése, időpont foglalása vagy átütemezése, befizetés rögzítése, a havi bevételek lekérdezése — és láncba fűzi őket, hogy egy feladatot az elejétől a végéig elvégezzen.
+- **Soha nem lépheti túl az Ön szerepkörét.** Minden eszközhívás újraellenőrzésre kerül a hívó felhasználó RBAC-jogosultságai alapján a végrehajtási ellenőrzőponton. A Copilot *pontosan* azt láthatja és teheti, amit az adott felhasználó a felületen keresztül tehetne — semmivel sem többet, a saját rendelőjére korlátozva.
+- **Az adatai védve vannak.** Az egészségügyi adatok (PHI) maszkolásra kerülnek, mielőtt bármi az LLM-szolgáltatóhoz jutna: a páciensnevek, telefonszámok, e-mail-címek és azonosítók determinisztikus tokenekre cserélődnek, a szabadszöveges klinikai eszközök pedig teljes egészében kimaradnak a felhő felé vezető útból. A maszkolás alapértelmezés szerint be van kapcsolva.
+- **Az írások előbb kérdeznek.** Minden adatmódosító művelet (foglalás, befizetés, szerkesztés) a beszélgetés közben megáll, és az Ön kifejezett jóváhagyására vár a végrehajtás előtt.
+- **Vezetett munkafolyamatok.** Kész forgatókönyvek — *Napi összefoglaló*, *Vizit előkészítése*, *Lyuk kitöltése*, *Esedékes visszahívások*, *Megválaszolatlan árajánlatok* — egyetlen érintéssel elindítják a gyakori többlépéses feladatokat.
+- **Proaktív összefoglalók.** Igény szerint bekapcsolható determinisztikus reggeli összefoglaló, amelyet e-mailben kap meg a csapata a napi naptárról, az esedékes visszahívásokról és a nyitott árajánlatokról — LLM nélkül, egészségügyi adatok kiadása nélkül.
+- **Modularitásra tervezve.** A Copilot az egyes modulok által egy közös registryn keresztül közzétett eszközöket használja; minden modul a saját képességeivel járul hozzá, így az ágens automatikusan bővül az új modulok telepítésével.
+
+A motorháztető alatt szolgáltatófüggetlen (LLM-szolgáltatói absztrakcióval), telepítésenként konfigurálható szolgáltatóval, modellel és rendelőnkénti tokenkerettel. Architektúra: [docs/technical/copilot-agentic-architecture.md](docs/technical/copilot-agentic-architecture.md).
+
+## Weboldal
+
+Látogasson el a [**dentalpin.com**](https://www.dentalpin.com) oldalra a termékinformációkért, a funkciókért és a kereskedelmi részletekért.
+
+## Közösség
+
+Csatlakozzon a [**Telegram-csatornánkhoz**](https://t.me/dentalpin) támogatásért, telepítési segítségért és kérdésekkel.
+
+## Képernyőképek
+
+### Kezdőlap
+![Dashboard](docs/screenshots/home.png)
+
+### Páciensek kezelése
+![Patients](docs/screenshots/patients.png)
+
+### Heti naptár
+![Weekly Schedule](docs/screenshots/schedule-week.png)
+
+### Kanban nézet
+![Kanban Schedule](docs/screenshots/schedule-canban.png)
+
+### Befizetések grafikonja
+![Payments Chart](docs/screenshots/payments-chart.png)
+
+### Beállítások
+![Settings](docs/screenshots/settings.png)
+
+## Telepítés
+
+Előre elkészített image-ek, klónozás és build nélkül. Bármely Dockerrel futó szerveren:
+
+```bash
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/Caddyfile
+curl -o .env https://raw.githubusercontent.com/dentalpin/dentalpin/main/.env.prod.example
+
+# Állítsa be a PUBLIC_URL, POSTGRES_PASSWORD és SECRET_KEY értékét a .env fájlban, majd:
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Irányítson egy domaint a szerverre, állítsa be a `PUBLIC_URL=https://your-domain`
+értéket, és a TLS az első indításkor automatikusan létrejön — a Caddy egyetlen
+originről szolgálja ki mindkét szolgáltatást, így nincs CORS és nincs megújítandó
+tanúsítvány. Állítsa be a `SEED_ON_STARTUP=1` értéket a demórendelő betöltéséhez,
+hogy élesítés előtt körülnézhessen.
+
+Image-ek: [`dentalpin-backend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-backend) ·
+[`dentalpin-frontend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-frontend)
+
+## Gyors kezdés (fejlesztés)
+
+Forrásból épít, hot reloaddal:
+
+```bash
+# Szolgáltatások indítása
+docker-compose up -d
+
+# Demóadatok betöltése (alapértelmezés szerint angolul)
+./scripts/seed-demo.sh
+
+# Vagy betöltés spanyolul
+./scripts/seed-demo.sh --lang es
+
+# Indiai GST demórendelő (tamil felület, vagy angol felület a --country in kapcsolóval)
+./scripts/seed-demo.sh --lang ta
+```
+
+Nyissa meg: http://localhost:3000
+
+### Demó belépési adatok
+
+Minden felhasználó jelszava: `demo1234`
+
+| E-mail | Szerepkör | Név (EN) | Név (ES) |
+|--------|-----------|----------|----------|
+| admin@demo.clinic | admin | Admin Demo | Admin Demo |
+| dentist@demo.clinic | dentist | Dr. Sarah Johnson | Dra. María García López |
+| hygienist@demo.clinic | hygienist | Michael Williams | Carlos López Martínez |
+| assistant@demo.clinic | assistant | Emily Davis | Ana Martínez Ruiz |
+| receptionist@demo.clinic | receptionist | Jessica Brown | Laura Sánchez Pérez |
+
+A demóadatok teljes leírását lásd: [docs/user-manual/en/demo.md](docs/user-manual/en/demo.md).
+
+## Technológiai stack
+
+| Réteg | Technológia |
+|-------|-------------|
+| Backend | FastAPI (Python 3.11+) |
+| Frontend | Nuxt 3 + Nuxt UI |
+| Adatbázis | PostgreSQL 15 |
+| Hitelesítés | JWT refresh tokenekkel |
+
+## Funkciók
+
+### AI Copilot
+- **Agentikus asszisztens** — Társalgó ágens, amely valós műveleteket meghívva tervez meg és hajt végre többlépéses feladatokat a páciensek, a naptár, a visszahívások, az árajánlatok, a befizetések és a riportok területén
+- **RBAC-paritás** — Minden művelet újraellenőrzésre kerül a felhasználó jogosultságai alapján; az ágens csak azt teheti, amit az adott felhasználó a felületen keresztül tehetne, a saját rendelőjére korlátozva
+- **Egészségügyi adatok maszkolása (PHI)** — A páciensazonosítók tokenizálva jutnak csak az LLM elé; a szabadszöveges klinikai adatok nem kerülnek a felhő felé vezető útra. Alapértelmezés szerint bekapcsolva
+- **Megerősített írások** — Az adatmódosító műveletek a beszélgetés közben megállnak a felhasználó kifejezett jóváhagyásáig
+- **Munkafolyamatok és összefoglaló** — Egyérintéses forgatókönyvek (napi összefoglaló, vizit előkészítése, lyuk kitöltése), valamint igény szerint bekapcsolható proaktív reggeli e-mail-összefoglaló
+- **Többnyelvű és szolgáltatófüggetlen** — A felülete nyelvén beszél Önnel; konfigurálható LLM-szolgáltató, modell és rendelőnkénti tokenkeret
+
+### Klinikai adminisztráció
+- **Páciensnyilvántartás** — Teljes páciensprofilok személyes adatokkal, elérhetőségekkel, kórtörténettel és jegyzetekkel
+- **Fogtérkép (odontogram)** — Interaktív fogdiagram fogankénti/felszínenkénti kezeléskövetéssel
+- **Időpontnaptár** — Heti és napi nézetek drag & drop funkcióval, kezelőnkénti oszlopokkal, ütközésészleléssel
+- **Kezeléskatalógus** — Testreszabható katalógus kódokkal, árakkal, áfatípusokkal és kategóriákkal
+
+### Pénzügyi adminisztráció
+- **Árajánlatok** — Kezelési árajánlatok készítése, a jóváhagyási folyamat követése (piszkozat → függőben → elfogadva/elutasítva), páciensaláírás rögzítése, PDF-generálás
+- **Számlák** — Számlák készítése árajánlatból vagy önállóan, automatikus sorszámozás, többféle fizetési mód, PDF-export
+- **Befizetések** — Részfizetések követése, befizetési előzmények, egyenlegszámítás
+
+### Rendelőmenedzsment
+- **Szerepköralapú hozzáférés-kezelés** — Öt szerepkör (rendszergazda, fogorvos, dentálhigiénikus, asszisztens, recepciós) részletes jogosultságokkal
+- **Kezelőhelyiségek kezelése** — Kezelőhelyiségek meghatározása beosztással és színekkel
+- **Szakemberek kezelése** — Időpontok hozzárendelése adott fogorvosokhoz/dentálhigiénikusokhoz
+
+### Felhasználói élmény
+- **Vizuális választók** — Intelligens legördülő menük a legutóbbi páciensekkel és a népszerű kezelésekkel
+- **Kilencnyelvű felület** — angol, spanyol, francia, portugál, tamil, német, magyar, lengyel és olasz — az alapalkalmazásban és minden modulban
+- **Sötét mód** — A rendszerbeállításhoz igazodó témaváltás
+- **Reszponzív dizájn** — Asztali gépen és tableten is működik
+
+### Technikai jellemzők
+- **Moduláris architektúra** — Pluginalapú rendszer az egyszerű bővíthetőségért
+- **Eseménybusz** — Modulok közötti kommunikáció értesítésekhez és integrációkhoz
+- **REST API** — Teljes API OpenAPI-dokumentációval
+- **Valós idejű frissítések** — Reaktív felület optimista frissítésekkel
+
+## Nyelvek
+
+A felület **kilenc nyelven** érhető el — English, Español, Français, Português,
+தமிழ் (Tamil), Deutsch, Magyar, Polski és Italiano — lefedve az alapalkalmazást
+**és minden modulréteget**, CI által kikényszerített kulcsparitás-teszttel, hogy a
+fordítások ne csúszhassanak szét észrevétlenül. A lengyel a teljes, háromalakú
+többesszám-szabályait használja.
+
+A páciensek felé irányuló kommunikáció (e-mail-sablonok, PDF-ek) jelenleg
+**öt nyelven** készül (es, en, fr, pt, ta); minden rendelő a személyzeti felület
+nyelvétől függetlenül választja meg a kommunikáció nyelvét.
+
+Hiányzik az Ön nyelve? Egy új nyelv hozzáadása kizárólag fordítási feladat — nézze
+meg az [i18n issue-kat](https://github.com/dentalpin/dentalpin/issues?q=label%3Ai18n),
+vagy nyisson újat.
+
+## Fejlesztés
+
+### Előfeltételek
+
+- Docker és Docker Compose
+- Python 3.11+ (a backend helyi fejlesztéséhez)
+- Node.js 18+ (a frontend helyi fejlesztéséhez)
+
+### Futtatás helyben
+
+```bash
+# Minden szolgáltatás indítása
+docker-compose up
+
+# Vagy a backend futtatása külön
+cd backend
+pip install -e ".[dev]"
+uvicorn app.main:app --reload
+
+# Vagy a frontend futtatása külön
+cd frontend
+npm install
+npm run dev
+```
+
+### Adatbázis-kezelés
+
+```bash
+# Adatbázis visszaállítása és a migrációk futtatása
+./scripts/reset-db.sh
+
+# Demóadatok betöltése (angol – alapértelmezett)
+./scripts/seed-demo.sh
+
+# Demóadatok betöltése (spanyol)
+./scripts/seed-demo.sh --lang es
+
+# Teljes beállítás (reset + betöltés egyetlen paranccsal)
+./scripts/setup-demo.sh
+```
+
+### Tesztek futtatása
+
+```bash
+# Backend unit + integrációs tesztek (Dockerben)
+docker-compose exec backend python -m pytest -v
+
+# Lassú Alembic round-trip (opcionális, lásd docs/technical/creating-modules.md)
+docker-compose exec backend python -m pytest -v -m alembic_roundtrip
+
+# Frontend unit tesztek (vitest)
+cd frontend
+npm run test
+```
+
+A **böngészős E2E (Playwright)** a `frontend/tests/e2e/` mappában található, és a
+teljes stacket vezérli a `localhost:3000` → `:8000` címen. A hoszton fut, mert az
+Alpine frontend konténer nem tudja elindítani a Chromiumot.
+
+```bash
+# Egyszeri beállítás
+(cd frontend && npm install && npx playwright install chromium)
+
+# Először győződjön meg róla, hogy a stack fut és fel van töltve adatokkal
+docker-compose up -d
+./scripts/seed-demo.sh
+
+# Teljes E2E csomag (nav + RBAC + páciens-adatlap smoke teszt)
+./scripts/e2e.sh
+
+# Egyetlen fájl
+./scripts/e2e.sh rbac
+
+# Interaktív felület
+./scripts/e2e.sh --ui
+```
+
+Teljes runbook + fixture-referencia: [docs/technical/e2e-testing.md](docs/technical/e2e-testing.md).
+
+## Architektúra
+
+A DentalPin moduláris pluginarchitektúrát használ. Minden funkció önálló modul, amely:
+- Deklarálja a SQLAlchemy-modelljeit
+- FastAPI routert biztosít
+- Feliratkozhat más modulok eseményeire
+
+A részleteket lásd: [ADR 0001 — moduláris pluginarchitektúra](docs/adr/0001-modular-plugin-architecture.md) és [docs/technical/creating-modules.md](docs/technical/creating-modules.md).
+
+## Licenc
+
+Business Source License 1.1 (BSL 1.1)
+
+**Kiegészítő használati engedély:** A DentalPin éles környezetben is használható, amennyiben nem kínálja kereskedelmi SaaS-ként fogorvosi rendelők irányítására.
+
+**Váltás dátuma:** a kiadástól számított 4 év
+
+**Váltás utáni licenc:** Apache 2.0
+
+A teljes feltételeket lásd: [LICENSE](LICENSE).
+
+## Közreműködés
+
+Az irányelveket lásd: [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+Támogatja a [Dentaltix](https://www.dentaltix.com)

--- a/README.it.md
+++ b/README.it.md
@@ -1,0 +1,322 @@
+# DentalPin
+
+[![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
+[![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
+[![fr](https://img.shields.io/badge/lang-fr-blue.svg)](./README.fr.md)
+[![pt](https://img.shields.io/badge/lang-pt-brightgreen.svg)](./README.pt.md)
+[![ta](https://img.shields.io/badge/lang-ta-green.svg)](./README.ta.md)
+[![de](https://img.shields.io/badge/lang-de-black.svg)](./README.de.md)
+[![hu](https://img.shields.io/badge/lang-hu-orange.svg)](./README.hu.md)
+[![pl](https://img.shields.io/badge/lang-pl-lightgrey.svg)](./README.pl.md)
+[![it](https://img.shields.io/badge/lang-it-blueviolet.svg)](./README.it.md)
+
+**Software open source per la gestione dello studio dentistico.** Pazienti,
+odontogramma, agenda, piani di cura, fatturazione e un copilot AI integrato —
+modulare, self-hosted, API-first.
+
+### ▶ [**Prova la demo dal vivo**](https://demo.dentalpin.com)
+
+Accedi con `admin@demo.clinic` / `demo1234` — accesso amministratore completo a uno
+studio con dati di esempio. Si azzera ogni notte, quindi esplora liberamente.
+
+[![DentalPin — scheda paziente con odontogramma](docs/screenshots/patients.png)](https://demo.dentalpin.com)
+
+<sub>[Sito web](https://www.dentalpin.com) · [Documentazione](https://docs.dentalpin.com) · [Telegram](https://t.me/dentalpin) · [Altri screenshot ↓](#screenshot)</sub>
+
+## Perché DentalPin?
+
+Gli studi dentistici di tutto il mondo condividono le stesse esigenze fondamentali: gestire i pazienti, pianificare gli appuntamenti, seguire i trattamenti e amministrare l'attività in modo efficiente. Eppure il panorama software è frammentato in decine di soluzioni localizzate e a codice chiuso che vincolano gli studi a contratti costosi e a tecnologie obsolete.
+
+**Crediamo che sia ora di cambiare.**
+
+DentalPin nasce da una premessa semplice: **un'unica piattaforma aperta per gli studi dentistici di tutto il mondo**. Non l'ennesima soluzione regionale, ma una base globale che ogni studio può adottare, ogni sviluppatore può estendere e ogni comunità può localizzare.
+
+### Perché ora?
+
+L'AI ha cambiato radicalmente ciò che i piccoli team possono costruire. Funzionalità che un tempo richiedevano grandi reparti di sviluppo oggi possono essere implementate in pochi giorni. Questa è la nostra occasione per creare il software dentale open source che avrebbe dovuto esistere già anni fa — prima che gli studi restassero intrappolati in sistemi legacy da cui non possono uscire.
+
+### I nostri principi
+
+- **Open source** — I dati del tuo studio appartengono a te. Anche il tuo software dovrebbe.
+- **Modulare** — Inizia in modo semplice, aggiungi ciò che ti serve. Non pagare per funzionalità che non userai mai.
+- **Globale per progettazione** — Pensato per la localizzazione fin dal primo giorno. Stesso nucleo, qualsiasi lingua, qualsiasi paese.
+- **API-first** — Ogni funzionalità è una API. Integra con qualsiasi cosa, automatizza tutto.
+- **Pronto per l'AI** — Strutturato per l'era dell'AI. Pronto per la pianificazione intelligente, il supporto alle decisioni cliniche e l'automazione dei flussi di lavoro.
+
+### La visione
+
+Non stiamo solo costruendo un software: stiamo costruendo le fondamenta di un ecosistema. Una piattaforma in cui gli sviluppatori contribuiscono con moduli, gli studi condividono i miglioramenti e l'intera comunità odontoiatrica beneficia dell'innovazione collettiva.
+
+Gli studi meritano di meglio del software chiuso e costoso del decennio scorso. DentalPin è l'alternativa aperta.
+
+## ✨ AI Copilot
+
+DentalPin include un **assistente AI agentico integrato** che trasforma l'intero studio in qualcosa con cui puoi semplicemente parlare. Chiedigli di trovare un paziente, liberare uno slot, sollecitare un preventivo rimasto senza risposta o farti un riepilogo della giornata — in normale spagnolo o inglese — e agisce sui tuoi dati reali.
+
+![AI Copilot](docs/screenshots/ia.png)
+
+Non è un chatbot appiccicato sopra. Il Copilot è un vero agente che **pianifica ed esegue attività in più passaggi** richiamando le stesse operazioni dell'interfaccia, su pazienti, agenda, richiami, preventivi, pagamenti e report.
+
+- **Agisce, non si limita a rispondere.** L'agente esegue strumenti reali — cercare pazienti, prenotare o riprogrammare appuntamenti, registrare un pagamento, estrarre gli incassi del mese — e li concatena per completare un'attività dall'inizio alla fine.
+- **Non può mai superare il tuo ruolo.** Ogni chiamata a uno strumento viene riverificata rispetto ai permessi RBAC dell'utente chiamante nel punto di controllo dell'esecuzione. Il Copilot può vedere e fare *esattamente* ciò che quell'utente potrebbe fare dall'interfaccia — niente di più, limitatamente al suo studio.
+- **I tuoi dati sono protetti.** I dati sanitari (PHI) vengono oscurati prima che qualsiasi cosa raggiunga il provider LLM: nomi dei pazienti, telefoni, e-mail e identificativi vengono sostituiti con token deterministici, e gli strumenti clinici a testo libero sono del tutto esclusi dal percorso cloud. L'oscuramento è attivo per impostazione predefinita.
+- **Le scritture chiedono prima.** Qualsiasi azione che modifica i dati (prenotazioni, pagamenti, modifiche) si mette in pausa durante la conversazione in attesa della tua conferma esplicita prima di essere eseguita.
+- **Flussi di lavoro guidati.** Playbook pronti all'uso — *Riepilogo del giorno*, *Prepara una visita*, *Riempi un buco in agenda*, *Richiami in scadenza*, *Preventivi senza risposta* — avviano con un tocco le attività multi-passaggio più comuni.
+- **Riepiloghi proattivi.** Attiva, se vuoi, un digest mattutino deterministico inviato via e-mail al tuo team, con il riepilogo dell'agenda del giorno, dei richiami in scadenza e dei preventivi aperti — senza LLM, senza dati sanitari fuori sede.
+- **Modulare per progettazione.** Il Copilot utilizza gli strumenti pubblicati da ciascun modulo attraverso un registro condiviso; ogni modulo contribuisce con le proprie capacità, quindi l'agente cresce automaticamente man mano che si installano nuovi moduli.
+
+Indipendente dal fornitore sotto il cofano (un'astrazione del provider LLM), con provider, modello e budget di token per studio configurabili per ogni installazione. Architettura: [docs/technical/copilot-agentic-architecture.md](docs/technical/copilot-agentic-architecture.md).
+
+## Sito web
+
+Visita [**dentalpin.com**](https://www.dentalpin.com) per informazioni sul prodotto, funzionalità e dettagli commerciali.
+
+## Community
+
+Unisciti al nostro [**canale Telegram**](https://t.me/dentalpin) per supporto, aiuto con l'installazione e domande.
+
+## Screenshot
+
+### Dashboard
+![Dashboard](docs/screenshots/home.png)
+
+### Gestione pazienti
+![Patients](docs/screenshots/patients.png)
+
+### Agenda settimanale
+![Weekly Schedule](docs/screenshots/schedule-week.png)
+
+### Agenda Kanban
+![Kanban Schedule](docs/screenshots/schedule-canban.png)
+
+### Grafico dei pagamenti
+![Payments Chart](docs/screenshots/payments-chart.png)
+
+### Impostazioni
+![Settings](docs/screenshots/settings.png)
+
+## Installazione
+
+Immagini precompilate, senza clone, senza build. Su qualsiasi server con Docker:
+
+```bash
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/Caddyfile
+curl -o .env https://raw.githubusercontent.com/dentalpin/dentalpin/main/.env.prod.example
+
+# Imposta PUBLIC_URL, POSTGRES_PASSWORD e SECRET_KEY in .env, poi:
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Punta un dominio al server, imposta `PUBLIC_URL=https://your-domain` e il TLS viene
+configurato al primo avvio — Caddy serve entrambi i servizi da un'unica origin,
+quindi niente CORS e nessun certificato da rinnovare. Imposta `SEED_ON_STARTUP=1`
+per caricare lo studio demo e dare un'occhiata prima di andare in produzione.
+
+Immagini: [`dentalpin-backend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-backend) ·
+[`dentalpin-frontend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-frontend)
+
+## Avvio rapido (sviluppo)
+
+Compila dai sorgenti con hot reload:
+
+```bash
+# Avvia i servizi
+docker-compose up -d
+
+# Carica i dati demo (inglese per impostazione predefinita)
+./scripts/seed-demo.sh
+
+# Oppure carica in spagnolo
+./scripts/seed-demo.sh --lang es
+
+# Studio demo India GST (interfaccia in tamil, o in inglese con --country in)
+./scripts/seed-demo.sh --lang ta
+```
+
+Apri http://localhost:3000
+
+### Credenziali demo
+
+Tutti gli utenti hanno la password: `demo1234`
+
+| E-mail | Ruolo | Nome (EN) | Nome (ES) |
+|--------|-------|-----------|-----------|
+| admin@demo.clinic | admin | Admin Demo | Admin Demo |
+| dentist@demo.clinic | dentist | Dr. Sarah Johnson | Dra. María García López |
+| hygienist@demo.clinic | hygienist | Michael Williams | Carlos López Martínez |
+| assistant@demo.clinic | assistant | Emily Davis | Ana Martínez Ruiz |
+| receptionist@demo.clinic | receptionist | Jessica Brown | Laura Sánchez Pérez |
+
+Per tutti i dettagli sui dati demo consulta [docs/user-manual/en/demo.md](docs/user-manual/en/demo.md).
+
+## Stack tecnologico
+
+| Livello | Tecnologia |
+|---------|------------|
+| Backend | FastAPI (Python 3.11+) |
+| Frontend | Nuxt 3 + Nuxt UI |
+| Database | PostgreSQL 15 |
+| Autenticazione | JWT con refresh token |
+
+## Funzionalità
+
+### AI Copilot
+- **Assistente agentico** — Agente conversazionale che pianifica ed esegue attività multi-passaggio su pazienti, agenda, richiami, preventivi, pagamenti e report richiamando operazioni reali
+- **Parità RBAC** — Ogni azione riverificata rispetto ai permessi dell'utente; l'agente può fare solo ciò che quell'utente potrebbe fare dall'interfaccia, limitatamente al suo studio
+- **Oscuramento dei dati sanitari (PHI)** — Identificativi dei pazienti tokenizzati prima di raggiungere l'LLM; i dati clinici a testo libero restano fuori dal percorso cloud. Attivo per impostazione predefinita
+- **Scritture confermate** — Le azioni che modificano i dati si fermano durante la conversazione in attesa della conferma esplicita dell'utente
+- **Flussi di lavoro e digest** — Playbook con un tocco (riepilogo del giorno, preparazione di una visita, riempimento di un buco in agenda) più un digest mattutino proattivo via e-mail attivabile su richiesta
+- **Multilingue e indipendente dal fornitore** — Ti parla nella lingua della tua interfaccia; provider LLM, modello e budget di token per studio configurabili
+
+### Gestione clinica
+- **Cartelle dei pazienti** — Profili completi con dati personali, contatti, anamnesi e note
+- **Scheda dentale (odontogramma)** — Diagramma interattivo dei denti con tracciamento dei trattamenti per dente/superficie
+- **Calendario appuntamenti** — Viste settimanale e giornaliera con drag & drop, colonne per professionista, rilevamento dei conflitti
+- **Catalogo trattamenti** — Catalogo personalizzabile con codici, prezzi, aliquote IVA e categorie
+
+### Gestione finanziaria
+- **Preventivi** — Creazione di preventivi di cura, tracciamento del flusso di approvazione (bozza → in attesa → approvato/rifiutato), acquisizione della firma del paziente, generazione PDF
+- **Fatture** — Generazione di fatture da preventivi o autonome, numerazione automatica, metodi di pagamento multipli, esportazione PDF
+- **Pagamenti** — Tracciamento dei pagamenti parziali, storico dei pagamenti, calcolo del saldo
+
+### Gestione dello studio
+- **Controllo degli accessi basato sui ruoli** — Cinque ruoli (amministratore, dentista, igienista, assistente, receptionist) con permessi granulari
+- **Gestione sale/riuniti** — Definizione delle sale di trattamento con orari e colori
+- **Gestione dei professionisti** — Assegnazione degli appuntamenti a specifici dentisti/igienisti
+
+### Esperienza utente
+- **Selettori visuali** — Menu a tendina intelligenti con i pazienti recenti e i trattamenti più richiesti
+- **Interfaccia in nove lingue** — inglese, spagnolo, francese, portoghese, tamil, tedesco, ungherese, polacco e italiano — app principale e ogni modulo
+- **Modalità scura** — Cambio di tema in base alle impostazioni di sistema
+- **Design responsive** — Funziona su desktop e tablet
+
+### Funzionalità tecniche
+- **Architettura modulare** — Sistema a plugin per un'estensibilità semplice
+- **Bus di eventi** — Comunicazione tra moduli per notifiche e integrazioni
+- **API REST** — API completa con documentazione OpenAPI
+- **Aggiornamenti in tempo reale** — Interfaccia reattiva con aggiornamenti ottimistici
+
+## Lingue
+
+L'interfaccia è disponibile in **nove lingue** — English, Español, Français,
+Português, தமிழ் (Tamil), Deutsch, Magyar, Polski e Italiano — coprendo l'app
+principale **e ogni layer dei moduli**, con un test di parità delle chiavi imposto
+dalla CI che impedisce alle localizzazioni di divergere silenziosamente. Il polacco
+usa le sue regole complete di plurale a tre forme.
+
+Le comunicazioni rivolte ai pazienti (template e-mail, PDF) sono attualmente
+disponibili in **cinque lingue** (es, en, fr, pt, ta); ogni studio sceglie la lingua
+di comunicazione indipendentemente dalla lingua dell'interfaccia del personale.
+
+Vuoi la tua lingua? Aggiungerne una è un contributo di sola traduzione — consulta le
+[issue i18n](https://github.com/dentalpin/dentalpin/issues?q=label%3Ai18n) o aprine
+una nuova.
+
+## Sviluppo
+
+### Prerequisiti
+
+- Docker e Docker Compose
+- Python 3.11+ (per lo sviluppo locale del backend)
+- Node.js 18+ (per lo sviluppo locale del frontend)
+
+### Esecuzione in locale
+
+```bash
+# Avvia tutti i servizi
+docker-compose up
+
+# Oppure esegui il backend separatamente
+cd backend
+pip install -e ".[dev]"
+uvicorn app.main:app --reload
+
+# Oppure esegui il frontend separatamente
+cd frontend
+npm install
+npm run dev
+```
+
+### Gestione del database
+
+```bash
+# Resetta il database ed esegui le migrazioni
+./scripts/reset-db.sh
+
+# Carica i dati demo (inglese - predefinito)
+./scripts/seed-demo.sh
+
+# Carica i dati demo (spagnolo)
+./scripts/seed-demo.sh --lang es
+
+# Configurazione completa (reset + seed in un solo comando)
+./scripts/setup-demo.sh
+```
+
+### Esecuzione dei test
+
+```bash
+# Unit + integrazione backend (in Docker)
+docker-compose exec backend python -m pytest -v
+
+# Round-trip Alembic lento (opzionale, vedi docs/technical/creating-modules.md)
+docker-compose exec backend python -m pytest -v -m alembic_roundtrip
+
+# Unit frontend (vitest)
+cd frontend
+npm run test
+```
+
+**L'E2E nel browser (Playwright)** si trova in `frontend/tests/e2e/` e pilota
+l'intero stack su `localhost:3000` → `:8000`. Gira sull'host perché il container
+frontend Alpine non può avviare Chromium.
+
+```bash
+# Configurazione una tantum
+(cd frontend && npm install && npx playwright install chromium)
+
+# Assicurati prima che lo stack sia attivo e con i dati caricati
+docker-compose up -d
+./scripts/seed-demo.sh
+
+# Suite E2E completa (nav + RBAC + smoke test della scheda paziente)
+./scripts/e2e.sh
+
+# Singolo file
+./scripts/e2e.sh rbac
+
+# Interfaccia interattiva
+./scripts/e2e.sh --ui
+```
+
+Runbook completo + riferimento alle fixture: [docs/technical/e2e-testing.md](docs/technical/e2e-testing.md).
+
+## Architettura
+
+DentalPin utilizza un'architettura modulare a plugin. Ogni funzionalità è un modulo autonomo che:
+- Dichiara i propri modelli SQLAlchemy
+- Fornisce un router FastAPI
+- Può sottoscrivere eventi di altri moduli
+
+Per i dettagli consulta [ADR 0001 — architettura modulare a plugin](docs/adr/0001-modular-plugin-architecture.md) e [docs/technical/creating-modules.md](docs/technical/creating-modules.md).
+
+## Licenza
+
+Business Source License 1.1 (BSL 1.1)
+
+**Concessione d'uso aggiuntiva:** Puoi usare DentalPin in produzione, purché tu non lo offra come SaaS commerciale per la gestione di studi dentistici.
+
+**Data di cambio:** 4 anni dal rilascio
+
+**Licenza di cambio:** Apache 2.0
+
+Per i termini completi consulta [LICENSE](LICENSE).
+
+## Contribuire
+
+Per le linee guida consulta [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+Sostenuto da [Dentaltix](https://www.dentaltix.com)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 [![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
 [![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
 [![fr](https://img.shields.io/badge/lang-fr-blue.svg)](./README.fr.md)
+[![pt](https://img.shields.io/badge/lang-pt-brightgreen.svg)](./README.pt.md)
 [![ta](https://img.shields.io/badge/lang-ta-green.svg)](./README.ta.md)
+[![de](https://img.shields.io/badge/lang-de-black.svg)](./README.de.md)
+[![hu](https://img.shields.io/badge/lang-hu-orange.svg)](./README.hu.md)
+[![pl](https://img.shields.io/badge/lang-pl-lightgrey.svg)](./README.pl.md)
+[![it](https://img.shields.io/badge/lang-it-blueviolet.svg)](./README.it.md)
 
 **Open source dental clinic management software.** Patients, odontogram, scheduling,
 treatment plans, billing and a built-in AI copilot — modular, self-hosted, API-first.
@@ -123,6 +128,9 @@ docker-compose up -d
 
 # Or seed in Spanish
 ./scripts/seed-demo.sh --lang es
+
+# India GST demo clinic (Tamil UI, or English UI with --country in)
+./scripts/seed-demo.sh --lang ta
 ```
 
 Open http://localhost:3000
@@ -139,7 +147,7 @@ All users have password: `demo1234`
 | assistant@demo.clinic | assistant | Emily Davis | Ana Martínez Ruiz |
 | receptionist@demo.clinic | receptionist | Jessica Brown | Laura Sánchez Pérez |
 
-See [docs/user-manual/demo.md](docs/user-manual/demo.md) for full details on demo data.
+See [docs/user-manual/en/demo.md](docs/user-manual/en/demo.md) for full details on demo data.
 
 ## Tech Stack
 
@@ -158,7 +166,7 @@ See [docs/user-manual/demo.md](docs/user-manual/demo.md) for full details on dem
 - **PHI Redaction** — Patient identifiers tokenized before reaching the LLM; free-text clinical data stays off the cloud path. On by default
 - **Confirmed Writes** — Data-changing actions pause for explicit user confirmation mid-conversation
 - **Workflows & Digest** — One-tap playbooks (daily briefing, prepare a visit, fill a gap) plus an opt-in proactive morning email digest
-- **Bilingual & Vendor-Agnostic** — Works in Spanish and English; configurable LLM provider, model, and per-clinic token budget
+- **Multilingual & Vendor-Agnostic** — Talks to you in the language of your UI; configurable LLM provider, model, and per-clinic token budget
 
 ### Clinical Management
 - **Patient Records** — Complete patient profiles with personal data, contact info, medical history, and notes
@@ -178,7 +186,7 @@ See [docs/user-manual/demo.md](docs/user-manual/demo.md) for full details on dem
 
 ### User Experience
 - **Visual Selectors** — Smart dropdowns showing recent patients and popular treatments
-- **Bilingual Interface** — Full Spanish and English localization
+- **Nine-Language Interface** — English, Spanish, French, Portuguese, Tamil, German, Hungarian, Polish and Italian — core app and every module
 - **Dark Mode** — System-aware theme switching
 - **Responsive Design** — Works on desktop and tablet
 
@@ -187,6 +195,21 @@ See [docs/user-manual/demo.md](docs/user-manual/demo.md) for full details on dem
 - **Event Bus** — Inter-module communication for notifications and integrations
 - **REST API** — Complete API with OpenAPI documentation
 - **Real-time Updates** — Reactive UI with optimistic updates
+
+## Languages
+
+The interface ships in **nine languages** — English, Español, Français, Português,
+தமிழ் (Tamil), Deutsch, Magyar, Polski and Italiano — covering the core app **and
+every module layer**, with a CI-enforced key-parity test so locales can't silently
+drift. Polish uses its full three-form plural rules.
+
+Patient-facing communications (email templates, PDFs) currently render in
+**five languages** (es, en, fr, pt, ta); each clinic picks its communication
+language independently of the staff UI language.
+
+Want your language? Adding one is a translation-only contribution — see the
+[i18n issues](https://github.com/dentalpin/dentalpin/issues?q=label%3Ai18n) or
+open a new one.
 
 ## Development
 
@@ -274,7 +297,7 @@ DentalPin uses a modular plugin architecture. Each feature is a self-contained m
 - Provides a FastAPI router
 - Can subscribe to events from other modules
 
-See [docs/architecture.md](docs/architecture.md) for details.
+See [ADR 0001 — modular plugin architecture](docs/adr/0001-modular-plugin-architecture.md) and [docs/technical/creating-modules.md](docs/technical/creating-modules.md) for details.
 
 ## License
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,0 +1,322 @@
+# DentalPin
+
+[![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
+[![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
+[![fr](https://img.shields.io/badge/lang-fr-blue.svg)](./README.fr.md)
+[![pt](https://img.shields.io/badge/lang-pt-brightgreen.svg)](./README.pt.md)
+[![ta](https://img.shields.io/badge/lang-ta-green.svg)](./README.ta.md)
+[![de](https://img.shields.io/badge/lang-de-black.svg)](./README.de.md)
+[![hu](https://img.shields.io/badge/lang-hu-orange.svg)](./README.hu.md)
+[![pl](https://img.shields.io/badge/lang-pl-lightgrey.svg)](./README.pl.md)
+[![it](https://img.shields.io/badge/lang-it-blueviolet.svg)](./README.it.md)
+
+**Oprogramowanie open source do zarządzania gabinetem stomatologicznym.** Pacjenci,
+diagram zębowy, terminarz, plany leczenia, fakturowanie i wbudowany copilot AI —
+modułowe, self-hosted, API-first.
+
+### ▶ [**Wypróbuj demo na żywo**](https://demo.dentalpin.com)
+
+Zaloguj się jako `admin@demo.clinic` / `demo1234` — pełny dostęp administratora do
+gabinetu z przykładowymi danymi. Baza resetuje się co noc, więc śmiało testuj wszystko.
+
+[![DentalPin — karta pacjenta z diagramem zębowym](docs/screenshots/patients.png)](https://demo.dentalpin.com)
+
+<sub>[Strona](https://www.dentalpin.com) · [Dokumentacja](https://docs.dentalpin.com) · [Telegram](https://t.me/dentalpin) · [Więcej zrzutów ekranu ↓](#zrzuty-ekranu)</sub>
+
+## Dlaczego DentalPin?
+
+Gabinety stomatologiczne na całym świecie mają te same podstawowe potrzeby: zarządzanie pacjentami, planowanie wizyt, śledzenie leczenia i sprawne prowadzenie praktyki. Tymczasem rynek oprogramowania jest rozdrobniony na dziesiątki lokalnych, zamkniętych rozwiązań, które wiążą gabinety kosztownymi umowami i przestarzałą technologią.
+
+**Uważamy, że czas na zmianę.**
+
+DentalPin opiera się na prostym założeniu: **jedna otwarta platforma dla gabinetów stomatologicznych na całym świecie**. Nie kolejne rozwiązanie regionalne, lecz globalny fundament, który każdy gabinet może wdrożyć, każdy programista rozszerzyć, a każda społeczność zlokalizować.
+
+### Dlaczego teraz?
+
+AI fundamentalnie zmieniła to, co mogą zbudować małe zespoły. Funkcje, które kiedyś wymagały dużych działów rozwoju, dziś można wdrożyć w kilka dni. To nasza szansa, aby stworzyć otwarte oprogramowanie stomatologiczne, które powinno istnieć już lata temu — zanim gabinety zostały uwięzione w systemach legacy, z których nie mogą się wydostać.
+
+### Nasze zasady
+
+- **Open source** — Dane Twojego gabinetu należą do Ciebie. Twoje oprogramowanie też powinno.
+- **Modułowość** — Zacznij prosto, dodawaj to, czego potrzebujesz. Nie płać za funkcje, których nigdy nie użyjesz.
+- **Globalność w założeniu** — Zaprojektowany z myślą o lokalizacji od pierwszego dnia. Ten sam rdzeń, dowolny język, dowolny kraj.
+- **API-first** — Każda funkcja to API. Integruj z czymkolwiek, automatyzuj wszystko.
+- **Gotowość na AI** — Zbudowany z myślą o erze AI. Gotowy na inteligentne planowanie wizyt, wsparcie decyzji klinicznych i automatyzację pracy.
+
+### Wizja
+
+Nie budujemy tylko oprogramowania — budujemy fundament ekosystemu. Platformę, w której programiści tworzą moduły, gabinety dzielą się usprawnieniami, a cała społeczność stomatologiczna korzysta ze wspólnych innowacji.
+
+Gabinety zasługują na coś lepszego niż zamknięte, drogie oprogramowanie sprzed dekady. DentalPin to otwarta alternatywa.
+
+## ✨ AI Copilot
+
+DentalPin ma wbudowanego **agentowego asystenta AI**, który zamienia cały gabinet w coś, z czym można po prostu porozmawiać. Poproś go o znalezienie pacjenta, zwolnienie terminu, upomnienie się o kosztorys bez odpowiedzi albo podsumowanie nadchodzącego dnia — zwykłym hiszpańskim lub angielskim — a on działa na Twoich prawdziwych danych.
+
+![AI Copilot](docs/screenshots/ia.png)
+
+To nie chatbot doklejony na wierzch. Copilot to prawdziwy agent, który **planuje i wykonuje wieloetapowe zadania**, wywołując te same operacje co interfejs — na pacjentach, terminarzu, wizytach kontrolnych, kosztorysach, płatnościach i raportach.
+
+- **Działa, a nie tylko odpowiada.** Agent uruchamia prawdziwe narzędzia — wyszukuje pacjentów, umawia lub przekłada wizyty, rejestruje płatność, pobiera wpływy z bieżącego miesiąca — i łączy je w łańcuch, aby wykonać zadanie od początku do końca.
+- **Nigdy nie przekroczy Twojej roli.** Każde wywołanie narzędzia jest ponownie sprawdzane względem uprawnień RBAC wywołującego użytkownika w punkcie kontrolnym wykonania. Copilot widzi i robi *dokładnie* to, co dany użytkownik mógłby zrobić przez interfejs — nic więcej, w granicach jego gabinetu.
+- **Twoje dane są chronione.** Dane medyczne (PHI) są maskowane, zanim cokolwiek trafi do dostawcy LLM: imiona i nazwiska pacjentów, telefony, e-maile i identyfikatory są zastępowane deterministycznymi tokenami, a narzędzia kliniczne operujące na tekście swobodnym są całkowicie wyłączone ze ścieżki chmurowej. Maskowanie jest domyślnie włączone.
+- **Zapisy najpierw pytają.** Każda akcja zmieniająca dane (rezerwacje, płatności, edycje) zatrzymuje się w trakcie rozmowy i czeka na Twoje wyraźne potwierdzenie przed wykonaniem.
+- **Prowadzone przepływy pracy.** Gotowe scenariusze — *Poranne podsumowanie*, *Przygotuj wizytę*, *Wypełnij lukę*, *Zaległe wizyty kontrolne*, *Kosztorysy bez odpowiedzi* — uruchamiają typowe wieloetapowe zadania jednym dotknięciem.
+- **Proaktywne podsumowania.** Włącz deterministyczny poranny raport wysyłany e-mailem do Twojego zespołu, podsumowujący plan dnia, zaległe wizyty kontrolne i otwarte kosztorysy — bez LLM, bez danych medycznych poza serwerem.
+- **Modułowy w założeniu.** Copilot korzysta z narzędzi publikowanych przez każdy moduł we wspólnym rejestrze; każdy moduł wnosi własne możliwości, więc agent rozwija się automatycznie wraz z instalowaniem nowych modułów.
+
+Pod maską niezależny od dostawcy (abstrakcja dostawcy LLM), z konfigurowanym per wdrożenie dostawcą, modelem i budżetem tokenów dla każdego gabinetu. Architektura: [docs/technical/copilot-agentic-architecture.md](docs/technical/copilot-agentic-architecture.md).
+
+## Strona internetowa
+
+Odwiedź [**dentalpin.com**](https://www.dentalpin.com), aby poznać informacje o produkcie, funkcje i szczegóły komercyjne.
+
+## Społeczność
+
+Dołącz do naszego [**kanału na Telegramie**](https://t.me/dentalpin) — wsparcie, pomoc w instalacji i pytania.
+
+## Zrzuty ekranu
+
+### Pulpit
+![Dashboard](docs/screenshots/home.png)
+
+### Zarządzanie pacjentami
+![Patients](docs/screenshots/patients.png)
+
+### Terminarz tygodniowy
+![Weekly Schedule](docs/screenshots/schedule-week.png)
+
+### Terminarz Kanban
+![Kanban Schedule](docs/screenshots/schedule-canban.png)
+
+### Wykres płatności
+![Payments Chart](docs/screenshots/payments-chart.png)
+
+### Ustawienia
+![Settings](docs/screenshots/settings.png)
+
+## Instalacja
+
+Gotowe obrazy, bez klonowania, bez budowania. Na dowolnym serwerze z Dockerem:
+
+```bash
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/Caddyfile
+curl -o .env https://raw.githubusercontent.com/dentalpin/dentalpin/main/.env.prod.example
+
+# Ustaw PUBLIC_URL, POSTGRES_PASSWORD i SECRET_KEY w .env, a następnie:
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Skieruj domenę na serwer, ustaw `PUBLIC_URL=https://your-domain`, a TLS zostanie
+skonfigurowany przy pierwszym uruchomieniu — Caddy obsługuje obie usługi z jednego
+originu, więc nie ma CORS ani certyfikatu do odnawiania. Ustaw `SEED_ON_STARTUP=1`,
+aby załadować gabinet demo i rozejrzeć się przed startem produkcyjnym.
+
+Obrazy: [`dentalpin-backend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-backend) ·
+[`dentalpin-frontend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-frontend)
+
+## Szybki start (rozwój)
+
+Buduje ze źródeł z hot reload:
+
+```bash
+# Uruchom usługi
+docker-compose up -d
+
+# Załaduj dane demo (domyślnie po angielsku)
+./scripts/seed-demo.sh
+
+# Lub załaduj po hiszpańsku
+./scripts/seed-demo.sh --lang es
+
+# Gabinet demo India GST (interfejs tamilski lub angielski z --country in)
+./scripts/seed-demo.sh --lang ta
+```
+
+Otwórz http://localhost:3000
+
+### Dane logowania do demo
+
+Wszyscy użytkownicy mają hasło: `demo1234`
+
+| E-mail | Rola | Imię i nazwisko (EN) | Imię i nazwisko (ES) |
+|--------|------|----------------------|----------------------|
+| admin@demo.clinic | admin | Admin Demo | Admin Demo |
+| dentist@demo.clinic | dentist | Dr. Sarah Johnson | Dra. María García López |
+| hygienist@demo.clinic | hygienist | Michael Williams | Carlos López Martínez |
+| assistant@demo.clinic | assistant | Emily Davis | Ana Martínez Ruiz |
+| receptionist@demo.clinic | receptionist | Jessica Brown | Laura Sánchez Pérez |
+
+Pełne informacje o danych demo znajdziesz w [docs/user-manual/en/demo.md](docs/user-manual/en/demo.md).
+
+## Stack technologiczny
+
+| Warstwa | Technologia |
+|---------|-------------|
+| Backend | FastAPI (Python 3.11+) |
+| Frontend | Nuxt 3 + Nuxt UI |
+| Baza danych | PostgreSQL 15 |
+| Uwierzytelnianie | JWT z refresh tokenami |
+
+## Funkcje
+
+### AI Copilot
+- **Agentowy asystent** — Konwersacyjny agent, który planuje i wykonuje wieloetapowe zadania na pacjentach, terminarzu, wizytach kontrolnych, kosztorysach, płatnościach i raportach, wywołując prawdziwe operacje
+- **Parytet RBAC** — Każda akcja ponownie sprawdzana względem uprawnień użytkownika; agent może zrobić tylko to, co dany użytkownik mógłby zrobić przez interfejs, w granicach jego gabinetu
+- **Maskowanie danych medycznych (PHI)** — Identyfikatory pacjentów tokenizowane, zanim dotrą do LLM; kliniczne dane tekstowe pozostają poza ścieżką chmurową. Domyślnie włączone
+- **Potwierdzane zapisy** — Akcje zmieniające dane zatrzymują się w trakcie rozmowy do wyraźnego potwierdzenia przez użytkownika
+- **Przepływy pracy i raport dnia** — Scenariusze na jedno dotknięcie (poranne podsumowanie, przygotowanie wizyty, wypełnienie luki) oraz opcjonalny proaktywny poranny raport e-mail
+- **Wielojęzyczny i niezależny od dostawcy** — Rozmawia z Tobą w języku Twojego interfejsu; konfigurowalny dostawca LLM, model i budżet tokenów per gabinet
+
+### Zarządzanie kliniczne
+- **Kartoteki pacjentów** — Kompletne profile pacjentów z danymi osobowymi, kontaktowymi, historią medyczną i notatkami
+- **Diagram zębowy (odontogram)** — Interaktywny diagram zębów ze śledzeniem leczenia dla każdego zęba/powierzchni
+- **Kalendarz wizyt** — Widoki tygodniowy i dzienny z przeciąganiem i upuszczaniem, kolumnami specjalistów, wykrywaniem konfliktów
+- **Katalog zabiegów** — Konfigurowalny katalog z kodami, cenami, stawkami VAT i kategoriami
+
+### Zarządzanie finansami
+- **Kosztorysy** — Tworzenie kosztorysów leczenia, śledzenie procesu akceptacji (szkic → oczekujący → zaakceptowany/odrzucony), podpis pacjenta, generowanie PDF
+- **Faktury** — Generowanie faktur z kosztorysów lub samodzielnych, automatyczna numeracja, wiele metod płatności, eksport do PDF
+- **Płatności** — Śledzenie płatności częściowych, historia płatności, wyliczanie salda
+
+### Zarządzanie gabinetem
+- **Kontrola dostępu oparta na rolach** — Pięć ról (administrator, dentysta, higienistka, asystent, recepcjonista) z granularnymi uprawnieniami
+- **Zarządzanie gabinetami/salami** — Definiowanie sal zabiegowych z harmonogramami i kolorami
+- **Zarządzanie specjalistami** — Przypisywanie wizyt do konkretnych dentystów/higienistek
+
+### Doświadczenie użytkownika
+- **Selektory wizualne** — Inteligentne listy rozwijane z ostatnimi pacjentami i popularnymi zabiegami
+- **Interfejs w dziewięciu językach** — angielski, hiszpański, francuski, portugalski, tamilski, niemiecki, węgierski, polski i włoski — rdzeń aplikacji i każdy moduł
+- **Tryb ciemny** — Przełączanie motywu zgodnie z ustawieniami systemu
+- **Responsywny design** — Działa na komputerze i tablecie
+
+### Funkcje techniczne
+- **Architektura modułowa** — System oparty na pluginach zapewniający łatwą rozszerzalność
+- **Szyna zdarzeń** — Komunikacja między modułami dla powiadomień i integracji
+- **REST API** — Kompletne API z dokumentacją OpenAPI
+- **Aktualizacje w czasie rzeczywistym** — Reaktywny interfejs z optymistycznymi aktualizacjami
+
+## Języki
+
+Interfejs jest dostępny w **dziewięciu językach** — English, Español, Français,
+Português, தமிழ் (Tamil), Deutsch, Magyar, Polski i Italiano — obejmując rdzeń
+aplikacji **i każdą warstwę modułów**, z wymuszanym przez CI testem parytetu kluczy,
+dzięki któremu tłumaczenia nie mogą się po cichu rozjechać. Polski używa pełnych
+trzech form liczby mnogiej.
+
+Komunikacja kierowana do pacjentów (szablony e-mail, PDF-y) jest obecnie generowana
+w **pięciu językach** (es, en, fr, pt, ta); każdy gabinet wybiera język komunikacji
+niezależnie od języka interfejsu personelu.
+
+Chcesz swój język? Dodanie języka to wkład czysto tłumaczeniowy — zobacz
+[zgłoszenia i18n](https://github.com/dentalpin/dentalpin/issues?q=label%3Ai18n)
+lub otwórz nowe.
+
+## Rozwój
+
+### Wymagania wstępne
+
+- Docker i Docker Compose
+- Python 3.11+ (do lokalnej pracy nad backendem)
+- Node.js 18+ (do lokalnej pracy nad frontendem)
+
+### Uruchamianie lokalnie
+
+```bash
+# Uruchom wszystkie usługi
+docker-compose up
+
+# Lub uruchom backend osobno
+cd backend
+pip install -e ".[dev]"
+uvicorn app.main:app --reload
+
+# Lub uruchom frontend osobno
+cd frontend
+npm install
+npm run dev
+```
+
+### Zarządzanie bazą danych
+
+```bash
+# Zresetuj bazę danych i uruchom migracje
+./scripts/reset-db.sh
+
+# Załaduj dane demo (angielski — domyślnie)
+./scripts/seed-demo.sh
+
+# Załaduj dane demo (hiszpański)
+./scripts/seed-demo.sh --lang es
+
+# Pełna konfiguracja (reset + dane demo jednym poleceniem)
+./scripts/setup-demo.sh
+```
+
+### Uruchamianie testów
+
+```bash
+# Testy jednostkowe + integracyjne backendu (w Dockerze)
+docker-compose exec backend python -m pytest -v
+
+# Wolny round-trip Alembic (opcjonalny, zobacz docs/technical/creating-modules.md)
+docker-compose exec backend python -m pytest -v -m alembic_roundtrip
+
+# Testy jednostkowe frontendu (vitest)
+cd frontend
+npm run test
+```
+
+**E2E w przeglądarce (Playwright)** znajduje się w `frontend/tests/e2e/` i steruje
+pełnym stackiem pod `localhost:3000` → `:8000`. Działa na hoście, ponieważ kontener
+frontendu na Alpine nie może uruchomić Chromium.
+
+```bash
+# Jednorazowa konfiguracja
+(cd frontend && npm install && npx playwright install chromium)
+
+# Najpierw upewnij się, że stack działa i ma załadowane dane
+docker-compose up -d
+./scripts/seed-demo.sh
+
+# Pełny zestaw E2E (nawigacja + RBAC + smoke test karty pacjenta)
+./scripts/e2e.sh
+
+# Pojedynczy plik
+./scripts/e2e.sh rbac
+
+# Interaktywny interfejs
+./scripts/e2e.sh --ui
+```
+
+Pełny runbook + opis fixture'ów: [docs/technical/e2e-testing.md](docs/technical/e2e-testing.md).
+
+## Architektura
+
+DentalPin używa modułowej architektury pluginów. Każda funkcja to samodzielny moduł, który:
+- Deklaruje swoje modele SQLAlchemy
+- Udostępnia router FastAPI
+- Może subskrybować zdarzenia innych modułów
+
+Szczegóły znajdziesz w [ADR 0001 — modułowa architektura pluginów](docs/adr/0001-modular-plugin-architecture.md) oraz [docs/technical/creating-modules.md](docs/technical/creating-modules.md).
+
+## Licencja
+
+Business Source License 1.1 (BSL 1.1)
+
+**Dodatkowe prawo użytkowania:** Możesz używać DentalPin produkcyjnie, o ile nie oferujesz go jako komercyjnego SaaS do zarządzania gabinetami stomatologicznymi.
+
+**Data zmiany:** 4 lata od wydania
+
+**Licencja docelowa:** Apache 2.0
+
+Pełne warunki znajdziesz w [LICENSE](LICENSE).
+
+## Współtworzenie
+
+Wytyczne znajdziesz w [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+Wspierane przez [Dentaltix](https://www.dentaltix.com)

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,0 +1,322 @@
+# DentalPin
+
+[![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
+[![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
+[![fr](https://img.shields.io/badge/lang-fr-blue.svg)](./README.fr.md)
+[![pt](https://img.shields.io/badge/lang-pt-brightgreen.svg)](./README.pt.md)
+[![ta](https://img.shields.io/badge/lang-ta-green.svg)](./README.ta.md)
+[![de](https://img.shields.io/badge/lang-de-black.svg)](./README.de.md)
+[![hu](https://img.shields.io/badge/lang-hu-orange.svg)](./README.hu.md)
+[![pl](https://img.shields.io/badge/lang-pl-lightgrey.svg)](./README.pl.md)
+[![it](https://img.shields.io/badge/lang-it-blueviolet.svg)](./README.it.md)
+
+**Software open source de gestão de clínicas dentárias.** Pacientes, odontograma,
+agenda, planos de tratamento, faturação e um Copilot de IA integrado — modular,
+self-hosted e API-first.
+
+### ▶ [**Experimente a demo ao vivo**](https://demo.dentalpin.com)
+
+Entre com `admin@demo.clinic` / `demo1234` — acesso completo de administrador a uma
+clínica com dados de exemplo. É reposta todas as noites, por isso explore à vontade.
+
+[![DentalPin — ficha de paciente com odontograma](docs/screenshots/patients.png)](https://demo.dentalpin.com)
+
+<sub>[Site](https://www.dentalpin.com) · [Documentação](https://docs.dentalpin.com) · [Telegram](https://t.me/dentalpin) · [Mais capturas ↓](#capturas-de-ecrã)</sub>
+
+## Porquê o DentalPin?
+
+As clínicas dentárias de todo o mundo partilham as mesmas necessidades fundamentais: gerir pacientes, marcar consultas, acompanhar tratamentos e gerir a sua prática de forma eficiente. No entanto, o panorama do software está fragmentado em dezenas de soluções localizadas e de código fechado que prendem as clínicas a contratos caros e a tecnologia ultrapassada.
+
+**Acreditamos que está na hora de mudar.**
+
+O DentalPin assenta numa premissa simples: **uma plataforma aberta para clínicas dentárias em qualquer lugar**. Não mais uma solução regional, mas uma base global que qualquer clínica pode adotar, qualquer programador pode estender e qualquer comunidade pode localizar.
+
+### Porquê agora?
+
+A IA mudou fundamentalmente o que as equipas pequenas conseguem construir. Funcionalidades que antes exigiam grandes departamentos de desenvolvimento podem agora ser implementadas em dias. Esta é a nossa janela para criar o software dentário open source que já devia existir há anos — antes de as clínicas ficarem presas a sistemas legacy dos quais não conseguem escapar.
+
+### Os nossos princípios
+
+- **Open Source** — Os dados da sua clínica pertencem-lhe. O seu software também.
+- **Modular** — Comece simples, adicione o que precisar. Não pague por funcionalidades que nunca vai usar.
+- **Global por Design** — Construído para a localização desde o primeiro dia. O mesmo núcleo, qualquer idioma, qualquer país.
+- **API-First** — Cada funcionalidade é uma API. Integre com tudo, automatize tudo.
+- **Pronto para a IA** — Estruturado para a era da IA. Preparado para agendamento inteligente, apoio à decisão clínica e automação de fluxos de trabalho.
+
+### A visão
+
+Não estamos apenas a construir software — estamos a construir a base de um ecossistema. Uma plataforma onde os programadores contribuem com módulos, as clínicas partilham melhorias e toda a comunidade dentária beneficia da inovação coletiva.
+
+As clínicas merecem melhor do que software fechado e caro da década passada. O DentalPin é a alternativa aberta.
+
+## ✨ Copilot de IA
+
+O DentalPin inclui um **assistente de IA agêntico** integrado que transforma toda a clínica em algo com que pode simplesmente conversar. Peça-lhe para encontrar um paciente, libertar uma vaga, dar seguimento a um orçamento sem resposta ou fazer-lhe um resumo do dia — em espanhol ou inglês correntes — e ele age sobre os seus dados reais.
+
+![AI Copilot](docs/screenshots/ia.png)
+
+Isto não é um chatbot acrescentado por cima. O Copilot é um verdadeiro agente que **planeia e executa tarefas multi-etapa** chamando as mesmas operações que a interface, em pacientes, agenda, reconvocações, orçamentos, pagamentos e relatórios.
+
+- **Faz, não se limita a responder.** O agente executa ferramentas reais — procurar pacientes, marcar ou remarcar consultas, registar um pagamento, obter os recebimentos do mês — e encadeia-as para completar uma tarefa de princípio a fim.
+- **Nunca pode exceder a sua função.** Cada chamada de ferramenta é re-verificada contra as permissões RBAC do utilizador que a invoca, no ponto de controlo da execução. O Copilot pode ver e fazer *exatamente* o que esse utilizador poderia fazer através da interface — nada mais, limitado à sua clínica.
+- **Os seus dados estão protegidos.** Os dados de saúde (PHI) são ocultados antes de qualquer coisa sair para o fornecedor de LLM: nomes de pacientes, telefones, emails e identificadores são substituídos por tokens deterministas, e as ferramentas clínicas de texto livre são totalmente excluídas do caminho cloud. A ocultação está ativa por predefinição.
+- **As escritas perguntam primeiro.** Qualquer ação que altere dados (marcações, pagamentos, edições) pausa a meio da conversa para a sua confirmação explícita antes de ser executada.
+- **Fluxos de trabalho guiados.** Playbooks prontos a usar — *Briefing diário*, *Preparar uma consulta*, *Preencher uma vaga*, *Reconvocações pendentes*, *Orçamentos sem resposta* — iniciam tarefas multi-etapa comuns num só toque.
+- **Briefings proativos.** Opte por receber um resumo matinal determinista enviado por email à sua equipa, com a agenda do dia, as reconvocações pendentes e os orçamentos em aberto — sem LLM, sem dados de saúde fora do sistema.
+- **Modular por design.** O Copilot consome ferramentas publicadas por cada módulo através de um registo partilhado; cada módulo contribui com as suas próprias capacidades, pelo que o agente cresce automaticamente à medida que novos módulos são instalados.
+
+Independente do fornecedor por baixo do capô (uma abstração de fornecedor de LLM), com fornecedor, modelo e orçamentos de tokens por clínica configuráveis por implantação. Arquitetura: [docs/technical/copilot-agentic-architecture.md](docs/technical/copilot-agentic-architecture.md).
+
+## Site
+
+Visite [**dentalpin.com**](https://www.dentalpin.com) para informações sobre o produto, funcionalidades e detalhes comerciais.
+
+## Comunidade
+
+Junte-se ao nosso [**canal de Telegram**](https://t.me/dentalpin) para suporte, ajuda com a instalação e perguntas.
+
+## Capturas de ecrã
+
+### Painel de controlo
+![Dashboard](docs/screenshots/home.png)
+
+### Gestão de pacientes
+![Patients](docs/screenshots/patients.png)
+
+### Agenda semanal
+![Weekly Schedule](docs/screenshots/schedule-week.png)
+
+### Agenda Kanban
+![Kanban Schedule](docs/screenshots/schedule-canban.png)
+
+### Gráfico de pagamentos
+![Payments Chart](docs/screenshots/payments-chart.png)
+
+### Definições
+![Settings](docs/screenshots/settings.png)
+
+## Instalação
+
+Imagens pré-construídas, sem clone, sem build. Em qualquer servidor com Docker:
+
+```bash
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/Caddyfile
+curl -o .env https://raw.githubusercontent.com/dentalpin/dentalpin/main/.env.prod.example
+
+# Defina PUBLIC_URL, POSTGRES_PASSWORD e SECRET_KEY no .env e depois:
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Aponte um domínio para o servidor, defina `PUBLIC_URL=https://your-domain` e o TLS é
+provisionado no primeiro arranque — o Caddy fica à frente dos dois serviços numa única
+origem, pelo que não há CORS nem certificados para renovar. Defina `SEED_ON_STARTUP=1`
+para carregar a clínica de demonstração e explorar antes de entrar em produção.
+
+Imagens: [`dentalpin-backend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-backend) ·
+[`dentalpin-frontend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-frontend)
+
+## Início rápido (desenvolvimento)
+
+Compila a partir do código-fonte, com hot reload:
+
+```bash
+# Iniciar os serviços
+docker-compose up -d
+
+# Semear dados de demonstração (inglês por predefinição)
+./scripts/seed-demo.sh
+
+# Ou semear em espanhol
+./scripts/seed-demo.sh --lang es
+
+# Clínica de demonstração com GST da Índia (interface em tâmil, ou em inglês com --country in)
+./scripts/seed-demo.sh --lang ta
+```
+
+Abra http://localhost:3000
+
+### Credenciais de demonstração
+
+Todos os utilizadores têm a palavra-passe: `demo1234`
+
+| Email | Função | Nome (EN) | Nome (ES) |
+|-------|--------|-----------|-----------|
+| admin@demo.clinic | admin | Admin Demo | Admin Demo |
+| dentist@demo.clinic | dentist | Dr. Sarah Johnson | Dra. María García López |
+| hygienist@demo.clinic | hygienist | Michael Williams | Carlos López Martínez |
+| assistant@demo.clinic | assistant | Emily Davis | Ana Martínez Ruiz |
+| receptionist@demo.clinic | receptionist | Jessica Brown | Laura Sánchez Pérez |
+
+Consulte [docs/user-manual/en/demo.md](docs/user-manual/en/demo.md) para todos os detalhes sobre os dados de demonstração.
+
+## Stack tecnológica
+
+| Camada | Tecnologia |
+|--------|-----------|
+| Backend | FastAPI (Python 3.11+) |
+| Frontend | Nuxt 3 + Nuxt UI |
+| Base de dados | PostgreSQL 15 |
+| Autenticação | JWT com refresh tokens |
+
+## Funcionalidades
+
+### Copilot de IA
+- **Assistente agêntico** — Agente conversacional que planeia e executa tarefas multi-etapa em pacientes, agenda, reconvocações, orçamentos, pagamentos e relatórios, chamando operações reais
+- **Paridade RBAC** — Cada ação é re-verificada contra as permissões do utilizador; o agente só pode fazer o que esse utilizador poderia fazer através da interface, limitado à sua clínica
+- **Ocultação de PHI** — Identificadores de pacientes tokenizados antes de chegarem ao LLM; os dados clínicos de texto livre ficam fora do caminho cloud. Ativa por predefinição
+- **Escritas confirmadas** — As ações que alteram dados pausam a meio da conversa para confirmação explícita do utilizador
+- **Fluxos de trabalho e resumo diário** — Playbooks de um toque (briefing diário, preparar uma consulta, preencher uma vaga) mais um resumo matinal proativo por email, opcional
+- **Multilingue e independente do fornecedor** — Fala consigo no idioma da sua interface; fornecedor de LLM, modelo e orçamento de tokens por clínica configuráveis
+
+### Gestão clínica
+- **Fichas de pacientes** — Perfis completos de pacientes com dados pessoais, informações de contacto, historial médico e notas
+- **Carta dentária (Odontograma)** — Diagrama dentário interativo com acompanhamento de tratamentos por dente/superfície
+- **Calendário de consultas** — Vistas semanal e diária com arrastar e largar, colunas por profissional, deteção de conflitos
+- **Catálogo de tratamentos** — Catálogo personalizável com códigos, preços, tipos de IVA e categorias
+
+### Gestão financeira
+- **Orçamentos** — Criação de orçamentos de tratamento, acompanhamento do fluxo de aprovação (rascunho → pendente → aprovado/rejeitado), captura da assinatura do paciente, geração de PDF
+- **Faturas** — Geração de faturas a partir de orçamentos ou de forma independente, numeração automática, múltiplos métodos de pagamento, exportação para PDF
+- **Pagamentos** — Registo de pagamentos parciais, histórico de pagamentos, cálculo de saldo
+
+### Gestão da prática
+- **Controlo de acesso baseado em funções** — Cinco funções (admin, dentista, higienista, assistente, rececionista) com permissões granulares
+- **Gestão de gabinetes/salas** — Definição de salas de tratamento com horários e cores
+- **Gestão de profissionais** — Atribuição de consultas a dentistas/higienistas específicos
+
+### Experiência de utilizador
+- **Seletores visuais** — Menus pendentes inteligentes que mostram pacientes recentes e tratamentos populares
+- **Interface em nove idiomas** — Inglês, espanhol, francês, português, tâmil, alemão, húngaro, polaco e italiano — aplicação principal e todos os módulos
+- **Modo escuro** — Mudança de tema de acordo com o sistema
+- **Design responsivo** — Funciona em desktop e tablet
+
+### Funcionalidades técnicas
+- **Arquitetura modular** — Sistema baseado em plugins para fácil extensibilidade
+- **Bus de eventos** — Comunicação entre módulos para notificações e integrações
+- **API REST** — API completa com documentação OpenAPI
+- **Atualizações em tempo real** — Interface reativa com atualizações otimistas
+
+## Idiomas
+
+A interface é disponibilizada em **nove idiomas** — English, Español, Français, Português,
+தமிழ் (Tamil), Deutsch, Magyar, Polski e Italiano — cobrindo a aplicação principal **e
+todas as camadas de módulos**, com um teste de paridade de chaves imposto na CI para que
+as localizações não divirjam silenciosamente. O polaco usa as suas regras completas de
+plural com três formas.
+
+As comunicações dirigidas ao paciente (modelos de email, PDFs) são atualmente geradas em
+**cinco idiomas** (es, en, fr, pt, ta); cada clínica escolhe o seu idioma de comunicação
+independentemente do idioma da interface da equipa.
+
+Quer o seu idioma? Adicionar um é uma contribuição apenas de tradução — veja as
+[issues de i18n](https://github.com/dentalpin/dentalpin/issues?q=label%3Ai18n) ou
+abra uma nova.
+
+## Desenvolvimento
+
+### Pré-requisitos
+
+- Docker e Docker Compose
+- Python 3.11+ (para desenvolvimento local do backend)
+- Node.js 18+ (para desenvolvimento local do frontend)
+
+### Execução local
+
+```bash
+# Iniciar todos os serviços
+docker-compose up
+
+# Ou executar o backend em separado
+cd backend
+pip install -e ".[dev]"
+uvicorn app.main:app --reload
+
+# Ou executar o frontend em separado
+cd frontend
+npm install
+npm run dev
+```
+
+### Gestão da base de dados
+
+```bash
+# Repor a base de dados e executar as migrações
+./scripts/reset-db.sh
+
+# Semear dados de demonstração (inglês — predefinição)
+./scripts/seed-demo.sh
+
+# Semear dados de demonstração (espanhol)
+./scripts/seed-demo.sh --lang es
+
+# Configuração completa (reset + seed num único comando)
+./scripts/setup-demo.sh
+```
+
+### Execução de testes
+
+```bash
+# Unitários + integração do backend (em Docker)
+docker-compose exec backend python -m pytest -v
+
+# Round-trip Alembic lento (opt-in, ver docs/technical/creating-modules.md)
+docker-compose exec backend python -m pytest -v -m alembic_roundtrip
+
+# Unitários do frontend (vitest)
+cd frontend
+npm run test
+```
+
+**E2E no navegador (Playwright)** vive em `frontend/tests/e2e/` e conduz
+a stack completa em `localhost:3000` → `:8000`. Corre no host porque
+o container Alpine do frontend não consegue lançar o Chromium.
+
+```bash
+# Configuração única inicial
+(cd frontend && npm install && npx playwright install chromium)
+
+# Garanta primeiro que a stack está levantada e semeada
+docker-compose up -d
+./scripts/seed-demo.sh
+
+# Suite E2E completa (nav + RBAC + smoke test do detalhe de paciente)
+./scripts/e2e.sh
+
+# Um único ficheiro
+./scripts/e2e.sh rbac
+
+# Interface interativa
+./scripts/e2e.sh --ui
+```
+
+Runbook completo + referência de fixtures: [docs/technical/e2e-testing.md](docs/technical/e2e-testing.md).
+
+## Arquitetura
+
+O DentalPin usa uma arquitetura modular de plugins. Cada funcionalidade é um módulo autónomo que:
+- Declara os seus modelos SQLAlchemy
+- Fornece um router FastAPI
+- Pode subscrever eventos de outros módulos
+
+Consulte [docs/adr/0001-modular-plugin-architecture.md](docs/adr/0001-modular-plugin-architecture.md) para mais detalhes.
+
+## Licença
+
+Business Source License 1.1 (BSL 1.1)
+
+**Concessão de uso adicional:** Pode usar o DentalPin em produção, desde que não o ofereça como SaaS comercial para gestão de clínicas dentárias.
+
+**Data de mudança:** 4 anos a partir do lançamento
+
+**Licença de mudança:** Apache 2.0
+
+Consulte [LICENSE](LICENSE) para os termos completos.
+
+## Contribuir
+
+Consulte [CONTRIBUTING.md](CONTRIBUTING.md) para as diretrizes.
+
+---
+
+Apoiado por [Dentaltix](https://www.dentaltix.com)

--- a/README.ta.md
+++ b/README.ta.md
@@ -3,7 +3,12 @@
 [![en](https://img.shields.io/badge/lang-en-red.svg)](./README.md)
 [![es](https://img.shields.io/badge/lang-es-yellow.svg)](./README.es.md)
 [![fr](https://img.shields.io/badge/lang-fr-blue.svg)](./README.fr.md)
+[![pt](https://img.shields.io/badge/lang-pt-brightgreen.svg)](./README.pt.md)
 [![ta](https://img.shields.io/badge/lang-ta-green.svg)](./README.ta.md)
+[![de](https://img.shields.io/badge/lang-de-black.svg)](./README.de.md)
+[![hu](https://img.shields.io/badge/lang-hu-orange.svg)](./README.hu.md)
+[![pl](https://img.shields.io/badge/lang-pl-lightgrey.svg)](./README.pl.md)
+[![it](https://img.shields.io/badge/lang-it-blueviolet.svg)](./README.it.md)
 
 **திறந்த மூல பல் மருத்துவமனை மேலாண்மை மென்பொருள்.** நோயாளிகள், பல் வரைபடம் (odontogram),
 அட்டவணை, சிகிச்சை திட்டங்கள், பில்லிங் மற்றும் உள்ளமைக்கப்பட்ட AI கோபைலட் — மட்டு அடிப்படையிலான,
@@ -90,7 +95,30 @@ DentalPin ஒரு உள்ளமைக்கப்பட்ட **ஏஜென
 ### அமைப்புகள்
 ![Settings](docs/screenshots/settings-ta.png)
 
-## விரைவு தொடக்கம்
+## நிறுவல்
+
+முன்பே கட்டமைக்கப்பட்ட இமேஜ்கள் — clone தேவையில்லை, build தேவையில்லை. Docker உள்ள எந்த சர்வரிலும்:
+
+```bash
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/dentalpin/dentalpin/main/Caddyfile
+curl -o .env https://raw.githubusercontent.com/dentalpin/dentalpin/main/.env.prod.example
+
+# .env இல் PUBLIC_URL, POSTGRES_PASSWORD மற்றும் SECRET_KEY ஐ அமைத்து, பிறகு:
+docker compose -f docker-compose.prod.yml up -d
+```
+
+சர்வருக்கு ஒரு டொமைனை சுட்டிக்காட்டி, `PUBLIC_URL=https://your-domain` ஐ அமைக்கவும்;
+முதல் துவக்கத்திலேயே TLS தானாக அமைக்கப்படும் — Caddy இரு சேவைகளையும் ஒரே origin இல்
+வழங்குகிறது, எனவே CORS பிரச்சனை இல்லை, புதுப்பிக்க வேண்டிய சான்றிதழும் இல்லை. நேரடி
+பயன்பாட்டிற்கு முன் டெமோ கிளினிக்கை ஏற்றிச் சுற்றிப் பார்க்க `SEED_ON_STARTUP=1` ஐ அமைக்கவும்.
+
+இமேஜ்கள்: [`dentalpin-backend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-backend) ·
+[`dentalpin-frontend`](https://github.com/dentalpin/dentalpin/pkgs/container/dentalpin-frontend)
+
+## விரைவு தொடக்கம் (மேம்பாடு)
+
+மூலக் குறியீட்டிலிருந்து hot reload உடன் கட்டமைக்கிறது:
 
 ```bash
 # சேவைகளைத் தொடங்கவும்
@@ -105,7 +133,7 @@ docker-compose up -d
 # அல்லது பிரெஞ்சில்
 ./scripts/seed-demo.sh --lang fr
 
-# அல்லது தமிழில்
+# இந்தியா GST டெமோ கிளினிக் (தமிழ் UI, அல்லது --country in உடன் ஆங்கில UI)
 ./scripts/seed-demo.sh --lang ta
 ```
 
@@ -123,7 +151,7 @@ http://localhost:3000 ஐத் திறக்கவும்
 | assistant@demo.clinic | assistant | Emily Davis | Ana Martínez Ruiz | Camille Petit | பிரியா செல்வக்குமார் |
 | receptionist@demo.clinic | receptionist | Jessica Brown | Laura Sánchez Pérez | Julie Bernard | தீபிகா முருகேசன் |
 
-டெமோ தரவு பற்றிய முழு விவரங்களுக்கு [docs/user-manual/demo.md](docs/user-manual/demo.md) ஐப் பார்க்கவும்.
+டெமோ தரவு பற்றிய முழு விவரங்களுக்கு [docs/user-manual/en/demo.md](docs/user-manual/en/demo.md) ஐப் பார்க்கவும்.
 
 ## தொழில்நுட்ப அடுக்கு
 
@@ -142,7 +170,7 @@ http://localhost:3000 ஐத் திறக்கவும்
 - **PHI நீக்குதல்** — நோயாளி அடையாளங்கள் LLM ஐ அடைவதற்கு முன் டோக்கனாக்கப்படுகின்றன; இலவச-உரை மருத்துவத் தரவு கிளவுட் பாதைக்கு வெளியே இருக்கும். இயல்பாகவே இயக்கத்தில் உள்ளது
 - **உறுதிப்படுத்தப்பட்ட எழுத்துகள்** — தரவை மாற்றும் செயல்கள் உரையாடலின் நடுவில் பயனரின் வெளிப்படையான உறுதிப்படுத்தலுக்காக இடைநிறுத்தப்படும்
 - **பணிப்பாய்வுகள் & டைஜெஸ்ட்** — ஒரே-தட்டு playbooks (தினசரி சுருக்கம், ஒரு வருகையைத் தயார் செய்தல், ஒரு இடைவெளியை நிரப்புதல்) மற்றும் ஒரு விருப்ப முன்கூட்டிய காலை மின்னஞ்சல் டைஜெஸ்ட்
-- **பன்மொழி & வழங்குநர்-சாராதது** — தமிழ், பிரெஞ்சு, ஸ்பானிஷ் மற்றும் ஆங்கிலத்தில் செயல்படுகிறது; உள்ளமைக்கக்கூடிய LLM வழங்குநர், மாடல், மற்றும் கிளினிக் ஒன்றுக்கான டோக்கன் பட்ஜெட்
+- **பன்மொழி & வழங்குநர்-சாராதது** — உங்கள் UI மொழியிலேயே உங்களுடன் பேசுகிறது; உள்ளமைக்கக்கூடிய LLM வழங்குநர், மாடல், மற்றும் கிளினிக் ஒன்றுக்கான டோக்கன் பட்ஜெட்
 
 ### மருத்துவ மேலாண்மை
 - **நோயாளி பதிவுகள்** — தனிப்பட்ட தரவு, தொடர்பு தகவல், மருத்துவ வரலாறு மற்றும் குறிப்புகளுடன் கூடிய முழுமையான நோயாளி சுயவிவரங்கள்
@@ -162,7 +190,7 @@ http://localhost:3000 ஐத் திறக்கவும்
 
 ### பயனர் அனுபவம்
 - **காட்சி தேர்வாளர்கள்** — சமீபத்திய நோயாளிகள் மற்றும் பிரபலமான சிகிச்சைகளைக் காட்டும் புத்திசாலித்தனமான dropdowns
-- **பன்மொழி இடைமுகம்** — தமிழ், பிரெஞ்சு, ஸ்பானிஷ் மற்றும் ஆங்கிலத்தில் முழுமையான உள்ளூர்மயமாக்கல்
+- **ஒன்பது மொழி இடைமுகம்** — ஆங்கிலம், ஸ்பானிஷ், பிரெஞ்சு, போர்ச்சுகீசியம், தமிழ், ஜெர்மன், ஹங்கேரியன், போலிஷ் மற்றும் இத்தாலியன் — மைய பயன்பாடு மற்றும் ஒவ்வொரு மட்டும்
 - **இருண்ட பயன்முறை** — கணினியை அறிந்த தீம் மாற்றம்
 - **பதிலளிக்கக்கூடிய வடிவமைப்பு** — டெஸ்க்டாப் மற்றும் டேப்லெட்டில் வேலை செய்யும்
 
@@ -170,7 +198,23 @@ http://localhost:3000 ஐத் திறக்கவும்
 - **மட்டு கட்டமைப்பு** — எளிதான விரிவாக்கத்திற்கான பிளக்-இன் அடிப்படையிலான அமைப்பு
 - **நிகழ்வு பஸ்** — அறிவிப்புகள் மற்றும் ஒருங்கிணைப்புகளுக்கான மட்டுகளுக்கிடையேயான தொடர்பு
 - **REST API** — OpenAPI ஆவணங்களுடன் கூடிய முழுமையான API
-- **நேரடி புதுப்பிப்புகள்** — மகிழ்ச்சிகரமான புதுப்பிப்புகளுடன் கூடிய தீவிர இடைமுகம்
+- **நேரடி புதுப்பிப்புகள்** — நம்பிக்கை அடிப்படையிலான (optimistic) புதுப்பிப்புகளுடன் கூடிய வினைத்திறன் இடைமுகம்
+
+## மொழிகள்
+
+இடைமுகம் **ஒன்பது மொழிகளில்** கிடைக்கிறது — English, Español, Français, Português,
+தமிழ் (Tamil), Deutsch, Magyar, Polski மற்றும் Italiano — மைய பயன்பாடு **மற்றும் ஒவ்வொரு
+மட்டு அடுக்கையும்** உள்ளடக்கியது; CI இல் செயல்படுத்தப்படும் key-parity சோதனையால்
+மொழிபெயர்ப்புகள் அமைதியாக விலகிச் செல்ல முடியாது. போலிஷ் அதன் முழு மூன்று-வடிவ
+பன்மை விதிகளைப் பயன்படுத்துகிறது.
+
+நோயாளிகளுக்கு அனுப்பப்படும் தகவல்தொடர்புகள் (மின்னஞ்சல் டெம்ப்ளேட்கள், PDFகள்) தற்போது
+**ஐந்து மொழிகளில்** (es, en, fr, pt, ta) உருவாக்கப்படுகின்றன; ஒவ்வொரு கிளினிக்கும்
+பணியாளர் UI மொழியிலிருந்து சுயாதீனமாக அதன் தகவல்தொடர்பு மொழியைத் தேர்வு செய்கிறது.
+
+உங்கள் மொழி வேண்டுமா? ஒரு மொழியைச் சேர்ப்பது மொழிபெயர்ப்பு-மட்டும் பங்களிப்பு —
+[i18n issues](https://github.com/dentalpin/dentalpin/issues?q=label%3Ai18n) ஐப்
+பார்க்கவும் அல்லது புதிதாக ஒன்றைத் திறக்கவும்.
 
 ## மேம்பாடு
 
@@ -264,7 +308,7 @@ DentalPin ஒரு மட்டு பிளக்-இன் கட்டமை
 - ஒரு FastAPI router ஐ வழங்குகிறது
 - மற்ற மட்டுகளின் நிகழ்வுகளுக்கு subscribe செய்யலாம்
 
-விவரங்களுக்கு [docs/architecture.md](docs/architecture.md) ஐப் பார்க்கவும்.
+விவரங்களுக்கு [docs/adr/0001-modular-plugin-architecture.md](docs/adr/0001-modular-plugin-architecture.md) ஐப் பார்க்கவும்.
 
 ## உரிமம்
 


### PR DESCRIPTION
Fixes #313.

## What's here

- **Five new README translations** — `README.pt.md`, `README.de.md`, `README.hu.md`, `README.pl.md`, `README.it.md` — full translations of the refreshed English source, each matching its app locale's register (pt is **European Portuguese** per `pt.json`; de uses Sie; it uses the tu-form marketing tone of `it.json`; hu formal; pl imperative). Commands, URLs, image paths and the credentials table stay byte-identical to English; bash comments translate per the es-README convention.
- **Same nine-badge language row on all nine READMEs.**
- **README.md refreshed**: a new *Languages* section (nine UI languages across core + all module layers, CI-enforced key parity, Polish three-form plurals; five patient-communication languages; how to add yours), the two-era-old *"Bilingual — Spanish and English"* claims updated (interface + Copilot bullets), the India GST demo seed example, and **two broken links fixed** (`docs/user-manual/demo.md` and `docs/architecture.md` never existed at those paths — now → `docs/user-manual/en/demo.md` and ADR 0001 + `creating-modules.md`).
- **README.es/fr/ta synced** with the English structure (they'd drifted — no Install section, old quick-start). Three genuine translation bugs found on the way: es said *"código cerrado"* where English says **open source**; fr had *hygénistes* + a cabinets/cabinets duplication; ta rendered *optimistic updates* as **"joyful updates"** (மகிழ்ச்சிகரமான). The fr/ta credential-table extra columns and `-ta.png` screenshots were kept — they reflect real seeded data.
- **CONTRIBUTING.md**: the Thank You section now credits all seven GitHub profiles with merged contributions — descriptions verified against `git log` (e.g. @hirad121 is integrations/webhooks + security hardening, @tresundios is india_gst + Tamil) — plus an invitation to add yourself in your first PR.

## Verification

All nine files checked structurally identical by script: 9 badges each, 14 H2 sections in the same order, balanced code fences, byte-identical command blocks, zero stale links. `docs-layout` passes.