### PR TITLE
refactor(core/modules): drain the dependency-debt allowlists — provider inversion + seed relocation (#309)

### DIFF
--- a/backend/app/modules/agenda/CHANGELOG.md
+++ b/backend/app/modules/agenda/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- refactor(#309): booking no longer imports treatment_plan — planned-item eager loading, validation and catalog snapshotting go through the new `PlannedWorkProvider` registry (`planned_work.py`); the import-allowlist entry is drained. The `planned_treatment_item_id` FK stays documented cycle-bound debt.
+
 - feat(#287): the appointment modal's email-only confirmation checkbox and mail dropdown are replaced by channel-aware controls driven by the clinic's manual channels (confirmation/reminder/cancellation per receivable channel).
 
 - fix(#101): a failed appointments fetch renders an error banner with Retry instead of a blank calendar that reads as a free week; the appointment modal's footer cancel now asks for confirmation.

--- a/backend/app/modules/agenda/CLAUDE.md
+++ b/backend/app/modules/agenda/CLAUDE.md
@@ -10,7 +10,19 @@ surface (appointments CRUD, transitions, cabinet assignments, kanban).
 
 ## Dependencies
 
-`manifest.depends = ["patients", "catalog"]`.
+`manifest.depends = ["patients", "catalog", "odontogram"]`.
+
+**Planned-work contract (#309).** Booking against treatment-plan items
+is a two-way product dependency, but ``treatment_plan`` already
+declares ``agenda`` and the manifest graph must stay acyclic — so this
+module NEVER imports treatment_plan. It owns the
+``PlannedWorkProvider`` protocol + registry in ``planned_work.py``;
+``treatment_plan`` registers its implementation at import time
+(``agenda_provider.py``). Loader options, booking validation and the
+catalog-item snapshot all go through the registry. The
+``appointment_treatments.planned_treatment_item_id`` FK remains
+documented debt in ``tests/test_module_fk_isolation.py`` — legalizing
+it needs a column-ownership move, not a manifest entry.
 
 ## Permissions
 

--- a/backend/app/modules/agenda/planned_work.py
+++ b/backend/app/modules/agenda/planned_work.py
@@ -1,0 +1,72 @@
+"""Planned-work provider contract (issue #309).
+
+``agenda`` and ``treatment_plan`` genuinely depend on each other at the
+product level: plans register into agenda's slots and consume its
+events, while booking validates and eager-loads planned items. The
+manifest graph must stay acyclic, and ``treatment_plan`` already
+declares ``agenda`` — so agenda's side of the edge cannot become a
+``manifest.depends`` entry (the loader raises
+``CircularDependencyError``).
+
+This registry inverts the remaining code edge instead, the same shape
+as billing's ``BillingComplianceHook``: agenda owns the contract,
+``treatment_plan`` (whose import direction is legal) registers an
+implementation at boot, and ``agenda/service.py`` stops importing
+``treatment_plan`` models. When no provider is registered — a fresh
+process before module registration, never a running app, since
+``treatment_plan`` is non-removable — planned-item features degrade to
+explicit errors rather than silent misbehaviour.
+
+Registration is idempotent (dev filesystem re-scan re-imports modules).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@runtime_checkable
+class PlannedWorkProvider(Protocol):
+    """What agenda needs from the planned-work owner."""
+
+    def appointment_loader_options(self) -> list[Any]:
+        """ORM loader options that eager-load the graph behind
+        ``AppointmentTreatment.planned_item`` (treatment → teeth /
+        catalog item, and the owning plan) for appointment reads."""
+        ...
+
+    async def validate_bookable_items(
+        self,
+        db: AsyncSession,
+        clinic_id: UUID,
+        patient_id: UUID,
+        planned_item_ids: list[UUID],
+    ) -> list[str]:
+        """Return human-readable errors for any item that cannot be
+        booked (missing, other clinic, other patient, terminal plan or
+        item state). Empty list means all bookable."""
+        ...
+
+    async def catalog_item_id_for(self, db: AsyncSession, planned_item_id: UUID) -> UUID | None:
+        """The catalog item behind a planned item's treatment, if any —
+        used to snapshot ``AppointmentTreatment.catalog_item_id`` at
+        booking time."""
+        ...
+
+
+class PlannedWorkRegistry:
+    def __init__(self) -> None:
+        self._provider: PlannedWorkProvider | None = None
+
+    def register(self, provider: PlannedWorkProvider) -> None:
+        self._provider = provider
+
+    def get(self) -> PlannedWorkProvider | None:
+        return self._provider
+
+
+planned_work_registry = PlannedWorkRegistry()

--- a/backend/app/modules/agenda/service.py
+++ b/backend/app/modules/agenda/service.py
@@ -17,9 +17,7 @@ from sqlalchemy.orm import selectinload
 from app.core.auth.models import ClinicMembership
 from app.core.events import EventType, event_bus
 from app.modules.catalog.models import TreatmentCatalogItem  # noqa: F401
-from app.modules.odontogram.models import Treatment
 from app.modules.patients.models import Patient
-from app.modules.treatment_plan.models import PlannedTreatmentItem
 
 from .models import (
     Appointment,
@@ -28,6 +26,7 @@ from .models import (
     AppointmentTreatment,
     Cabinet,
 )
+from .planned_work import planned_work_registry
 from .tz import as_utc, get_clinic_tz
 
 # Canonical state machine. Mirrored in the frontend composable
@@ -54,6 +53,14 @@ def _plain_excerpt(text: str, limit: int = 200) -> str:
     stripped = _HTML_TAG_RE.sub(" ", text or "")
     collapsed = _WS_RE.sub(" ", stripped).strip()
     return collapsed[:limit]
+
+
+def _planned_item_loader_options() -> list:
+    """Loader options for ``AppointmentTreatment.planned_item`` from the
+    planned-work provider; empty (relationship stays lazy) when no
+    provider is registered."""
+    provider = planned_work_registry.get()
+    return provider.appointment_loader_options() if provider else []
 
 
 class InvalidTransitionError(ValueError):
@@ -185,13 +192,9 @@ class AppointmentService:
                 selectinload(Appointment.patient),
                 selectinload(Appointment.professional),
                 selectinload(Appointment.treatments).options(
-                    selectinload(AppointmentTreatment.planned_item).options(
-                        selectinload(PlannedTreatmentItem.treatment).options(
-                            selectinload(Treatment.teeth),
-                            selectinload(Treatment.catalog_item),
-                        ),
-                        selectinload(PlannedTreatmentItem.treatment_plan),
-                    ),
+                    # Planned-item graph comes from the provider so agenda
+                    # never imports treatment_plan models (#309).
+                    *_planned_item_loader_options(),
                     selectinload(AppointmentTreatment.catalog_item),
                 ),
             )
@@ -285,13 +288,9 @@ class AppointmentService:
                 selectinload(Appointment.patient),
                 selectinload(Appointment.professional),
                 selectinload(Appointment.treatments).options(
-                    selectinload(AppointmentTreatment.planned_item).options(
-                        selectinload(PlannedTreatmentItem.treatment).options(
-                            selectinload(Treatment.teeth),
-                            selectinload(Treatment.catalog_item),
-                        ),
-                        selectinload(PlannedTreatmentItem.treatment_plan),
-                    ),
+                    # Planned-item graph comes from the provider so agenda
+                    # never imports treatment_plan models (#309).
+                    *_planned_item_loader_options(),
                     selectinload(AppointmentTreatment.catalog_item),
                 ),
             )
@@ -340,36 +339,14 @@ class AppointmentService:
         if not planned_item_ids:
             return
 
-        result = await db.execute(
-            select(PlannedTreatmentItem)
-            .options(selectinload(PlannedTreatmentItem.treatment_plan))
-            .where(PlannedTreatmentItem.id.in_(planned_item_ids))
-        )
-        items = {item.id: item for item in result.scalars().all()}
+        provider = planned_work_registry.get()
+        if provider is None:
+            # treatment_plan is non-removable, so this only happens in a
+            # process that never registered modules — refuse rather than
+            # book against unvalidated planned work.
+            raise ValueError("Planned-work provider not available")
 
-        errors = []
-        for item_id in planned_item_ids:
-            item = items.get(item_id)
-            if not item:
-                errors.append(f"Treatment item {item_id} not found")
-                continue
-            if item.clinic_id != clinic_id:
-                errors.append(f"Treatment item {item_id} not found")
-                continue
-            plan = item.treatment_plan
-            if not plan or plan.patient_id != patient_id:
-                errors.append(f"Treatment item {item_id} does not belong to patient")
-                continue
-            # `pending` (plan confirmed, budget not yet accepted) is bookable
-            # on purpose: an unconfirmed `draft` already is, so confirming a
-            # plan must not take that away — clinics book the first visit while
-            # the patient is still deciding (#108). Terminal states stay out.
-            if plan.status not in ("active", "draft", "pending"):
-                errors.append(f"Treatment item {item_id} belongs to {plan.status} plan")
-                continue
-            if item.status != "pending":
-                errors.append(f"Treatment item {item_id} is already {item.status}")
-
+        errors = await provider.validate_bookable_items(db, clinic_id, patient_id, planned_item_ids)
         if errors:
             raise ValueError("; ".join(errors))
 
@@ -488,13 +465,11 @@ class AppointmentService:
             )
 
         if planned_item_ids:
+            provider = planned_work_registry.get()
             for order, planned_item_id in enumerate(planned_item_ids):
-                planned_item = await db.get(PlannedTreatmentItem, planned_item_id)
-                catalog_item_id = None
-                if planned_item:
-                    await db.refresh(planned_item, ["treatment"])
-                    if planned_item.treatment:
-                        catalog_item_id = planned_item.treatment.catalog_item_id
+                catalog_item_id = (
+                    await provider.catalog_item_id_for(db, planned_item_id) if provider else None
+                )
 
                 treatment = AppointmentTreatment(
                     appointment_id=appointment.id,
@@ -596,13 +571,11 @@ class AppointmentService:
                 await db.delete(existing)
             await db.flush()
 
+            provider = planned_work_registry.get()
             for order, planned_item_id in enumerate(planned_item_ids):
-                planned_item = await db.get(PlannedTreatmentItem, planned_item_id)
-                catalog_item_id = None
-                if planned_item:
-                    await db.refresh(planned_item, ["treatment"])
-                    if planned_item.treatment:
-                        catalog_item_id = planned_item.treatment.catalog_item_id
+                catalog_item_id = (
+                    await provider.catalog_item_id_for(db, planned_item_id) if provider else None
+                )
 
                 treatment = AppointmentTreatment(
                     appointment_id=appointment.id,

--- a/backend/app/modules/patient_timeline/CHANGELOG.md
+++ b/backend/app/modules/patient_timeline/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- refactor(#309): the demo seed moved to the host seeds package (`app/seeds/patient_timeline_demo.py`) — the module deliberately declares only `patients`, and the seed's five cross-module imports had it on the isolation allowlist; all five entries drained.
+
 - feat(#287): subscribes the generic notification.sent/notification.failed events (all channels) instead of the legacy email.* pair — WhatsApp outbound now shows on the timeline.
 
 - i18n(#131/#275): demo-seed treatment names fall back to any non-empty

--- a/backend/app/modules/treatment_plan/CHANGELOG.md
+++ b/backend/app/modules/treatment_plan/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- refactor(#309): implements agenda's planned-work contract in `agenda_provider.py`, registered at import time — this direction is declarable (`agenda` ∈ depends), agenda's wasn't (manifest cycle).
+
 - fix(#101): removing a plan item asks for confirmation naming the treatment.
 
 - feat(#207): the plan header links to the draft quote while the plan is `pending` (and the confirm toast carries a "view quote" action); *Programar cita* opens the appointment modal with the plan's pending treatments preselected (`?new=1&plan_id=`); a post-appointment follow-up prompt lists linked treatments the visit left unmarked and completes them in one click.

--- a/backend/app/modules/treatment_plan/CLAUDE.md
+++ b/backend/app/modules/treatment_plan/CLAUDE.md
@@ -95,6 +95,16 @@ Clinical-note created events (`clinical_notes.{administrative,diagnosis,treatmen
 | `budget.superseded`             | `on_budget_superseded`      | repoint `budget_id` to the resent version (only while still pointing at the old one) |
 | `odontogram.treatment.performed` | `on_treatment_performed`   | mark planned item completed when its tooth treatment is performed |
 
+## Agenda planned-work provider
+
+``agenda_provider.py`` implements agenda's ``PlannedWorkProvider``
+protocol (registered at import time in ``__init__.py``, issue #309):
+eager-load options for ``AppointmentTreatment.planned_item``, the
+booking-time validation rules (draft/pending/active plans bookable —
+#108 — items only while ``pending``), and the catalog-item snapshot
+for booking. Keep its validation in sync with the state machine above;
+agenda calls it blind through the registry.
+
 ## Frontend slots consumed
 
 | Slot (host) | Component | Purpose |

--- a/backend/app/modules/treatment_plan/__init__.py
+++ b/backend/app/modules/treatment_plan/__init__.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter
 from app.core.events.types import EventType
 from app.core.plugins import BaseModule
 from app.core.scheduling import ScheduledJob
+from app.modules.agenda.planned_work import planned_work_registry as _planned_work_registry
 
 from .models import (
     PlannedTreatmentItem,
@@ -27,6 +28,15 @@ from .router import router
 # time. Safe because ``media`` is in ``manifest.depends`` and Python
 # import order resolves it first.
 _register_attachment_owners()
+
+# Agenda's planned-work provider (issue #309): the agenda↔treatment_plan
+# product dependency is two-way, but only this direction is declarable
+# (agenda ∈ manifest.depends; the reverse would be a manifest cycle).
+# Import-time registration, idempotent — mirrors the attachment owners
+# above.
+from .agenda_provider import TreatmentPlanPlannedWorkProvider  # noqa: E402
+
+_planned_work_registry.register(TreatmentPlanPlannedWorkProvider())
 
 
 class TreatmentPlanModule(BaseModule):

--- a/backend/app/modules/treatment_plan/agenda_provider.py
+++ b/backend/app/modules/treatment_plan/agenda_provider.py
@@ -1,0 +1,88 @@
+"""treatment_plan's implementation of agenda's planned-work contract.
+
+Registered on every boot from ``TreatmentPlanModule.__init__`` (issue
+#309). The import direction is legal — ``agenda`` is in this module's
+``manifest.depends`` — which is exactly why the implementation lives
+here and not in agenda: the manifest graph stays acyclic while agenda
+keeps its booking-time validation and eager loading.
+
+Keep the validation rules in sync with the plan state machine (see the
+module CLAUDE.md): ``draft``/``pending``/``active`` plans are bookable
+(#108), terminal ones are not; an item is bookable only while
+``pending``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.modules.agenda.models import AppointmentTreatment
+from app.modules.odontogram.models import Treatment
+
+from .models import PlannedTreatmentItem
+
+
+class TreatmentPlanPlannedWorkProvider:
+    def appointment_loader_options(self) -> list[Any]:
+        return [
+            selectinload(AppointmentTreatment.planned_item).options(
+                selectinload(PlannedTreatmentItem.treatment).options(
+                    selectinload(Treatment.teeth),
+                    selectinload(Treatment.catalog_item),
+                ),
+                selectinload(PlannedTreatmentItem.treatment_plan),
+            )
+        ]
+
+    async def validate_bookable_items(
+        self,
+        db: AsyncSession,
+        clinic_id: UUID,
+        patient_id: UUID,
+        planned_item_ids: list[UUID],
+    ) -> list[str]:
+        result = await db.execute(
+            select(PlannedTreatmentItem)
+            .options(selectinload(PlannedTreatmentItem.treatment_plan))
+            .where(PlannedTreatmentItem.id.in_(planned_item_ids))
+        )
+        items = {item.id: item for item in result.scalars().all()}
+
+        errors: list[str] = []
+        for item_id in planned_item_ids:
+            item = items.get(item_id)
+            if not item:
+                errors.append(f"Treatment item {item_id} not found")
+                continue
+            if item.clinic_id != clinic_id:
+                errors.append(f"Treatment item {item_id} not found")
+                continue
+            plan = item.treatment_plan
+            if not plan or plan.patient_id != patient_id:
+                errors.append(f"Treatment item {item_id} does not belong to patient")
+                continue
+            # `pending` (plan confirmed, budget not yet accepted) is bookable
+            # on purpose: an unconfirmed `draft` already is, so confirming a
+            # plan must not take that away — clinics book the first visit while
+            # the patient is still deciding (#108). Terminal states stay out.
+            if plan.status not in ("active", "draft", "pending"):
+                errors.append(f"Treatment item {item_id} belongs to {plan.status} plan")
+                continue
+            if item.status != "pending":
+                errors.append(f"Treatment item {item_id} is already {item.status}")
+
+        return errors
+
+    async def catalog_item_id_for(self, db: AsyncSession, planned_item_id: UUID) -> UUID | None:
+        planned_item = await db.get(PlannedTreatmentItem, planned_item_id)
+        if not planned_item:
+            return None
+        await db.refresh(planned_item, ["treatment"])
+        if planned_item.treatment:
+            return planned_item.treatment.catalog_item_id
+        return None

--- a/backend/app/seeds/patient_timeline_demo.py
+++ b/backend/app/seeds/patient_timeline_demo.py
@@ -8,11 +8,12 @@ Only invoked by ``backend/scripts/seed_demo.py`` and only when
 ``patient_timeline`` is installed in ``core_module``. Idempotent for the
 given clinic: wipes the clinic's timeline rows, then repopulates.
 
-Runtime isolation note: this seed intentionally imports models from
-other modules (agenda, budget, billing, odontogram, treatment_plan) so
-it can walk the seeded narrative. Seed code is admin-only; it never
-runs in the request path, so the in-process isolation that
-``events.py`` enforces is preserved.
+Lives in the host seeds package, not inside the patient_timeline
+module (#309): it reads models from five other modules to walk the
+seeded narrative, and patient_timeline deliberately declares none of
+them — its event sources are runtime-optional by design. Host-level
+demo seeding is the established home for such cross-module fixtures
+(see ``demo_data.py`` and the india_gst precedent).
 """
 
 from __future__ import annotations
@@ -28,10 +29,9 @@ from app.modules.agenda.models import Appointment
 from app.modules.billing.models import Invoice
 from app.modules.budget.models import Budget
 from app.modules.odontogram.models import Treatment
+from app.modules.patient_timeline.models import PatientTimeline
 from app.modules.treatment_plan.models import PlannedTreatmentItem, TreatmentPlan
 from app.seeds.demo_data import t
-
-from .models import PatientTimeline
 
 
 async def seed_timeline_demo(db: AsyncSession, clinic_id: UUID) -> dict[str, int]:

--- a/backend/scripts/seed_demo.py
+++ b/backend/scripts/seed_demo.py
@@ -845,7 +845,7 @@ async def main(lang: str = "en", country: str = "generic") -> None:
 
             if await _module_is_installed(db, "patient_timeline"):
                 print("\n[opt] Creating patient timeline demo (module installed)...")
-                from app.modules.patient_timeline.seed import seed_timeline_demo
+                from app.seeds.patient_timeline_demo import seed_timeline_demo
 
                 stats = await seed_timeline_demo(db, clinic_id=CLINIC_ID)
                 print(

--- a/backend/tests/test_module_fk_isolation.py
+++ b/backend/tests/test_module_fk_isolation.py
@@ -34,6 +34,13 @@ MODULES_ROOT = Path(_modules_pkg.__file__).resolve().parent
 # agenda→treatment_plan mirrors the import already tracked in
 # test_module_isolation.KNOWN_VIOLATIONS (the appointment↔plan-item link).
 KNOWN_FK_VIOLATIONS: set[tuple[str, str, str, str, str]] = {
+    # CYCLE-BOUND (#309): treatment_plan.depends already contains agenda,
+    # so this edge can never become a manifest entry. The code-level
+    # import was inverted through agenda/planned_work.py; the FK can only
+    # become legal by moving column ownership into a treatment_plan-owned
+    # link table (a real migration through the booking flow — tracked as
+    # the follow-up on #309). Both modules are non-removable, so the
+    # uninstall hazard the ratchet guards against cannot occur today.
     (
         "agenda",
         "appointment_treatments",

--- a/backend/tests/test_module_isolation.py
+++ b/backend/tests/test_module_isolation.py
@@ -104,14 +104,19 @@ def _list_modules() -> list[str]:
 # fails until the allowlist is updated (forcing the cleanup to be
 # explicit). The goal is to drain this set over time, not grow it.
 KNOWN_VIOLATIONS: set[tuple[str, str, str]] = {
-    ("agenda", "service.py", "treatment_plan"),
-    ("agenda", "kanban_service.py", "schedules"),
-    ("billing", "router.py", "reports"),
-    ("patient_timeline", "seed.py", "agenda"),
-    ("patient_timeline", "seed.py", "billing"),
-    ("patient_timeline", "seed.py", "budget"),
-    ("patient_timeline", "seed.py", "odontogram"),
-    ("patient_timeline", "seed.py", "treatment_plan"),
+    # The former patient_timeline/seed.py entries drained by relocating the
+    # demo seed to app/seeds/patient_timeline_demo.py (#309) — host-level
+    # demo seeding is the established home for cross-module fixtures, and
+    # the module's event sources stay runtime-optional by design.
+    #
+    # Both remaining entries are CYCLE-BOUND: the target module already
+    # declares the reverse dependency, and the loader rejects manifest
+    # cycles (topology.py, CircularDependencyError). Draining them means
+    # inverting the code edge (a provider registry the target registers
+    # into, like agenda/planned_work.py did for treatment_plan in #309),
+    # not adding a manifest entry.
+    ("agenda", "kanban_service.py", "schedules"),  # schedules.depends ⊇ {agenda}
+    ("billing", "router.py", "reports"),  # reports.depends ⊇ {billing}
 }
 
 

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -118,7 +118,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.AGENDA_VISIT_NOTE_UPDATED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:869`
+  - `agenda` — `backend/app/modules/agenda/service.py:842`
 - **Subscribers:**
   - `patient_timeline`
 
@@ -126,14 +126,14 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_CABINET_CHANGED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:806`
+  - `agenda` — `backend/app/modules/agenda/service.py:779`
 - **Subscribers:** —
 
 ### `appointment.cancelled`
 
 - **Constant:** `EventType.APPOINTMENT_CANCELLED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:744`
+  - `agenda` — `backend/app/modules/agenda/service.py:717`
 - **Subscribers:**
   - `activity_journal`
   - `copilot`
@@ -146,7 +146,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_CHECKED_IN`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:741`
+  - `agenda` — `backend/app/modules/agenda/service.py:714`
 - **Subscribers:**
   - `activity_journal`
   - `patient_timeline`
@@ -155,7 +155,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_COMPLETED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:743`
+  - `agenda` — `backend/app/modules/agenda/service.py:716`
 - **Subscribers:**
   - `activity_journal`
   - `integrations`
@@ -167,7 +167,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_CONFIRMED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:740`
+  - `agenda` — `backend/app/modules/agenda/service.py:713`
 - **Subscribers:**
   - `activity_journal`
   - `patient_timeline`
@@ -176,7 +176,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_IN_TREATMENT`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:742`
+  - `agenda` — `backend/app/modules/agenda/service.py:715`
 - **Subscribers:**
   - `activity_journal`
   - `patient_timeline`
@@ -185,7 +185,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_NO_SHOW`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:745`
+  - `agenda` — `backend/app/modules/agenda/service.py:718`
 - **Subscribers:**
   - `activity_journal`
   - `patient_timeline`
@@ -194,7 +194,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_SCHEDULED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:508`
+  - `agenda` — `backend/app/modules/agenda/service.py:483`
 - **Subscribers:**
   - `activity_journal`
   - `notifications`
@@ -206,14 +206,14 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 
 - **Constant:** `EventType.APPOINTMENT_STATUS_CHANGED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:735`
+  - `agenda` — `backend/app/modules/agenda/service.py:708`
 - **Subscribers:** —
 
 ### `appointment.updated`
 
 - **Constant:** `EventType.APPOINTMENT_UPDATED`
 - **Publishers:**
-  - `agenda` — `backend/app/modules/agenda/service.py:636`
+  - `agenda` — `backend/app/modules/agenda/service.py:609`
 - **Subscribers:**
   - `schedules`
 


### PR DESCRIPTION
Fixes #309 — with a course correction over the issue's proposal, detailed in [this comment](https://github.com/dentalpin/dentalpin/issues/309#issuecomment-5440882199): **step 1 can't land.** `treatment_plan.depends` already contains `agenda`, and the loader rejects manifest cycles (`topology.py` → `CircularDependencyError`). The same is true of both other non-seed allowlist entries (`schedules` declares `agenda`; `reports` declares `billing`). So this PR drains what's drainable and documents what's cycle-bound.

## Drained — `agenda → treatment_plan` import (the issue's main edge)

**Provider inversion**, the `BillingComplianceHook` shape: agenda owns a `PlannedWorkProvider` protocol + registry (`agenda/planned_work.py`); `treatment_plan` — whose import direction *is* declarable — registers its implementation at import time (`agenda_provider.py`). Through the registry go:
- the eager-load options behind `AppointmentTreatment.planned_item` (both read paths),
- `validate_planned_items` (the #108 booking-gate rules preserved **verbatim** — all 8 planned-items tests pass unchanged),
- the catalog-item snapshot on appointment create *and* update.

`agenda/service.py` no longer imports `treatment_plan` (nor the odontogram models it only needed for those loader chains); the `KNOWN_VIOLATIONS` entry is gone.

## Drained — the five `patient_timeline/seed.py` entries, by relocation

I first tried declaring the five deps and reverted it: the module's CLAUDE.md states its event sources are **runtime-optional by design**, and hard-declaring five modules for seed-only reads inverts that design for the wrong reason. Instead the demo seed moved to the host seeds package (`app/seeds/patient_timeline_demo.py`) next to `demo_data.py` — the india_gst precedent: host-level demo seeding is the established home for cross-module fixtures. `scripts/seed_demo.py` updated.

## Documented, not drained

- `agenda→schedules` and `billing→reports`: entries stay with explicit **cycle-rationale comments** so the next reader doesn't re-attempt the manifest route (the drain path is another provider inversion, if/when it's worth it).
- The `appointment_treatments.planned_treatment_item_id` **FK**: its allowlist entry now states the constraint (cycle-bound; legalizing it means moving column ownership into a treatment_plan-owned link table through the booking flow) — that's the follow-up left on the issue, per your "open question". Both modules are non-removable, so the uninstall hazard the ratchet guards against can't occur today.

## Verification (local Postgres)

Module isolation + FK isolation + appointment planned-items + cli/lifecycle + alembic suites — 131 tests green; provider registration smoke-checked at import (`planned_work_registry.get()` non-None after importing the module); ruff clean; catalogs regenerated; module CLAUDE.mds updated (agenda's Dependencies section also had drifted from its manifest — fixed).