### PR TITLE
fix(frontend): useApi error contract — unhandled 4xx now surface the backend's message (#101)

### DIFF
--- a/backend/app/modules/agenda/CHANGELOG.md
+++ b/backend/app/modules/agenda/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#287): the appointment modal's email-only confirmation checkbox and mail dropdown are replaced by channel-aware controls driven by the clinic's manual channels (confirmation/reminder/cancellation per receivable channel).
 
 - fix(#101): a failed appointments fetch renders an error banner with Retry instead of a blank calendar that reads as a free week; the appointment modal's footer cancel now asks for confirmation.

--- a/backend/app/modules/agenda/frontend/components/clinical/AppointmentModal.vue
+++ b/backend/app/modules/agenda/frontend/components/clinical/AppointmentModal.vue
@@ -606,7 +606,7 @@ async function handleSave() {
     emit('saved', savedAppointment)
     emit('update:open', false)
   } catch (error: unknown) {
-    const fetchError = error as { statusCode?: number, data?: { message?: string, detail?: string } }
+    const fetchError = error as { statusCode?: number }
 
     if (fetchError.statusCode === 409) {
       toast.add({
@@ -617,7 +617,7 @@ async function handleSave() {
     } else {
       toast.add({
         title: t('common.error'),
-        description: fetchError.data?.detail || fetchError.data?.message || t('common.serverError'),
+        description: errorMessage(error, t('common.serverError')),
         color: 'error'
       })
     }

--- a/backend/app/modules/agenda/frontend/composables/useAppointments.ts
+++ b/backend/app/modules/agenda/frontend/composables/useAppointments.ts
@@ -40,8 +40,10 @@ export function useAppointments() {
         page_size: '500'
       })
 
+      // Callers render `error` as the #101 load-error banner.
       const response = await api.get<PaginatedResponse<Appointment>>(
-        `/api/v1/agenda/appointments?${params.toString()}`
+        `/api/v1/agenda/appointments?${params.toString()}`,
+        { errorToast: false }
       )
 
       appointments.value = response.data
@@ -56,9 +58,11 @@ export function useAppointments() {
   }
 
   async function createAppointment(data: AppointmentCreate): Promise<Appointment> {
+    // Callers catch and present (409 conflict copy, form toasts).
     const response = await api.post<ApiResponse<Appointment>>(
       '/api/v1/agenda/appointments',
-      data
+      data,
+      { errorToast: false }
     )
 
     // Add to local state
@@ -68,9 +72,11 @@ export function useAppointments() {
   }
 
   async function updateAppointment(id: string, data: AppointmentUpdate): Promise<Appointment> {
+    // Callers catch and present (409 conflict copy, form toasts).
     const response = await api.put<ApiResponse<Appointment>>(
       `/api/v1/agenda/appointments/${id}`,
-      data
+      data,
+      { errorToast: false }
     )
 
     // Update local state
@@ -82,7 +88,8 @@ export function useAppointments() {
   }
 
   async function cancelAppointment(id: string): Promise<void> {
-    await api.del(`/api/v1/agenda/appointments/${id}`)
+    // Caller (AppointmentModal) catches and toasts errorMessage.
+    await api.del(`/api/v1/agenda/appointments/${id}`, { errorToast: false })
 
     // Update local state - mark as cancelled
     appointments.value = appointments.value.map(apt =>
@@ -120,9 +127,11 @@ export function useAppointments() {
     }
 
     try {
+      // Callers catch the rethrow and toast the conflict themselves.
       const response = await api.patch<ApiResponse<Appointment>>(
         `/api/v1/agenda/appointments/${id}/cabinet`,
-        { cabinet_id: cabinetId, note: note ?? null }
+        { cabinet_id: cabinetId, note: note ?? null },
+        { errorToast: false }
       )
       appointments.value = appointments.value.map(apt =>
         apt.id === id ? response.data : apt
@@ -160,9 +169,11 @@ export function useAppointments() {
     }
 
     try {
+      // Callers catch the rethrow and toast the failed transition.
       const response = await api.post<ApiResponse<Appointment>>(
         `/api/v1/agenda/appointments/${id}/transitions`,
-        { to_status: to, note: note ?? null }
+        { to_status: to, note: note ?? null },
+        { errorToast: false }
       )
       appointments.value = appointments.value.map(apt =>
         apt.id === id ? response.data : apt

--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#287): invoice send accepts `send_method=whatsapp` with per-channel recipient validation; the send modal renders channel buttons from the clinic's manual channels.
 
 - fix(#127): every icon-only button in the module's frontend has an i18n-sourced `aria-label` (screen readers announced them as just "button").

--- a/backend/app/modules/billing/frontend/components/InvoiceCollectModal.vue
+++ b/backend/app/modules/billing/frontend/components/InvoiceCollectModal.vue
@@ -8,6 +8,7 @@
  */
 
 import type { InvoicePayment, PaymentMethod } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 
 const props = withDefaults(defineProps<{
   open: boolean
@@ -69,8 +70,7 @@ async function handleSubmit(payload: {
     emit('recorded', recorded)
     emit('update:open', false)
   } catch (e: unknown) {
-    const err = e as { data?: { message?: string, detail?: string } }
-    errorMsg.value = err?.data?.message || err?.data?.detail || t('invoice.errors.recordPayment')
+    errorMsg.value = errorMessage(e, t('invoice.errors.recordPayment'))
   } finally {
     isSubmitting.value = false
   }

--- a/backend/app/modules/billing/frontend/composables/useInvoices.ts
+++ b/backend/app/modules/billing/frontend/composables/useInvoices.ts
@@ -88,7 +88,9 @@ export function useInvoices() {
   async function createSeries(data: InvoiceSeriesCreate): Promise<InvoiceSeries> {
     const response = await api.post<ApiResponse<InvoiceSeries>>(
       '/api/v1/billing/series',
-      data
+      data,
+      // Caller (invoice-series settings page) toasts the failure itself.
+      { errorToast: false }
     )
     return response.data
   }
@@ -96,7 +98,8 @@ export function useInvoices() {
   async function updateSeries(id: string, data: InvoiceSeriesUpdate): Promise<InvoiceSeries> {
     const response = await api.put<ApiResponse<InvoiceSeries>>(
       `/api/v1/billing/series/${id}`,
-      data
+      data,
+      { errorToast: false }
     )
     return response.data
   }
@@ -104,7 +107,8 @@ export function useInvoices() {
   async function resetSeriesCounter(id: string, data: SeriesResetRequest): Promise<InvoiceSeries> {
     const response = await api.post<ApiResponse<InvoiceSeries>>(
       `/api/v1/billing/series/${id}/reset`,
-      data
+      data,
+      { errorToast: false }
     )
     return response.data
   }
@@ -139,7 +143,9 @@ export function useInvoices() {
       }
 
       const response = await api.get<PaginatedResponse<InvoiceListItem>>(
-        `/api/v1/billing/invoices?${searchParams.toString()}`
+        `/api/v1/billing/invoices?${searchParams.toString()}`,
+        // List page renders the `error` state via DataListLayout.
+        { errorToast: false }
       )
 
       invoices.value = response.data
@@ -192,7 +198,9 @@ export function useInvoices() {
   async function createInvoice(data: InvoiceCreate): Promise<Invoice> {
     const response = await api.post<ApiResponse<Invoice>>(
       '/api/v1/billing/invoices',
-      data
+      data,
+      // Callers toast via errorMessage() — keep single-toast behaviour.
+      { errorToast: false }
     )
     invoices.value = [toListItem(response.data), ...invoices.value]
     return response.data
@@ -201,7 +209,8 @@ export function useInvoices() {
   async function createFromBudget(budgetId: string, data: InvoiceFromBudgetCreate): Promise<Invoice> {
     const response = await api.post<ApiResponse<Invoice>>(
       `/api/v1/billing/invoices/from-budget/${budgetId}`,
-      data
+      data,
+      { errorToast: false }
     )
     invoices.value = [toListItem(response.data), ...invoices.value]
     return response.data
@@ -210,7 +219,8 @@ export function useInvoices() {
   async function updateInvoice(id: string, data: InvoiceUpdate): Promise<Invoice> {
     const response = await api.put<ApiResponse<Invoice>>(
       `/api/v1/billing/invoices/${id}`,
-      data
+      data,
+      { errorToast: false }
     )
 
     // Update local state
@@ -242,7 +252,9 @@ export function useInvoices() {
   ): Promise<Invoice> {
     const response = await api.patch<ApiResponse<Invoice>>(
       `/api/v1/billing/invoices/${id}/billing-party`,
-      data
+      data,
+      // Verifactu slot presents 409 (concurrent edit) and other errors.
+      { errorToast: false }
     )
     if (currentInvoice.value?.id === id) {
       currentInvoice.value = { ...currentInvoice.value, ...response.data }
@@ -251,7 +263,7 @@ export function useInvoices() {
   }
 
   async function deleteInvoice(id: string): Promise<void> {
-    await api.del(`/api/v1/billing/invoices/${id}`)
+    await api.del(`/api/v1/billing/invoices/${id}`, { errorToast: false })
 
     // Remove from local state
     invoices.value = invoices.value.filter(i => i.id !== id)
@@ -267,7 +279,8 @@ export function useInvoices() {
   async function addItem(invoiceId: string, data: InvoiceItemCreate): Promise<InvoiceItem> {
     const response = await api.post<ApiResponse<InvoiceItem>>(
       `/api/v1/billing/invoices/${invoiceId}/items`,
-      data
+      data,
+      { errorToast: false }
     )
 
     // Refetch current invoice to get updated totals
@@ -285,7 +298,8 @@ export function useInvoices() {
   ): Promise<InvoiceItem> {
     const response = await api.put<ApiResponse<InvoiceItem>>(
       `/api/v1/billing/invoices/${invoiceId}/items/${itemId}`,
-      data
+      data,
+      { errorToast: false }
     )
 
     // Refetch current invoice to get updated totals
@@ -297,7 +311,7 @@ export function useInvoices() {
   }
 
   async function removeItem(invoiceId: string, itemId: string): Promise<void> {
-    await api.del(`/api/v1/billing/invoices/${invoiceId}/items/${itemId}`)
+    await api.del(`/api/v1/billing/invoices/${invoiceId}/items/${itemId}`, { errorToast: false })
 
     // Refetch current invoice to get updated totals
     if (currentInvoice.value?.id === invoiceId) {
@@ -312,7 +326,8 @@ export function useInvoices() {
   async function issueInvoice(id: string, data: InvoiceIssueRequest = {}): Promise<Invoice> {
     const response = await api.post<ApiResponse<Invoice>>(
       `/api/v1/billing/invoices/${id}/issue`,
-      data
+      data,
+      { errorToast: false }
     )
 
     // Update local state
@@ -325,7 +340,8 @@ export function useInvoices() {
     const params = reason ? `?reason=${encodeURIComponent(reason)}` : ''
     const response = await api.post<ApiResponse<Invoice>>(
       `/api/v1/billing/invoices/${id}/void${params}`,
-      {}
+      {},
+      { errorToast: false }
     )
 
     // Update local state
@@ -337,7 +353,8 @@ export function useInvoices() {
   async function sendInvoice(id: string, data: InvoiceSendRequest): Promise<Invoice> {
     const response = await api.post<ApiResponse<Invoice>>(
       `/api/v1/billing/invoices/${id}/send-email`,
-      data
+      data,
+      { errorToast: false }
     )
 
     return response.data
@@ -346,7 +363,8 @@ export function useInvoices() {
   async function createCreditNote(id: string, data: CreditNoteCreate): Promise<Invoice> {
     const response = await api.post<ApiResponse<Invoice>>(
       `/api/v1/billing/invoices/${id}/credit-note`,
-      data
+      data,
+      { errorToast: false }
     )
     invoices.value = [toListItem(response.data), ...invoices.value]
     updateInvoiceStatus(id, 'cancelled')
@@ -376,7 +394,9 @@ export function useInvoices() {
   async function recordPayment(invoiceId: string, data: InvoicePaymentApply): Promise<InvoicePayment> {
     const response = await api.post<ApiResponse<InvoicePayment>>(
       `/api/v1/billing/invoices/${invoiceId}/payments`,
-      data
+      data,
+      // InvoiceCollectModal renders the failure inline in the modal.
+      { errorToast: false }
     )
 
     // Refetch invoice to pick up the recomputed totals + status.

--- a/backend/app/modules/billing/frontend/pages/invoices/from-budget/[budgetId].vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/from-budget/[budgetId].vue
@@ -39,10 +39,12 @@ onMounted(async () => {
   try {
     const [budgetData, vatResponse, paymentSummary] = await Promise.all([
       fetchBudget(budgetId),
-      api.get<{ data: VatType[] }>('/api/v1/catalog/vat-types'),
+      // The surrounding catch toasts + navigates away on any failure.
+      api.get<{ data: VatType[] }>('/api/v1/catalog/vat-types', { errorToast: false }),
       api.post<ApiResponse<{ summaries: Record<string, { payment_status: string }> }>>(
         '/api/v1/payments/summary/by-budgets',
-        { budget_ids: [budgetId] }
+        { budget_ids: [budgetId] },
+        { errorToast: false }
       )
     ])
 
@@ -51,7 +53,7 @@ onMounted(async () => {
     budgetFullyPaid.value = paymentSummary.data.summaries[budgetId]?.payment_status === 'paid'
     if (budgetFullyPaid.value) form.value.payment_term_days = 0
     if (budgetData?.patient) {
-      patient.value = (await api.get<ApiResponse<Patient>>(`/api/v1/patients/${budgetData.patient.id}`)).data
+      patient.value = (await api.get<ApiResponse<Patient>>(`/api/v1/patients/${budgetData.patient.id}`, { errorToast: false })).data
     }
 
     // Pre-select all items that have available quantity

--- a/backend/app/modules/billing/frontend/pages/invoices/index.vue
+++ b/backend/app/modules/billing/frontend/pages/invoices/index.vue
@@ -72,7 +72,9 @@ async function fetcher(q: {
   if (q.sort) params.set('sort', q.sort)
 
   const response = await api.get<PaginatedResponse<InvoiceListItem>>(
-    `/api/v1/billing/invoices?${params.toString()}`
+    `/api/v1/billing/invoices?${params.toString()}`,
+    // useListQuery surfaces failures via the `error` banner.
+    { errorToast: false }
   )
   return { data: response.data, total: response.total }
 }

--- a/backend/app/modules/billing/frontend/pages/settings/invoice-series/index.vue
+++ b/backend/app/modules/billing/frontend/pages/settings/invoice-series/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { InvoiceSeries, InvoiceSeriesCreate, InvoiceSeriesUpdate, SeriesResetRequest } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 
 const { t } = useI18n()
 const { isAdmin } = usePermissions()
@@ -106,8 +107,7 @@ async function handleCreate() {
     toast.add({ title: t('invoiceSeries.created'), color: 'success' })
     await loadSeries()
   } catch (e: unknown) {
-    const error = e as { data?: { message?: string } }
-    toast.add({ title: error.data?.message || t('common.error'), color: 'error' })
+    toast.add({ title: errorMessage(e, t('common.error')), color: 'error' })
   } finally {
     isCreating.value = false
   }
@@ -144,8 +144,7 @@ async function handleUpdate() {
     toast.add({ title: t('invoiceSeries.saved'), color: 'success' })
     await loadSeries()
   } catch (e: unknown) {
-    const error = e as { data?: { message?: string } }
-    toast.add({ title: error.data?.message || t('common.error'), color: 'error' })
+    toast.add({ title: errorMessage(e, t('common.error')), color: 'error' })
   } finally {
     isEditing.value = false
   }
@@ -172,8 +171,7 @@ async function handleReset() {
     toast.add({ title: t('invoiceSeries.resetSuccess'), color: 'success' })
     await loadSeries()
   } catch (e: unknown) {
-    const error = e as { data?: { message?: string } }
-    toast.add({ title: error.data?.message || t('common.error'), color: 'error' })
+    toast.add({ title: errorMessage(e, t('common.error')), color: 'error' })
   } finally {
     isResetting.value = false
   }

--- a/backend/app/modules/billing/frontend/plugins/settings.client.ts
+++ b/backend/app/modules/billing/frontend/plugins/settings.client.ts
@@ -21,7 +21,8 @@ export default defineNuxtPlugin(() => {
     severity: 'warning',
     load: async (api) => {
       const state = useSeriesOnboardingState()
-      const res = await api.get<{ data: unknown[] }>('/api/v1/billing/series')
+      // Background onboarding probe — never toast from here.
+      const res = await api.get<{ data: unknown[] }>('/api/v1/billing/series', { errorToast: false })
       state.value = { loaded: true, count: res.data.length }
     },
     when: () => {

--- a/backend/app/modules/budget/CHANGELOG.md
+++ b/backend/app/modules/budget/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#287): `send_method` accepts `whatsapp` (router/workflow/tools; legacy `send_email` kept); the send modal offers a button per configured manual channel; the public-link wa.me button is secondary ('Open in WhatsApp'); the reminder cron's clinics query no longer references the never-created `clinics.deleted_at` column (it raised on every tick).
 
 - fix(#101): a failed signature fetch no longer renders as 'not signed' — fetchSignature only nulls on a real 404 and the card shows an error state with Retry.

--- a/backend/app/modules/budget/frontend/composables/useBudgetSettings.ts
+++ b/backend/app/modules/budget/frontend/composables/useBudgetSettings.ts
@@ -1,4 +1,5 @@
 import type { ApiResponse } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 
 export interface BudgetSettings {
   budget_expiry_days: number
@@ -35,14 +36,16 @@ export function useBudgetSettings() {
     try {
       const response = await api.patch<ApiResponse<BudgetSettings>>(
         '/api/v1/auth/clinic/settings/budget',
-        payload
+        payload,
+        // This catch toasts the failure itself.
+        { errorToast: false }
       )
       settings.value = response.data
       toast.add({ title: t('budget.settings.saved'), color: 'success' })
       return true
     } catch (error) {
       console.error('Error saving budget settings:', error)
-      toast.add({ title: t('errors.updateFailed'), color: 'error' })
+      toast.add({ title: errorMessage(error, t('errors.updateFailed')), color: 'error' })
       return false
     } finally {
       saving.value = false

--- a/backend/app/modules/budget/frontend/composables/useBudgets.ts
+++ b/backend/app/modules/budget/frontend/composables/useBudgets.ts
@@ -112,7 +112,9 @@ export function useBudgets() {
 
     try {
       const response = await api.get<ApiResponse<BudgetDetail>>(
-        `/api/v1/budget/budgets/${id}`
+        `/api/v1/budget/budgets/${id}`,
+        // Callers present the failure (toast + redirect) on the null return.
+        { errorToast: false }
       )
       currentBudget.value = response.data
       return response.data
@@ -143,7 +145,9 @@ export function useBudgets() {
   async function createBudget(data: BudgetCreate): Promise<BudgetDetail> {
     const response = await api.post<ApiResponse<BudgetDetail>>(
       '/api/v1/budget/budgets',
-      data
+      data,
+      // Callers toast via errorMessage() — keep single-toast behaviour.
+      { errorToast: false }
     )
     budgets.value = [toListItem(response.data), ...budgets.value]
     currentBudget.value = response.data
@@ -153,7 +157,8 @@ export function useBudgets() {
   async function updateBudget(id: string, data: BudgetUpdate): Promise<BudgetDetail> {
     const response = await api.put<ApiResponse<BudgetDetail>>(
       `/api/v1/budget/budgets/${id}`,
-      data
+      data,
+      { errorToast: false }
     )
 
     // Update local state
@@ -175,7 +180,7 @@ export function useBudgets() {
   }
 
   async function deleteBudget(id: string): Promise<void> {
-    await api.del(`/api/v1/budget/budgets/${id}`)
+    await api.del(`/api/v1/budget/budgets/${id}`, { errorToast: false })
 
     // Remove from local state
     budgets.value = budgets.value.filter(b => b.id !== id)
@@ -191,7 +196,8 @@ export function useBudgets() {
   async function addItem(budgetId: string, data: BudgetItemCreate): Promise<BudgetItem> {
     const response = await api.post<ApiResponse<BudgetItem>>(
       `/api/v1/budget/budgets/${budgetId}/items`,
-      data
+      data,
+      { errorToast: false }
     )
 
     // Refetch current budget to get updated totals
@@ -221,7 +227,7 @@ export function useBudgets() {
   }
 
   async function removeItem(budgetId: string, itemId: string): Promise<void> {
-    await api.del(`/api/v1/budget/budgets/${budgetId}/items/${itemId}`)
+    await api.del(`/api/v1/budget/budgets/${budgetId}/items/${itemId}`, { errorToast: false })
 
     // Refetch current budget to get updated totals
     if (currentBudget.value?.id === budgetId) {
@@ -236,7 +242,8 @@ export function useBudgets() {
   async function sendBudget(id: string, data: BudgetSendRequest = {}): Promise<Budget> {
     const response = await api.post<ApiResponse<Budget>>(
       `/api/v1/budget/budgets/${id}/send`,
-      data
+      data,
+      { errorToast: false }
     )
 
     // Update local state
@@ -248,7 +255,8 @@ export function useBudgets() {
   async function acceptBudget(id: string, data: BudgetAcceptRequest): Promise<Budget> {
     const response = await api.post<ApiResponse<Budget>>(
       `/api/v1/budget/budgets/${id}/accept`,
-      data
+      data,
+      { errorToast: false }
     )
 
     // Update local state
@@ -260,7 +268,8 @@ export function useBudgets() {
   async function rejectBudget(id: string, data: BudgetRejectRequest = {}): Promise<Budget> {
     const response = await api.post<ApiResponse<Budget>>(
       `/api/v1/budget/budgets/${id}/reject`,
-      data
+      data,
+      { errorToast: false }
     )
 
     // Update local state
@@ -272,7 +281,8 @@ export function useBudgets() {
   async function cancelBudget(id: string, data: BudgetCancelRequest = {}): Promise<Budget> {
     const response = await api.post<ApiResponse<Budget>>(
       `/api/v1/budget/budgets/${id}/cancel`,
-      data
+      data,
+      { errorToast: false }
     )
 
     // Update local state
@@ -284,7 +294,8 @@ export function useBudgets() {
   async function duplicateBudget(id: string): Promise<BudgetDetail> {
     const response = await api.post<ApiResponse<BudgetDetail>>(
       `/api/v1/budget/budgets/${id}/duplicate`,
-      {}
+      {},
+      { errorToast: false }
     )
     budgets.value = [toListItem(response.data), ...budgets.value]
     return response.data
@@ -293,7 +304,8 @@ export function useBudgets() {
   async function resendBudget(id: string): Promise<BudgetDetail> {
     const response = await api.post<ApiResponse<BudgetDetail>>(
       `/api/v1/budget/budgets/${id}/resend`,
-      {}
+      {},
+      { errorToast: false }
     )
     budgets.value = [toListItem(response.data), ...budgets.value]
     return response.data
@@ -385,7 +397,10 @@ export function useBudgets() {
   async function fetchSignature(id: string): Promise<BudgetSignatureMeta | null> {
     try {
       const response = await api.get<ApiResponse<BudgetSignatureMeta>>(
-        `/api/v1/budget/budgets/${id}/signature`
+        `/api/v1/budget/budgets/${id}/signature`,
+        // Probe-style read: 404 means "not signed"; other failures render
+        // as the signature card's loadError state, never a toast.
+        { errorToast: false }
       )
       return response.data
     } catch (e: unknown) {

--- a/backend/app/modules/budget/frontend/pages/budgets/index.vue
+++ b/backend/app/modules/budget/frontend/pages/budgets/index.vue
@@ -126,7 +126,9 @@ async function fetcher(q: {
   if (q.sort) params.set('sort', q.sort)
 
   const response = await api.get<PaginatedResponse<BudgetListItem>>(
-    `/api/v1/budget/budgets?${params.toString()}`
+    `/api/v1/budget/budgets?${params.toString()}`,
+    // useListQuery surfaces failures via the `error` banner.
+    { errorToast: false }
   )
 
   // Step 3: bulk summaries enrichment.

--- a/backend/app/modules/catalog/CHANGELOG.md
+++ b/backend/app/modules/catalog/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - fix(#101): a failed catalog load shows an error banner with Retry instead of the 'no items' empty state (which even offered the seed CTA on a mere fetch failure).
 
 - fix(#127): every icon-only button in the module's frontend has an i18n-sourced `aria-label` (screen readers announced them as just "button").

--- a/backend/app/modules/catalog/frontend/composables/useCatalog.ts
+++ b/backend/app/modules/catalog/frontend/composables/useCatalog.ts
@@ -15,24 +15,7 @@ import type {
   TreatmentCatalogItemCreate,
   TreatmentCatalogItemUpdate
 } from '~~/app/types'
-
-/**
- * Extract the FastAPI error `detail` from a fetch error, so toasts can show
- * the exact server message instead of a generic one. Returns null for
- * network errors or unexpected bodies (caller falls back to generic text).
- */
-function apiErrorDetail(e: unknown): string | null {
-  const detail = (e as { data?: { detail?: unknown } }).data?.detail
-  if (typeof detail === 'string') return detail
-  if (Array.isArray(detail)) {
-    // 422 validation errors: [{loc: ["body", "field"], msg: "..."}]
-    const parts = (detail as Array<{ loc?: unknown[], msg?: string }>)
-      .map(d => [Array.isArray(d.loc) ? d.loc.slice(1).join('.') : '', d.msg].filter(Boolean).join(': '))
-      .filter(Boolean)
-    return parts.length ? parts.join('; ') : null
-  }
-  return null
-}
+import { errorMessage } from '~~/app/utils/error'
 
 export function useCatalog() {
   const api = useApi()
@@ -88,7 +71,8 @@ export function useCatalog() {
     try {
       const response = await api.post<ApiResponse<TreatmentCatalogCategory>>(
         '/api/v1/catalog/categories',
-        data
+        data,
+        { errorToast: false }
       )
 
       toast.add({
@@ -112,7 +96,7 @@ export function useCatalog() {
       } else {
         toast.add({
           title: t('common.error'),
-          description: apiErrorDetail(e) || t('catalog.categoryCreateFailed'),
+          description: errorMessage(e, t('catalog.categoryCreateFailed')),
           color: 'error'
         })
       }
@@ -127,7 +111,8 @@ export function useCatalog() {
     try {
       const response = await api.put<ApiResponse<TreatmentCatalogCategory>>(
         `/api/v1/catalog/categories/${categoryId}`,
-        data
+        data,
+        { errorToast: false }
       )
 
       toast.add({
@@ -151,7 +136,7 @@ export function useCatalog() {
       } else {
         toast.add({
           title: t('common.error'),
-          description: apiErrorDetail(e) || t('catalog.categoryUpdateFailed'),
+          description: errorMessage(e, t('catalog.categoryUpdateFailed')),
           color: 'error'
         })
       }
@@ -161,7 +146,7 @@ export function useCatalog() {
 
   async function deleteCategory(categoryId: string): Promise<boolean> {
     try {
-      await api.del(`/api/v1/catalog/categories/${categoryId}`)
+      await api.del(`/api/v1/catalog/categories/${categoryId}`, { errorToast: false })
 
       toast.add({
         title: t('common.success'),
@@ -184,7 +169,7 @@ export function useCatalog() {
       } else {
         toast.add({
           title: t('common.error'),
-          description: apiErrorDetail(e) || t('catalog.categoryDeleteFailed'),
+          description: errorMessage(e, t('catalog.categoryDeleteFailed')),
           color: 'error'
         })
       }
@@ -255,7 +240,8 @@ export function useCatalog() {
     try {
       const response = await api.post<ApiResponse<TreatmentCatalogItem>>(
         '/api/v1/catalog/items',
-        data
+        data,
+        { errorToast: false }
       )
 
       toast.add({
@@ -285,7 +271,7 @@ export function useCatalog() {
       } else {
         toast.add({
           title: t('common.error'),
-          description: apiErrorDetail(e) || t('catalog.itemCreateFailed'),
+          description: errorMessage(e, t('catalog.itemCreateFailed')),
           color: 'error'
         })
       }
@@ -300,7 +286,8 @@ export function useCatalog() {
     try {
       const response = await api.put<ApiResponse<TreatmentCatalogItem>>(
         `/api/v1/catalog/items/${itemId}`,
-        data
+        data,
+        { errorToast: false }
       )
 
       toast.add({
@@ -314,17 +301,17 @@ export function useCatalog() {
 
       return response.data
     } catch (e: unknown) {
-      const fetchError = e as { statusCode?: number, data?: { message?: string } }
+      const fetchError = e as { statusCode?: number }
       if (fetchError.statusCode === 403) {
         toast.add({
           title: t('common.error'),
-          description: fetchError.data?.message || t('catalog.cannotModifySystemItem'),
+          description: errorMessage(e, t('catalog.cannotModifySystemItem')),
           color: 'error'
         })
       } else {
         toast.add({
           title: t('common.error'),
-          description: apiErrorDetail(e) || t('catalog.itemUpdateFailed'),
+          description: errorMessage(e, t('catalog.itemUpdateFailed')),
           color: 'error'
         })
       }
@@ -334,7 +321,7 @@ export function useCatalog() {
 
   async function deleteItem(itemId: string): Promise<boolean> {
     try {
-      await api.del(`/api/v1/catalog/items/${itemId}`)
+      await api.del(`/api/v1/catalog/items/${itemId}`, { errorToast: false })
 
       toast.add({
         title: t('common.success'),
@@ -357,7 +344,7 @@ export function useCatalog() {
       } else {
         toast.add({
           title: t('common.error'),
-          description: apiErrorDetail(e) || t('catalog.itemDeleteFailed'),
+          description: errorMessage(e, t('catalog.itemDeleteFailed')),
           color: 'error'
         })
       }
@@ -394,7 +381,8 @@ export function useCatalog() {
     try {
       const response = await api.post<ApiResponse<{ categories: number, items: number, vat_types: number }>>(
         '/api/v1/catalog/seed',
-        {}
+        {},
+        { errorToast: false }
       )
       toast.add({
         title: t('common.success'),
@@ -406,7 +394,7 @@ export function useCatalog() {
     } catch (e: unknown) {
       toast.add({
         title: t('common.error'),
-        description: apiErrorDetail(e) || t('catalog.defaultsFailed'),
+        description: errorMessage(e, t('catalog.defaultsFailed')),
         color: 'error'
       })
       return false

--- a/backend/app/modules/catalog/frontend/composables/useVatTypes.ts
+++ b/backend/app/modules/catalog/frontend/composables/useVatTypes.ts
@@ -48,7 +48,7 @@ export function useVatTypes() {
     isLoading.value = true
     try {
       const params = includeInactive ? '?include_inactive=true' : ''
-      const response = await api.get<ApiResponse<VatType[]>>(`/api/v1/catalog/vat-types${params}`)
+      const response = await api.get<ApiResponse<VatType[]>>(`/api/v1/catalog/vat-types${params}`, { errorToast: false })
       vatTypes.value = response.data
     } catch (e) {
       toast.add({
@@ -64,7 +64,7 @@ export function useVatTypes() {
   // Create a new VAT type
   async function createVatType(data: VatTypeCreate): Promise<VatType | null> {
     try {
-      const response = await api.post<ApiResponse<VatType>>('/api/v1/catalog/vat-types', data)
+      const response = await api.post<ApiResponse<VatType>>('/api/v1/catalog/vat-types', data, { errorToast: false })
       // If setting as default, update local state
       if (data.is_default) {
         vatTypes.value = vatTypes.value.map(vt => ({ ...vt, is_default: false }))
@@ -89,7 +89,7 @@ export function useVatTypes() {
   // Update a VAT type
   async function updateVatType(id: string, data: VatTypeUpdate): Promise<VatType | null> {
     try {
-      const response = await api.put<ApiResponse<VatType>>(`/api/v1/catalog/vat-types/${id}`, data)
+      const response = await api.put<ApiResponse<VatType>>(`/api/v1/catalog/vat-types/${id}`, data, { errorToast: false })
       // If setting as default, update local state
       if (data.is_default) {
         vatTypes.value = vatTypes.value.map(vt => ({
@@ -121,7 +121,7 @@ export function useVatTypes() {
   // Delete a VAT type (soft delete)
   async function deleteVatType(id: string): Promise<boolean> {
     try {
-      await api.del(`/api/v1/catalog/vat-types/${id}`)
+      await api.del(`/api/v1/catalog/vat-types/${id}`, { errorToast: false })
       // Mark as inactive in local state
       const deleted = vatTypes.value.find(vt => vt.id === id)
       if (deleted) deleted.is_active = false

--- a/backend/app/modules/clinical_notes/CHANGELOG.md
+++ b/backend/app/modules/clinical_notes/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - fix(#101): the note composer keeps typed text and attachments when a save fails (teardown only on success); the three unconfirmed delete surfaces now confirm like the other two.
 
 - feat(#131): German (de) locale for the module's frontend layer.

--- a/backend/app/modules/clinical_notes/frontend/composables/useClinicalNotes.ts
+++ b/backend/app/modules/clinical_notes/frontend/composables/useClinicalNotes.ts
@@ -89,7 +89,8 @@ export function useClinicalNotes() {
     try {
       const response = await api.post<ApiResponse<ClinicalNote>>(
         '/api/v1/clinical_notes/notes',
-        input
+        input,
+        { errorToast: false }
       )
       toast.add({ title: t('clinicalNotes.toasts.saved'), color: 'success' })
       return response.data
@@ -105,7 +106,8 @@ export function useClinicalNotes() {
       const payload: ClinicalNoteUpdate = { body }
       const response = await api.patch<ApiResponse<ClinicalNote>>(
         `/api/v1/clinical_notes/notes/${noteId}`,
-        payload
+        payload,
+        { errorToast: false }
       )
       toast.add({ title: t('clinicalNotes.toasts.saved'), color: 'success' })
       return response.data

--- a/backend/app/modules/copilot/CHANGELOG.md
+++ b/backend/app/modules/copilot/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#131): German (de) locale for the module's frontend layer.
 - feat(#144, #132): Polish (pl) and Italian (it) locales for the module's frontend layer.
 - fix(#184): `PERMISSIONS` imported from `~~/app/config/permissions` (the `~/` form only worked through the layer-aliasing fallback).

--- a/backend/app/modules/copilot/frontend/components/CopilotNudges.vue
+++ b/backend/app/modules/copilot/frontend/components/CopilotNudges.vue
@@ -54,7 +54,7 @@ function promptOf(n: Nudge): string {
 async function dismiss(n: Nudge) {
   nudges.value = nudges.value.filter(x => x.id !== n.id)
   try {
-    await api.post(`/api/v1/copilot/nudges/${n.id}/dismiss`, {})
+    await api.post(`/api/v1/copilot/nudges/${n.id}/dismiss`, {}, { errorToast: false })
   } catch {
     // optimistic; a failed dismiss just reappears on next load
   }

--- a/backend/app/modules/copilot/frontend/components/CopilotSettingsPanel.vue
+++ b/backend/app/modules/copilot/frontend/components/CopilotSettingsPanel.vue
@@ -96,7 +96,7 @@ async function save() {
       digest_enabled: settings.value.digest_enabled,
       digest_hour: settings.value.digest_hour,
       digest_recipient_user_ids: settings.value.digest_recipient_user_ids
-    })
+    }, { errorToast: false })
     settings.value = res.data
     toast.add({ title: t('copilot.settings.saved'), color: 'success' })
   } catch (e) {

--- a/backend/app/modules/india_gst/CHANGELOG.md
+++ b/backend/app/modules/india_gst/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#144, #132): Polish (pl) and Italian (it) locales for the module's frontend layer.
 
 - feat(#262): GSTIN validation verifies the 15th-character mod-36 check digit (`gstin_checksum_char`) on top of the CBIC format regex — typos are rejected at the settings PUT with the expected digit named. The settings response gains `gstin_state_mismatch` (GSTIN's leading state code vs `clinic_state` — warn, never block) and the settings screen shows a live hint; the fixture/demo GSTINs were checksum-corrected (`…1Z5→…1Z7`, `…9Z9→…9ZW`, `…1Z6→…1ZC`, `…1Z3→…1Z4`).

--- a/backend/app/modules/india_gst/frontend/composables/useIndiaGst.ts
+++ b/backend/app/modules/india_gst/frontend/composables/useIndiaGst.ts
@@ -50,13 +50,17 @@ export interface IndiaGstMissingSacItem {
 export function useIndiaGst() {
   const api = useApi()
 
+  // Callers of these either toast the failure in their own catch
+  // (settings page, invoice form panel) or treat it as a semantic
+  // "module not active" fallback (banner, form panel) — suppress the
+  // auto-toast to keep single-message behaviour.
   async function getSettings() {
-    const res = await api.get<ApiResponse<IndiaGstSettings>>('/api/v1/india_gst/settings')
+    const res = await api.get<ApiResponse<IndiaGstSettings>>('/api/v1/india_gst/settings', { errorToast: false })
     return res.data
   }
 
   async function updateSettings(payload: Partial<IndiaGstSettings>) {
-    const res = await api.put<ApiResponse<IndiaGstSettings>>('/api/v1/india_gst/settings', payload)
+    const res = await api.put<ApiResponse<IndiaGstSettings>>('/api/v1/india_gst/settings', payload, { errorToast: false })
     return res.data
   }
 
@@ -64,14 +68,15 @@ export function useIndiaGst() {
     const res = await api.get<ApiResponse<{
       configured: Array<{ catalog_item_id: string, sac_code: string, notes: string | null }>
       missing: IndiaGstMissingSacItem[]
-    }>>('/api/v1/india_gst/catalog-defaults')
+    }>>('/api/v1/india_gst/catalog-defaults', { errorToast: false })
     return res.data
   }
 
   async function autoconfigureCatalogDefaults() {
     const res = await api.post<ApiResponse<{ configured_count: number, sac_code: string }>>(
       '/api/v1/india_gst/catalog-defaults/autoconfigure',
-      {}
+      {},
+      { errorToast: false }
     )
     return res.data
   }
@@ -88,10 +93,12 @@ export function useIndiaGst() {
     items: Array<{ vat_rate: string | number, line_tax: string | number, sac_code?: string | null }>,
     placeOfSupply: string | null
   ) {
+    // Live preview re-run on every place-of-supply change — the panel
+    // falls back to "no preview" on failure; toasting would be noise.
     const res = await api.post<ApiResponse<GstBreakdown>>('/api/v1/india_gst/tax-preview', {
       items,
       place_of_supply: placeOfSupply
-    })
+    }, { errorToast: false })
     return res.data
   }
 
@@ -99,7 +106,8 @@ export function useIndiaGst() {
     invoiceId: string,
     payload: { place_of_supply?: string | null, items?: Array<{ invoice_item_id: string, sac_code: string | null }> }
   ) {
-    await api.put(`/api/v1/india_gst/invoices/${invoiceId}`, payload)
+    // The invoice form panel toasts its own save-error message.
+    await api.put(`/api/v1/india_gst/invoices/${invoiceId}`, payload, { errorToast: false })
   }
 
   async function getEinvoiceStatus(invoiceId: string) {

--- a/backend/app/modules/india_gst/frontend/pages/reports/india-gst.vue
+++ b/backend/app/modules/india_gst/frontend/pages/reports/india-gst.vue
@@ -50,8 +50,8 @@ async function load() {
   isLoading.value = true
   try {
     const [summaryRes, txRes] = await Promise.all([
-      api.get<{ data: Summary }>('/api/v1/india_gst/reports/summary'),
-      api.get<{ data: TransactionRow[] }>('/api/v1/india_gst/reports/transactions')
+      api.get<{ data: Summary }>('/api/v1/india_gst/reports/summary', { errorToast: false }),
+      api.get<{ data: TransactionRow[] }>('/api/v1/india_gst/reports/transactions', { errorToast: false })
     ])
     summary.value = summaryRes.data
     transactions.value = txRes.data

--- a/backend/app/modules/inventory/CHANGELOG.md
+++ b/backend/app/modules/inventory/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#131): German (de) locale for the module's frontend layer.
 - feat(#144, #132): Polish (pl) and Italian (it) locales for the module's frontend layer.
 

--- a/backend/app/modules/inventory/frontend/composables/useInventory.ts
+++ b/backend/app/modules/inventory/frontend/composables/useInventory.ts
@@ -46,6 +46,8 @@ export interface InventoryListFilters {
 export function useInventory() {
   const api = useApi()
 
+  // Every caller (pages/inventory/index.vue) catches and toasts via its
+  // own `notifyError` — suppress useApi's auto-toast to stay single-toast.
   async function list(filters: InventoryListFilters = {}): Promise<ApiPaged<InventoryItem>> {
     const qs = new URLSearchParams()
     for (const [k, v] of Object.entries(filters)) {
@@ -53,23 +55,24 @@ export function useInventory() {
       qs.append(k, String(v))
     }
     const url = `/api/v1/inventory/${qs.toString() ? `?${qs.toString()}` : ''}`
-    return await api.get<ApiPaged<InventoryItem>>(url)
+    return await api.get<ApiPaged<InventoryItem>>(url, { errorToast: false })
   }
 
   async function create(payload: InventoryItemCreatePayload): Promise<ApiOk<InventoryItem>> {
-    return await api.post<ApiOk<InventoryItem>>('/api/v1/inventory/', payload)
+    return await api.post<ApiOk<InventoryItem>>('/api/v1/inventory/', payload, { errorToast: false })
   }
 
   async function update(id: string, payload: InventoryItemUpdatePayload): Promise<ApiOk<InventoryItem>> {
-    return await api.patch<ApiOk<InventoryItem>>(`/api/v1/inventory/${id}`, payload)
+    return await api.patch<ApiOk<InventoryItem>>(`/api/v1/inventory/${id}`, payload, { errorToast: false })
   }
 
   async function adjust(id: string, delta: number): Promise<ApiOk<InventoryItem>> {
-    return await api.post<ApiOk<InventoryItem>>(`/api/v1/inventory/${id}/adjust`, { delta })
+    // 409 (stock would go negative) is an expected branch the page toasts.
+    return await api.post<ApiOk<InventoryItem>>(`/api/v1/inventory/${id}/adjust`, { delta }, { errorToast: false })
   }
 
   async function remove(id: string): Promise<void> {
-    await api.del(`/api/v1/inventory/${id}`)
+    await api.del(`/api/v1/inventory/${id}`, { errorToast: false })
   }
 
   return { list, create, update, adjust, remove }

--- a/backend/app/modules/media/CHANGELOG.md
+++ b/backend/app/modules/media/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - fix(#127): every icon-only button in the module's frontend has an i18n-sourced `aria-label` (screen readers announced them as just "button").
 
 - fix(#184): type-check clean — drop the `onRequest` hook that cast ofetch's `Headers` to delete `Content-Type` (ofetch already leaves it unset for `FormData`).

--- a/backend/app/modules/media/frontend/composables/useAttachments.ts
+++ b/backend/app/modules/media/frontend/composables/useAttachments.ts
@@ -34,7 +34,8 @@ export function useAttachments() {
     try {
       const response = await api.post<ApiResponse<MediaAttachment>>(
         '/api/v1/media/attachments',
-        payload
+        payload,
+        { errorToast: false }
       )
       return response.data
     } catch (error) {
@@ -50,7 +51,7 @@ export function useAttachments() {
 
   async function unlink(attachmentId: string): Promise<boolean> {
     try {
-      await api.del(`/api/v1/media/attachments/${attachmentId}`)
+      await api.del(`/api/v1/media/attachments/${attachmentId}`, { errorToast: false })
       return true
     } catch (error) {
       console.error('Error unlinking attachment:', error)

--- a/backend/app/modules/media/frontend/composables/usePhotos.ts
+++ b/backend/app/modules/media/frontend/composables/usePhotos.ts
@@ -67,7 +67,8 @@ export function usePhotos() {
       params.append('page_size', String(filters.page_size ?? 40))
 
       const response = await api.get<PaginatedResponse<Document>>(
-        `/api/v1/media/patients/${patientId}/photos?${params}`
+        `/api/v1/media/patients/${patientId}/photos?${params}`,
+        { errorToast: false }
       )
       photos.value = response.data
       total.value = response.total
@@ -103,7 +104,8 @@ export function usePhotos() {
 
       const response = await api.post<ApiResponse<Document>>(
         `/api/v1/media/patients/${patientId}/photos`,
-        formData
+        formData,
+        { errorToast: false }
       )
       toast.add({
         title: t('common.success'),
@@ -131,7 +133,8 @@ export function usePhotos() {
     try {
       const response = await api.patch<ApiResponse<Document>>(
         `/api/v1/media/documents/${documentId}/photo-metadata`,
-        patch
+        patch,
+        { errorToast: false }
       )
       const idx = photos.value.findIndex(p => p.id === documentId)
       if (idx !== -1) photos.value[idx] = response.data
@@ -147,7 +150,8 @@ export function usePhotos() {
     try {
       const response = await api.post<ApiResponse<Document>>(
         `/api/v1/media/documents/${a}/pair/${b}`,
-        {}
+        {},
+        { errorToast: false }
       )
       toast.add({
         title: t('photoGallery.paired', 'Before/after paired'),
@@ -163,7 +167,7 @@ export function usePhotos() {
 
   async function unpair(documentId: string): Promise<boolean> {
     try {
-      await api.del(`/api/v1/media/documents/${documentId}/pair`)
+      await api.del(`/api/v1/media/documents/${documentId}/pair`, { errorToast: false })
       return true
     } catch (error) {
       console.error('Error unpairing:', error)

--- a/backend/app/modules/medical_reference/CHANGELOG.md
+++ b/backend/app/modules/medical_reference/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#144, #132): Polish (pl) and Italian (it) locales for the module's frontend layer.
 - fix(#274): the patient warning chips subscribe to the host data bus on
   the `patients_clinical` namespace (ADR 0021) and refetch after every

--- a/backend/app/modules/medical_reference/frontend/composables/useMedicalReference.ts
+++ b/backend/app/modules/medical_reference/frontend/composables/useMedicalReference.ts
@@ -1,3 +1,5 @@
+import { errorMessage } from '~~/app/utils/error'
+
 interface ApiResponse<T> { data: T }
 
 export type ReferenceKind = 'allergies' | 'medications' | 'diseases' | 'surgeries'
@@ -63,14 +65,13 @@ export function useMedicalReference() {
 
   async function create(kind: ReferenceKind, data: { name: string }): Promise<ReferenceItem | null> {
     try {
-      const res = await api.post<ApiResponse<ReferenceItem>>(`/api/v1/medical_reference/${kind}`, data)
+      const res = await api.post<ApiResponse<ReferenceItem>>(`/api/v1/medical_reference/${kind}`, data, { errorToast: false })
       toast.add({ title: t('common.success'), description: t('medicalReference.addSuccess'), color: 'success' })
       return res.data
     } catch (e: unknown) {
-      const err = e as { data?: { detail?: string } }
       toast.add({
         title: t('common.error'),
-        description: err?.data?.detail || t('medicalReference.addError'),
+        description: errorMessage(e, t('medicalReference.addError')),
         color: 'error'
       })
       console.error(`Failed to create medical_reference/${kind} item:`, e)
@@ -84,7 +85,7 @@ export function useMedicalReference() {
     data: { name?: string, is_active?: boolean }
   ): Promise<ReferenceItem | null> {
     try {
-      const res = await api.put<ApiResponse<ReferenceItem>>(`/api/v1/medical_reference/${kind}/${id}`, data)
+      const res = await api.put<ApiResponse<ReferenceItem>>(`/api/v1/medical_reference/${kind}/${id}`, data, { errorToast: false })
       return res.data
     } catch (e) {
       toast.add({ title: t('common.error'), description: t('medicalReference.updateError'), color: 'error' })
@@ -95,7 +96,7 @@ export function useMedicalReference() {
 
   async function deactivate(kind: ReferenceKind, id: string): Promise<boolean> {
     try {
-      await api.del(`/api/v1/medical_reference/${kind}/${id}`)
+      await api.del(`/api/v1/medical_reference/${kind}/${id}`, { errorToast: false })
       return true
     } catch (e) {
       toast.add({ title: t('common.error'), description: t('medicalReference.deactivateError'), color: 'error' })
@@ -127,15 +128,15 @@ export function useMedicalReference() {
     try {
       const res = await api.post<ApiResponse<ReferenceInteraction>>(
         '/api/v1/medical_reference/interactions',
-        data
+        data,
+        { errorToast: false }
       )
       toast.add({ title: t('common.success'), description: t('medicalReference.addSuccess'), color: 'success' })
       return res.data
     } catch (e: unknown) {
-      const err = e as { data?: { detail?: string } }
       toast.add({
         title: t('common.error'),
-        description: err?.data?.detail || t('medicalReference.addError'),
+        description: errorMessage(e, t('medicalReference.addError')),
         color: 'error'
       })
       console.error('Failed to create interaction:', e)
@@ -145,7 +146,7 @@ export function useMedicalReference() {
 
   async function deactivateInteraction(id: string): Promise<boolean> {
     try {
-      await api.del(`/api/v1/medical_reference/interactions/${id}`)
+      await api.del(`/api/v1/medical_reference/interactions/${id}`, { errorToast: false })
       return true
     } catch (e) {
       toast.add({ title: t('common.error'), description: t('medicalReference.deactivateError'), color: 'error' })
@@ -177,15 +178,15 @@ export function useMedicalReference() {
     try {
       const res = await api.post<ApiResponse<ReferenceContraindication>>(
         '/api/v1/medical_reference/contraindications',
-        data
+        data,
+        { errorToast: false }
       )
       toast.add({ title: t('common.success'), description: t('medicalReference.addSuccess'), color: 'success' })
       return res.data
     } catch (e: unknown) {
-      const err = e as { data?: { detail?: string } }
       toast.add({
         title: t('common.error'),
-        description: err?.data?.detail || t('medicalReference.addError'),
+        description: errorMessage(e, t('medicalReference.addError')),
         color: 'error'
       })
       console.error('Failed to create contraindication:', e)
@@ -195,7 +196,7 @@ export function useMedicalReference() {
 
   async function deactivateContraindication(id: string): Promise<boolean> {
     try {
-      await api.del(`/api/v1/medical_reference/contraindications/${id}`)
+      await api.del(`/api/v1/medical_reference/contraindications/${id}`, { errorToast: false })
       return true
     } catch (e) {
       toast.add({ title: t('common.error'), description: t('medicalReference.deactivateError'), color: 'error' })

--- a/backend/app/modules/medication_catalog/CHANGELOG.md
+++ b/backend/app/modules/medication_catalog/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#144, #132): Polish (pl) and Italian (it) locales for the module's frontend layer.
 
 - Name normalisation now matches the unique index key exactly

--- a/backend/app/modules/medication_catalog/frontend/components/settings/MedicationCatalogSettingsPage.vue
+++ b/backend/app/modules/medication_catalog/frontend/components/settings/MedicationCatalogSettingsPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { PERMISSIONS } from '~~/app/config/permissions'
+import { errorMessage } from '~~/app/utils/error'
 import {
   useMedicationCatalog,
   type MedicationCatalogItem,
@@ -142,9 +143,7 @@ async function submit() {
     showModal.value = false
     await load()
   } catch (err: unknown) {
-    // ofetch's FetchError carries the ApiResponse envelope in `.data`.
-    const fetchErr = err as { data?: { message?: string } | undefined }
-    formError.value = fetchErr?.data?.message || t('medications.duplicateName')
+    formError.value = errorMessage(err, t('medications.duplicateName'))
   } finally {
     saving.value = false
   }

--- a/backend/app/modules/medication_catalog/frontend/composables/useMedicationCatalog.ts
+++ b/backend/app/modules/medication_catalog/frontend/composables/useMedicationCatalog.ts
@@ -62,12 +62,14 @@ export function useMedicationCatalog() {
     return await api.get<ApiPaged<MedicationCatalogItem>>(url)
   }
 
+  // 409 on duplicate names is an expected branch — the settings page
+  // renders it as an inline form error, so suppress the auto-toast.
   async function create(payload: MedicationCreatePayload): Promise<ApiOk<MedicationCatalogItem>> {
-    return await api.post<ApiOk<MedicationCatalogItem>>('/api/v1/medication_catalog/', payload)
+    return await api.post<ApiOk<MedicationCatalogItem>>('/api/v1/medication_catalog/', payload, { errorToast: false })
   }
 
   async function update(id: string, payload: MedicationUpdatePayload): Promise<ApiOk<MedicationCatalogItem>> {
-    return await api.patch<ApiOk<MedicationCatalogItem>>(`/api/v1/medication_catalog/${id}`, payload)
+    return await api.patch<ApiOk<MedicationCatalogItem>>(`/api/v1/medication_catalog/${id}`, payload, { errorToast: false })
   }
 
   async function remove(id: string): Promise<void> {

--- a/backend/app/modules/migration_import/CHANGELOG.md
+++ b/backend/app/modules/migration_import/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#131): German (de) locale for the module's frontend layer.
 - feat(#144, #132): Polish (pl) and Italian (it) locales for the module's frontend layer.
 

--- a/backend/app/modules/migration_import/frontend/components/settings/DataMigrationPage.vue
+++ b/backend/app/modules/migration_import/frontend/components/settings/DataMigrationPage.vue
@@ -127,7 +127,9 @@ async function startUpload() {
   try {
     const formData = new FormData()
     formData.append('file', file.value)
-    const res = await api.post<{ data: ImportJob }>('/api/v1/migration_import/jobs', formData)
+    // Failures here (and in the nested validate/preview calls) render
+    // into the `uploadError` inline alert — no auto-toast.
+    const res = await api.post<{ data: ImportJob }>('/api/v1/migration_import/jobs', formData, { errorToast: false })
     job.value = res.data
     await runValidate()
   } catch (err: unknown) {
@@ -141,7 +143,9 @@ async function runValidate() {
   if (!job.value) return
   const res = await api.post<{ data: ImportJob }>(
     `/api/v1/migration_import/jobs/${job.value.id}/validate`,
-    { passphrase: passphrase.value || null }
+    { passphrase: passphrase.value || null },
+    // Bad passphrase / corrupt file → surfaced via `uploadError`.
+    { errorToast: false }
   )
   job.value = res.data
   if (job.value.status === 'validated') await loadPreview()
@@ -151,7 +155,9 @@ async function loadPreview() {
   if (!job.value) return
   const res = await api.post<{ data: PreviewResponse }>(
     `/api/v1/migration_import/jobs/${job.value.id}/preview`,
-    { passphrase: passphrase.value || null }
+    { passphrase: passphrase.value || null },
+    // Reached only via startUpload's try — surfaced via `uploadError`.
+    { errorToast: false }
   )
   preview.value = res.data
   job.value = res.data.job
@@ -177,7 +183,9 @@ async function buildProposals() {
   try {
     const res = await api.post<{ data: ProposalSummary }>(
       `/api/v1/migration_import/jobs/${job.value.id}/proposals`,
-      { passphrase: passphrase.value || null }
+      { passphrase: passphrase.value || null },
+      // Failure renders into the `proposalsError` inline alert.
+      { errorToast: false }
     )
     proposalSummary.value = res.data
     await loadProposals()

--- a/backend/app/modules/notifications/CHANGELOG.md
+++ b/backend/app/modules/notifications/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#287): clinic-wide channel configuration — `preferred_channel`, `fallback_enabled`, `manual_channels` on clinic_notification_settings (migration notif_0004) with `available_channels` computed from the adapter registry; the gateway resolves auto-sends as preferred→fallback instead of per-type channel lists; missing preference rows no longer block WhatsApp (opt-out, bug 11); manual `POST /send` accepts `channels` and no longer 400s phone-only WhatsApp sends; every contact guard is email-OR-phone; the broken 7/14-day budget reminder actually sends (new `budget_reminder` handler + templates); skip rows carry the real channel; Settings page grew a Channels card; the type table gained invoice_sent/budget_reminder/recall_reminder.
 
 - fix(#287): an explicit `whatsapp_enabled=False` opt-out blocks WhatsApp even under `force_send` — same contract as `email_enabled` (the reminder cron and staff Send buttons pass `force_send` and must not override a recorded opt-out); missing rows still don't block.

--- a/backend/app/modules/notifications/frontend/components/ConversationThread.vue
+++ b/backend/app/modules/notifications/frontend/components/ConversationThread.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useConversation } from '../composables/useConversation'
+import { errorDetail } from '~~/app/utils/error'
 
 const props = defineProps<{ ctx: { patient: { id: string } } }>()
 const { t } = useI18n()
@@ -33,10 +34,9 @@ async function onSend() {
     await conv.reply(draft.value.trim())
     draft.value = ''
   } catch (e: unknown) {
-    const detail = (e as { data?: { detail?: string } })?.data?.detail
     toast.add({
       title: t('notifications.conversation.replyError'),
-      description: detail ?? t('notifications.conversation.windowClosed'),
+      description: errorDetail(e) ?? t('notifications.conversation.windowClosed'),
       color: 'error'
     })
   }

--- a/backend/app/modules/notifications/frontend/composables/useCommunicationsSettings.ts
+++ b/backend/app/modules/notifications/frontend/composables/useCommunicationsSettings.ts
@@ -33,7 +33,8 @@ export function useCommunicationsSettings() {
     try {
       const response = await api.patch<ApiResponse<CommunicationsSettings>>(
         '/api/v1/auth/clinic/settings/communications',
-        payload
+        payload,
+        { errorToast: false }
       )
       settings.value = response.data
       toast.add({

--- a/backend/app/modules/notifications/frontend/composables/useConversation.ts
+++ b/backend/app/modules/notifications/frontend/composables/useConversation.ts
@@ -39,9 +39,12 @@ export function useConversation(patientId: string) {
   async function reply(body: string, channel = 'whatsapp') {
     sending.value = true
     try {
+      // 409 outside the 24h WhatsApp window is an expected branch — the
+      // caller (ConversationThread) presents it, so no auto-toast here.
       const res = await api.post<ApiResponse<ConversationMessage>>(
         `${BASE}/${patientId}/reply`,
-        { channel, body }
+        { channel, body },
+        { errorToast: false }
       )
       messages.value.push(res.data)
       return true

--- a/backend/app/modules/notifications/frontend/composables/useNotificationSend.ts
+++ b/backend/app/modules/notifications/frontend/composables/useNotificationSend.ts
@@ -44,7 +44,8 @@ export function useNotificationSend() {
       }
       const response = await api.post<ApiResponse<ManualSendResponse>>(
         '/api/v1/notifications/send',
-        payload
+        payload,
+        { errorToast: false }
       )
       if (response.data.success) {
         toast.add({

--- a/backend/app/modules/notifications/frontend/composables/useNotificationSettings.ts
+++ b/backend/app/modules/notifications/frontend/composables/useNotificationSettings.ts
@@ -98,7 +98,8 @@ export function useNotificationSettings() {
     isLoading.value = true
     try {
       const response = await api.get<ApiResponse<ClinicNotificationSettings>>(
-        '/api/v1/notifications/settings'
+        '/api/v1/notifications/settings',
+        { errorToast: false }
       )
       settings.value = response.data
     } catch (e) {
@@ -120,7 +121,8 @@ export function useNotificationSettings() {
     try {
       const response = await api.put<ApiResponse<ClinicNotificationSettings>>(
         '/api/v1/notifications/settings',
-        data
+        data,
+        { errorToast: false }
       )
       settings.value = response.data
       toast.add({
@@ -149,7 +151,8 @@ export function useNotificationSettings() {
     try {
       const response = await api.post<ApiResponse<TestEmailResponse>>(
         '/api/v1/notifications/test',
-        { to_email: toEmail }
+        { to_email: toEmail },
+        { errorToast: false }
       )
       if (response.data.success) {
         toast.add({
@@ -185,7 +188,8 @@ export function useNotificationSettings() {
     try {
       const response = await api.post<ApiResponse<ManualSendResponse>>(
         '/api/v1/notifications/send',
-        request
+        request,
+        { errorToast: false }
       )
       if (response.data.success) {
         toast.add({
@@ -273,7 +277,8 @@ export function useNotificationSettings() {
     isSmtpLoading.value = true
     try {
       const response = await api.get<ApiResponse<SmtpSettings>>(
-        '/api/v1/notifications/smtp-settings'
+        '/api/v1/notifications/smtp-settings',
+        { errorToast: false }
       )
       smtpSettings.value = response.data
     } catch (e) {
@@ -295,7 +300,8 @@ export function useNotificationSettings() {
     try {
       const response = await api.put<ApiResponse<SmtpSettings>>(
         '/api/v1/notifications/smtp-settings',
-        data
+        data,
+        { errorToast: false }
       )
       smtpSettings.value = response.data
       toast.add({
@@ -324,7 +330,8 @@ export function useNotificationSettings() {
     try {
       const response = await api.post<ApiResponse<TestEmailResponse>>(
         '/api/v1/notifications/smtp-settings/test',
-        request
+        request,
+        { errorToast: false }
       )
       if (response.data.success) {
         toast.add({

--- a/backend/app/modules/odontogram/CHANGELOG.md
+++ b/backend/app/modules/odontogram/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - fix(#101): treatment delete asks for confirmation (names the treatment and tooth); the edit modal stays open with the user's edits when a save fails, and surface edits are actually included in the update payload (they were silently dropped).
 
 - feat: global treatments from unmapped catalog items are creatable —

--- a/backend/app/modules/odontogram/frontend/composables/useOdontogramData.ts
+++ b/backend/app/modules/odontogram/frontend/composables/useOdontogramData.ts
@@ -76,8 +76,10 @@ export function useOdontogramData() {
     error.value = null
 
     try {
+      // OdontogramChart renders `error` as its load-error alert.
       const response = await api.get<ApiResponse<OdontogramData>>(
-        `/api/v1/odontogram/patients/${patientId}/odontogram`
+        `/api/v1/odontogram/patients/${patientId}/odontogram`,
+        { errorToast: false }
       )
       odontogramData.value = response.data
     } catch (err) {
@@ -97,7 +99,8 @@ export function useOdontogramData() {
     try {
       const response = await api.put<ApiResponse<ToothRecord>>(
         `/api/v1/odontogram/patients/${patientId}/teeth/${toothNumber}`,
-        update as Record<string, unknown>
+        update as Record<string, unknown>,
+        { errorToast: false }
       )
 
       // Update local state
@@ -135,7 +138,8 @@ export function useOdontogramData() {
     try {
       const response = await api.patch<ApiResponse<ToothRecord[]>>(
         `/api/v1/odontogram/patients/${patientId}/teeth/bulk`,
-        { updates } as Record<string, unknown>
+        { updates } as Record<string, unknown>,
+        { errorToast: false }
       )
 
       // Update local state

--- a/backend/app/modules/odontogram/frontend/composables/useOdontogramTimeline.ts
+++ b/backend/app/modules/odontogram/frontend/composables/useOdontogramTimeline.ts
@@ -73,7 +73,8 @@ export function useOdontogramTimeline() {
     loading.value = true
     try {
       const response = await api.get<ApiResponse<OdontogramData>>(
-        `/api/v1/odontogram/patients/${patientId}/odontogram/at?date=${date}`
+        `/api/v1/odontogram/patients/${patientId}/odontogram/at?date=${date}`,
+        { errorToast: false }
       )
       historicalTeeth.value = response.data.teeth
       historicalTreatments.value = response.data.treatments || []

--- a/backend/app/modules/odontogram/frontend/composables/useTreatments.ts
+++ b/backend/app/modules/odontogram/frontend/composables/useTreatments.ts
@@ -111,7 +111,8 @@ export function useTreatments() {
       }
       const response = await api.post<ApiResponse<Treatment>>(
         `/api/v1/odontogram/patients/${patientId}/treatments`,
-        body
+        body,
+        { errorToast: false }
       )
       const normalized = normalizeTreatment(response.data)
       treatments.value.push(normalized)
@@ -135,7 +136,8 @@ export function useTreatments() {
       const body = { ...data, status: toBackendStatus(data.status) }
       const response = await api.put<ApiResponse<Treatment>>(
         `/api/v1/odontogram/treatments/${treatmentId}`,
-        body as Record<string, unknown>
+        body as Record<string, unknown>,
+        { errorToast: false }
       )
       const normalized = normalizeTreatment(response.data)
       updateLocalTreatment(normalized)
@@ -154,7 +156,7 @@ export function useTreatments() {
 
   async function deleteTreatment(treatmentId: string): Promise<boolean> {
     try {
-      await api.del(`/api/v1/odontogram/treatments/${treatmentId}`)
+      await api.del(`/api/v1/odontogram/treatments/${treatmentId}`, { errorToast: false })
       removeLocalTreatment(treatmentId)
       toast.add({ title: t('odontogram.treatments.treatmentDeleted'), color: 'success' })
       return true
@@ -176,7 +178,8 @@ export function useTreatments() {
     try {
       const response = await api.patch<ApiResponse<Treatment>>(
         `/api/v1/odontogram/treatments/${treatmentId}/perform`,
-        { notes } as Record<string, unknown>
+        { notes } as Record<string, unknown>,
+        { errorToast: false }
       )
       const normalized = normalizeTreatment(response.data)
       updateLocalTreatment(normalized)

--- a/backend/app/modules/patient_relationships/CHANGELOG.md
+++ b/backend/app/modules/patient_relationships/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#131): German (de) locale for the module's frontend layer.
 
 - feat(#144, #132): Polish (pl) and Italian (it) locales for the module's frontend layer.

--- a/backend/app/modules/patient_relationships/frontend/composables/usePatientRelationships.ts
+++ b/backend/app/modules/patient_relationships/frontend/composables/usePatientRelationships.ts
@@ -1,4 +1,5 @@
 import type { ApiResponse } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 
 export interface PatientRelationship {
   id: string
@@ -44,7 +45,8 @@ export function usePatientRelationships(patientId: Ref<string | undefined>) {
     try {
       const res = await api.post<ApiResponse<PatientRelationship>>(
         `/api/v1/patient_relationships/patients/${patientId.value}/relationships`,
-        data
+        data,
+        { errorToast: false }
       )
       relationships.value.push(res.data)
       toast.add({
@@ -54,10 +56,9 @@ export function usePatientRelationships(patientId: Ref<string | undefined>) {
       })
       return true
     } catch (e: unknown) {
-      const err = e as { data?: { detail?: string } }
       toast.add({
         title: t('common.error'),
-        description: err?.data?.detail || t('patientRelationships.relationships.addError'),
+        description: errorMessage(e, t('patientRelationships.relationships.addError')),
         color: 'error'
       })
       console.error('Failed to add relationship:', e)
@@ -71,7 +72,8 @@ export function usePatientRelationships(patientId: Ref<string | undefined>) {
     if (!patientId.value) return false
     try {
       await api.del(
-        `/api/v1/patient_relationships/patients/${patientId.value}/relationships/${relationshipId}`
+        `/api/v1/patient_relationships/patients/${patientId.value}/relationships/${relationshipId}`,
+        { errorToast: false }
       )
       relationships.value = relationships.value.filter(r => r.id !== relationshipId)
       return true

--- a/backend/app/modules/patients/CHANGELOG.md
+++ b/backend/app/modules/patients/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - fix: `last_visit` (list sort and `get_recent_patients`) counts **completed** appointments only, matching the patient-summary last-visit card's definition — a future booking or a cancellation no longer ranks a patient as recently seen (PR #251 review follow-up).
 - chore: delete the orphaned `VisitSummaryCard.vue` (never mounted; superseded by the agenda-owned `NextAppointmentCard` + `LastVisitCard` on `patient.summary.cards`, #182) and its now-unused `patients.visitSummary.*` i18n keys in all five locales.
 

--- a/backend/app/modules/patients/frontend/components/patient/PatientSectionEditModal.vue
+++ b/backend/app/modules/patients/frontend/components/patient/PatientSectionEditModal.vue
@@ -8,6 +8,7 @@ import type {
   PatientAddress,
   PatientBillingAddress
 } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 
 type SectionType = 'demographics' | 'emergency' | 'guardian' | 'billing' | 'medical'
 
@@ -201,14 +202,15 @@ async function handleSave() {
 
     if (method === 'del') {
       try {
-        await api.del(endpoint)
+        await api.del(endpoint, { errorToast: false })
       } catch (e: unknown) {
         // Emergency/guardian may not exist yet — delete 404 is harmless.
         const err = e as { statusCode?: number }
         if (err.statusCode !== 404) throw e
       }
     } else {
-      await api.put(endpoint, updateData as Record<string, unknown>)
+      // Failures are toasted by the catch below — keep single-toast.
+      await api.put(endpoint, updateData as Record<string, unknown>, { errorToast: false })
     }
 
     toast.add({
@@ -222,10 +224,9 @@ async function handleSave() {
     await nextTick()
     emit('save', props.section, (updateData ?? {}) as Record<string, unknown>)
   } catch (error: unknown) {
-    const fetchError = error as { statusCode?: number, data?: { message?: string } }
     toast.add({
       title: t('common.error'),
-      description: fetchError.data?.message || t('common.serverError'),
+      description: errorMessage(error, t('common.serverError')),
       color: 'error'
     })
   } finally {

--- a/backend/app/modules/patients/frontend/pages/patients/[id].vue
+++ b/backend/app/modules/patients/frontend/pages/patients/[id].vue
@@ -16,6 +16,7 @@
  * modules' APIs directly.
  */
 import type { PatientExtended, ApiResponse } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 import { PERMISSIONS } from '~~/app/config/permissions'
 
 const { t } = useI18n()
@@ -203,7 +204,8 @@ async function archivePatient() {
   isSubmitting.value = true
 
   try {
-    await api.del(`/api/v1/patients/${patientId}`)
+    // Failures are toasted by the catch below — keep single-toast.
+    await api.del(`/api/v1/patients/${patientId}`, { errorToast: false })
 
     toast.add({
       title: t('common.success'),
@@ -213,11 +215,9 @@ async function archivePatient() {
 
     await router.push('/patients')
   } catch (error: unknown) {
-    const fetchError = error as { statusCode?: number, data?: { message?: string } }
-
     toast.add({
       title: t('common.error'),
-      description: fetchError.data?.message || t('common.serverError'),
+      description: errorMessage(error, t('common.serverError')),
       color: 'error'
     })
   } finally {

--- a/backend/app/modules/patients/frontend/pages/patients/index.vue
+++ b/backend/app/modules/patients/frontend/pages/patients/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Patient, PatientCreate, PaginatedResponse, ApiResponse } from '~~/app/types'
+import { errorMessage } from '~~/app/utils/error'
 import { PATIENT_STATUS_ROLE, type PatientStatus } from '~~/app/config/severity'
 import { PERMISSIONS } from '~~/app/config/permissions'
 
@@ -217,7 +218,7 @@ async function createPatient() {
       national_id: newPatient.national_id || null,
       date_of_birth: newPatient.date_of_birth || null,
       notes: newPatient.notes || null
-    })
+    }, { errorToast: false })
     toast.add({
       title: t('common.success'),
       description: t('patients.created'),
@@ -228,10 +229,9 @@ async function createPatient() {
     await refresh()
     await router.push(`/patients/${response.data.id}`)
   } catch (e: unknown) {
-    const fetchError = e as { statusCode?: number, data?: { message?: string } }
     toast.add({
       title: t('common.error'),
-      description: fetchError.data?.message || t('common.serverError'),
+      description: errorMessage(e, t('common.serverError')),
       color: 'error'
     })
   } finally {
@@ -246,283 +246,285 @@ function patientCity(p: Patient): string {
 </script>
 
 <template>
-  <DataListLayout
-    :title="t('patients.title')"
-    :loading="isLoading"
-    :empty="!patients.length"
-    :error="error"
-    :page="page"
-    :page-size="pageSize"
-    :total="total"
-    :total-pages="totalPages"
-    @update:page="(v) => (page = v)"
-  >
-    <template #actions>
-      <UButton
-        color="primary"
-        variant="soft"
-        icon="i-lucide-plus"
-        @click="isCreateModalOpen = true"
-      >
-        {{ t('patients.create') }}
-      </UButton>
-    </template>
-
-    <template #toolbar>
-      <FilterBar
-        :active-count="activeFilterCount"
-        @reset="resetFilters"
-      >
-        <template #search>
-          <SearchBar
-            :model-value="filters.q"
-            :placeholder="t('patients.searchPlaceholder')"
-            max-width="max-w-md"
-            @update:model-value="(v) => setFilter('q', v)"
-          />
-        </template>
-
-        <FilterChipMulti
-          :model-value="filters.status"
-          :items="statusItems"
-          :label="t('patients.filters.status')"
-          icon="i-lucide-circle-dot"
-          @update:model-value="(v) => setFilter('status', v)"
-        />
-
-        <FilterToggle
-          :model-value="filters.do_not_contact"
-          :label="t('patients.filters.doNotContactOnly')"
-          :label-false="t('patients.filters.doNotContactOnlyContactable')"
-          icon="i-lucide-bell-off"
-          tristate
-          @update:model-value="(v) => setFilter('do_not_contact', v)"
-        />
-
-        <ModuleSlot
-          name="patients.list.filter"
-          :ctx="debtFilterCtx()"
-        />
-
-        <template #right>
-          <SortMenu
-            :model-value="sort"
-            :options="sortOptions"
-            @update:model-value="(v) => (sort = v)"
-          />
-        </template>
-      </FilterBar>
-    </template>
-
-    <template #empty>
-      <EmptyState
-        icon="i-lucide-users"
-        :title="activeFilterCount || filters.q ? t('patients.noResults') : t('patients.empty')"
-        :description="activeFilterCount || filters.q ? undefined : t('dashboard.welcomeMessage')"
-      >
-        <template
-          v-if="!activeFilterCount && !filters.q"
-          #actions
+  <div>
+    <DataListLayout
+      :title="t('patients.title')"
+      :loading="isLoading"
+      :empty="!patients.length"
+      :error="error"
+      :page="page"
+      :page-size="pageSize"
+      :total="total"
+      :total-pages="totalPages"
+      @update:page="(v) => (page = v)"
+    >
+      <template #actions>
+        <UButton
+          color="primary"
+          variant="soft"
+          icon="i-lucide-plus"
+          @click="isCreateModalOpen = true"
         >
-          <UButton
-            color="primary"
-            variant="soft"
-            icon="i-lucide-plus"
-            @click="isCreateModalOpen = true"
-          >
-            {{ t('patients.emptyAction') }}
-          </UButton>
-        </template>
-      </EmptyState>
-    </template>
+          {{ t('patients.create') }}
+        </UButton>
+      </template>
 
-    <template #rows>
-      <DataListItem
-        v-for="patient in patients"
-        :key="patient.id"
-        :to="`/patients/${patient.id}`"
-      >
-        <template #row>
-          <UAvatar
-            :alt="patient.first_name"
-            size="sm"
+      <template #toolbar>
+        <FilterBar
+          :active-count="activeFilterCount"
+          @reset="resetFilters"
+        >
+          <template #search>
+            <SearchBar
+              :model-value="filters.q"
+              :placeholder="t('patients.searchPlaceholder')"
+              max-width="max-w-md"
+              @update:model-value="(v) => setFilter('q', v)"
+            />
+          </template>
+
+          <FilterChipMulti
+            :model-value="filters.status"
+            :items="statusItems"
+            :label="t('patients.filters.status')"
+            icon="i-lucide-circle-dot"
+            @update:model-value="(v) => setFilter('status', v)"
           />
-          <div class="flex-1 min-w-0">
-            <div class="text-ui text-default truncate flex items-center gap-2">
-              {{ patient.last_name }}, {{ patient.first_name }}
-              <UIcon
-                v-if="patient.do_not_contact"
-                name="i-lucide-bell-off"
-                class="w-3.5 h-3.5 text-warning shrink-0"
-                :title="t('patients.doNotContact.label')"
-              />
-            </div>
-            <div class="text-caption text-subtle truncate">
-              <span v-if="patientCity(patient)">{{ patientCity(patient) }} · </span>{{ patient.phone || patient.email || '—' }}
-            </div>
-          </div>
-          <div class="shrink-0 flex items-center gap-3 ml-auto">
-            <ModuleSlot
-              name="patients.list.row.financial"
-              :ctx="{ patient_id: patient.id, summary: debtSummaries[patient.id] ?? null }"
-            />
-            <StatusBadge
-              :role="PATIENT_STATUS_ROLE[patient.status as PatientStatus] || 'neutral'"
-              :label="t(`patients.status.${patient.status}`)"
-            />
-            <UIcon
-              name="i-lucide-chevron-right"
-              class="text-subtle"
-            />
-          </div>
-        </template>
 
-        <template #card>
-          <div class="flex items-center gap-3">
+          <FilterToggle
+            :model-value="filters.do_not_contact"
+            :label="t('patients.filters.doNotContactOnly')"
+            :label-false="t('patients.filters.doNotContactOnlyContactable')"
+            icon="i-lucide-bell-off"
+            tristate
+            @update:model-value="(v) => setFilter('do_not_contact', v)"
+          />
+
+          <ModuleSlot
+            name="patients.list.filter"
+            :ctx="debtFilterCtx()"
+          />
+
+          <template #right>
+            <SortMenu
+              :model-value="sort"
+              :options="sortOptions"
+              @update:model-value="(v) => (sort = v)"
+            />
+          </template>
+        </FilterBar>
+      </template>
+
+      <template #empty>
+        <EmptyState
+          icon="i-lucide-users"
+          :title="activeFilterCount || filters.q ? t('patients.noResults') : t('patients.empty')"
+          :description="activeFilterCount || filters.q ? undefined : t('dashboard.welcomeMessage')"
+        >
+          <template
+            v-if="!activeFilterCount && !filters.q"
+            #actions
+          >
+            <UButton
+              color="primary"
+              variant="soft"
+              icon="i-lucide-plus"
+              @click="isCreateModalOpen = true"
+            >
+              {{ t('patients.emptyAction') }}
+            </UButton>
+          </template>
+        </EmptyState>
+      </template>
+
+      <template #rows>
+        <DataListItem
+          v-for="patient in patients"
+          :key="patient.id"
+          :to="`/patients/${patient.id}`"
+        >
+          <template #row>
             <UAvatar
               :alt="patient.first_name"
-              size="md"
+              size="sm"
             />
             <div class="flex-1 min-w-0">
-              <div class="font-medium text-default truncate flex items-center gap-2">
+              <div class="text-ui text-default truncate flex items-center gap-2">
                 {{ patient.last_name }}, {{ patient.first_name }}
                 <UIcon
                   v-if="patient.do_not_contact"
                   name="i-lucide-bell-off"
                   class="w-3.5 h-3.5 text-warning shrink-0"
+                  :title="t('patients.doNotContact.label')"
                 />
               </div>
               <div class="text-caption text-subtle truncate">
-                {{ patient.phone || patient.email || '—' }}
+                <span v-if="patientCity(patient)">{{ patientCity(patient) }} · </span>{{ patient.phone || patient.email || '—' }}
               </div>
             </div>
-            <StatusBadge
-              :role="PATIENT_STATUS_ROLE[patient.status as PatientStatus] || 'neutral'"
-              :label="t(`patients.status.${patient.status}`)"
-              class="shrink-0"
-            />
-          </div>
-          <div class="flex items-center justify-between gap-2">
-            <span class="text-caption text-subtle truncate">
-              {{ patientCity(patient) || '—' }}
-            </span>
-            <ModuleSlot
-              name="patients.list.row.financial"
-              :ctx="{ patient_id: patient.id, summary: debtSummaries[patient.id] ?? null }"
-            />
-          </div>
-        </template>
-      </DataListItem>
-    </template>
-  </DataListLayout>
+            <div class="shrink-0 flex items-center gap-3 ml-auto">
+              <ModuleSlot
+                name="patients.list.row.financial"
+                :ctx="{ patient_id: patient.id, summary: debtSummaries[patient.id] ?? null }"
+              />
+              <StatusBadge
+                :role="PATIENT_STATUS_ROLE[patient.status as PatientStatus] || 'neutral'"
+                :label="t(`patients.status.${patient.status}`)"
+              />
+              <UIcon
+                name="i-lucide-chevron-right"
+                class="text-subtle"
+              />
+            </div>
+          </template>
 
-  <UModal v-model:open="isCreateModalOpen">
-    <template #content>
-      <UCard>
-        <template #header>
-          <div class="flex items-center justify-between">
-            <h2 class="text-h1 text-default">
-              {{ t('patients.create') }}
-            </h2>
-            <UButton
-              variant="ghost"
-              color="neutral"
-              icon="i-lucide-x"
-              :aria-label="t('common.close', 'Cerrar')"
-              @click="isCreateModalOpen = false"
-            />
-          </div>
-        </template>
+          <template #card>
+            <div class="flex items-center gap-3">
+              <UAvatar
+                :alt="patient.first_name"
+                size="md"
+              />
+              <div class="flex-1 min-w-0">
+                <div class="font-medium text-default truncate flex items-center gap-2">
+                  {{ patient.last_name }}, {{ patient.first_name }}
+                  <UIcon
+                    v-if="patient.do_not_contact"
+                    name="i-lucide-bell-off"
+                    class="w-3.5 h-3.5 text-warning shrink-0"
+                  />
+                </div>
+                <div class="text-caption text-subtle truncate">
+                  {{ patient.phone || patient.email || '—' }}
+                </div>
+              </div>
+              <StatusBadge
+                :role="PATIENT_STATUS_ROLE[patient.status as PatientStatus] || 'neutral'"
+                :label="t(`patients.status.${patient.status}`)"
+                class="shrink-0"
+              />
+            </div>
+            <div class="flex items-center justify-between gap-2">
+              <span class="text-caption text-subtle truncate">
+                {{ patientCity(patient) || '—' }}
+              </span>
+              <ModuleSlot
+                name="patients.list.row.financial"
+                :ctx="{ patient_id: patient.id, summary: debtSummaries[patient.id] ?? null }"
+              />
+            </div>
+          </template>
+        </DataListItem>
+      </template>
+    </DataListLayout>
 
-        <form
-          class="space-y-4"
-          @submit.prevent="createPatient"
-        >
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <UFormField
-              :label="t('patients.firstName')"
-              required
-            >
-              <UInput
-                v-model="newPatient.first_name"
-                :placeholder="t('patients.firstName')"
+    <UModal v-model:open="isCreateModalOpen">
+      <template #content>
+        <UCard>
+          <template #header>
+            <div class="flex items-center justify-between">
+              <h2 class="text-h1 text-default">
+                {{ t('patients.create') }}
+              </h2>
+              <UButton
+                variant="ghost"
+                color="neutral"
+                icon="i-lucide-x"
+                :aria-label="t('common.close', 'Cerrar')"
+                @click="isCreateModalOpen = false"
+              />
+            </div>
+          </template>
+
+          <form
+            class="space-y-4"
+            @submit.prevent="createPatient"
+          >
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <UFormField
+                :label="t('patients.firstName')"
                 required
-              />
-            </UFormField>
-            <UFormField
-              :label="t('patients.lastName')"
-              required
-            >
-              <UInput
-                v-model="newPatient.last_name"
-                :placeholder="t('patients.lastName')"
+              >
+                <UInput
+                  v-model="newPatient.first_name"
+                  :placeholder="t('patients.firstName')"
+                  required
+                />
+              </UFormField>
+              <UFormField
+                :label="t('patients.lastName')"
                 required
-              />
-            </UFormField>
-          </div>
+              >
+                <UInput
+                  v-model="newPatient.last_name"
+                  :placeholder="t('patients.lastName')"
+                  required
+                />
+              </UFormField>
+            </div>
 
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <UFormField :label="t('patients.phone')">
-              <UInput
-                v-model="newPatient.phone"
-                :placeholder="t('patients.phone')"
-                type="tel"
-              />
-            </UFormField>
-            <UFormField :label="t('patients.email')">
-              <UInput
-                v-model="newPatient.email"
-                :placeholder="t('patients.email')"
-                type="email"
-              />
-            </UFormField>
-          </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <UFormField :label="t('patients.phone')">
+                <UInput
+                  v-model="newPatient.phone"
+                  :placeholder="t('patients.phone')"
+                  type="tel"
+                />
+              </UFormField>
+              <UFormField :label="t('patients.email')">
+                <UInput
+                  v-model="newPatient.email"
+                  :placeholder="t('patients.email')"
+                  type="email"
+                />
+              </UFormField>
+            </div>
 
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <UFormField :label="t('patients.nationalId')">
-              <UInput
-                v-model="newPatient.national_id"
-                placeholder="12345678A"
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <UFormField :label="t('patients.nationalId')">
+                <UInput
+                  v-model="newPatient.national_id"
+                  placeholder="12345678A"
+                />
+              </UFormField>
+              <UFormField :label="t('patients.dateOfBirth')">
+                <UInput
+                  v-model="newPatient.date_of_birth"
+                  type="date"
+                />
+              </UFormField>
+            </div>
+
+            <UFormField :label="t('patients.notes')">
+              <UTextarea
+                v-model="newPatient.notes"
+                :placeholder="t('patients.notes')"
+                :rows="3"
               />
             </UFormField>
-            <UFormField :label="t('patients.dateOfBirth')">
-              <UInput
-                v-model="newPatient.date_of_birth"
-                type="date"
-              />
-            </UFormField>
-          </div>
+          </form>
 
-          <UFormField :label="t('patients.notes')">
-            <UTextarea
-              v-model="newPatient.notes"
-              :placeholder="t('patients.notes')"
-              :rows="3"
-            />
-          </UFormField>
-        </form>
-
-        <template #footer>
-          <div class="flex justify-end gap-3">
-            <UButton
-              variant="outline"
-              color="neutral"
-              @click="isCreateModalOpen = false"
-            >
-              {{ t('common.cancel') }}
-            </UButton>
-            <UButton
-              color="primary"
-              variant="solid"
-              :loading="isSubmitting"
-              :disabled="!newPatient.first_name || !newPatient.last_name"
-              @click="createPatient"
-            >
-              {{ t('common.save') }}
-            </UButton>
-          </div>
-        </template>
-      </UCard>
-    </template>
-  </UModal>
+          <template #footer>
+            <div class="flex justify-end gap-3">
+              <UButton
+                variant="outline"
+                color="neutral"
+                @click="isCreateModalOpen = false"
+              >
+                {{ t('common.cancel') }}
+              </UButton>
+              <UButton
+                color="primary"
+                variant="solid"
+                :loading="isSubmitting"
+                :disabled="!newPatient.first_name || !newPatient.last_name"
+                @click="createPatient"
+              >
+                {{ t('common.save') }}
+              </UButton>
+            </div>
+          </template>
+        </UCard>
+      </template>
+    </UModal>
+  </div>
 </template>

--- a/backend/app/modules/patients/frontend/plugins/slots.client.ts
+++ b/backend/app/modules/patients/frontend/plugins/slots.client.ts
@@ -37,7 +37,9 @@ export default defineNuxtPlugin(() => {
     severity: 'info',
     load: async (api) => {
       const state = usePatientsOnboardingState()
-      const res = await api.get<{ total: number }>('/api/v1/patients?page_size=1')
+      // Background onboarding probe (best-effort via allSettled) — must
+      // never toast on failure.
+      const res = await api.get<{ total: number }>('/api/v1/patients?page_size=1', { errorToast: false })
       state.value = { loaded: true, total: res.total }
     },
     when: () => {

--- a/backend/app/modules/patients_clinical/CHANGELOG.md
+++ b/backend/app/modules/patients_clinical/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - fix(#274): `saveMedicalHistory()` publishes a `patients_clinical` tick
   on the host data bus (ADR 0021) after a successful PUT, and
   `usePatientAlerts` subscribes to it. The header alert chips no longer

--- a/backend/app/modules/patients_clinical/frontend/composables/useMedicalHistory.ts
+++ b/backend/app/modules/patients_clinical/frontend/composables/useMedicalHistory.ts
@@ -67,7 +67,9 @@ export function useMedicalHistory(patientId: Ref<string | undefined>) {
     try {
       const response = await api.put<ApiResponse<MedicalHistory>>(
         `/api/v1/patients_clinical/patients/${patientId.value}/medical-history`,
-        medicalHistory.value
+        medicalHistory.value,
+        // The catch below toasts its own save-error message.
+        { errorToast: false }
       )
       medicalHistory.value = response.data
       // Cross-module refresh signal (#274): announce on the host data bus

--- a/backend/app/modules/payments/CHANGELOG.md
+++ b/backend/app/modules/payments/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - fix(#101): /reports/payments gets the same failed-fetch error banner; an error state is no longer mistakable for an empty period.
 
 - feat(#207): "Collect payment" shortcut in the post-appointment follow-up dialog — opens the shared payment modal for the visit's patient.

--- a/backend/app/modules/payments/frontend/composables/usePayments.ts
+++ b/backend/app/modules/payments/frontend/composables/usePayments.ts
@@ -92,7 +92,8 @@ export function usePayments() {
 
   async function create(payload: PaymentRecordCreate): Promise<PaymentRecord | null> {
     try {
-      const resp = await api.post<ApiResponse<PaymentRecord>>('/api/v1/payments', payload)
+      // Create/collect modals render the failure inline (errorToast off).
+      const resp = await api.post<ApiResponse<PaymentRecord>>('/api/v1/payments', payload, { errorToast: false })
       return resp.data
     } catch (e) {
       error.value = (e as Error).message
@@ -102,7 +103,7 @@ export function usePayments() {
 
   async function reallocate(id: string, payload: PaymentReallocate): Promise<PaymentRecord | null> {
     try {
-      const resp = await api.post<ApiResponse<PaymentRecord>>(`/api/v1/payments/${id}/reallocate`, payload)
+      const resp = await api.post<ApiResponse<PaymentRecord>>(`/api/v1/payments/${id}/reallocate`, payload, { errorToast: false })
       return resp.data
     } catch (e) {
       error.value = (e as Error).message
@@ -112,7 +113,7 @@ export function usePayments() {
 
   async function refund(id: string, payload: PaymentRefundCreate): Promise<PaymentRefund | null> {
     try {
-      const resp = await api.post<ApiResponse<PaymentRefund>>(`/api/v1/payments/${id}/refunds`, payload)
+      const resp = await api.post<ApiResponse<PaymentRefund>>(`/api/v1/payments/${id}/refunds`, payload, { errorToast: false })
       return resp.data
     } catch (e) {
       error.value = (e as Error).message
@@ -269,7 +270,9 @@ export function usePaymentReports() {
   async function summary(date_from: string, date_to: string): Promise<PaymentsSummary | null> {
     try {
       const resp = await api.get<ApiResponse<PaymentsSummary>>(
-        `/api/v1/payments/reports/summary?date_from=${date_from}&date_to=${date_to}`
+        `/api/v1/payments/reports/summary?date_from=${date_from}&date_to=${date_to}`,
+        // Reports page renders the fetchFailed error state (issue #101).
+        { errorToast: false }
       )
       return resp.data
     } catch {
@@ -281,7 +284,8 @@ export function usePaymentReports() {
   async function byMethod(date_from: string, date_to: string): Promise<MethodBreakdown[]> {
     try {
       const resp = await api.get<ApiResponse<MethodBreakdown[]>>(
-        `/api/v1/payments/reports/by-method?date_from=${date_from}&date_to=${date_to}`
+        `/api/v1/payments/reports/by-method?date_from=${date_from}&date_to=${date_to}`,
+        { errorToast: false }
       )
       return resp.data
     } catch {
@@ -293,7 +297,8 @@ export function usePaymentReports() {
   async function byProfessional(date_from: string, date_to: string): Promise<ProfessionalBreakdown[]> {
     try {
       const resp = await api.get<ApiResponse<ProfessionalBreakdown[]>>(
-        `/api/v1/payments/reports/by-professional?date_from=${date_from}&date_to=${date_to}`
+        `/api/v1/payments/reports/by-professional?date_from=${date_from}&date_to=${date_to}`,
+        { errorToast: false }
       )
       return resp.data
     } catch {
@@ -304,7 +309,7 @@ export function usePaymentReports() {
 
   async function aging(): Promise<AgingBuckets | null> {
     try {
-      const resp = await api.get<ApiResponse<AgingBuckets>>('/api/v1/payments/reports/aging-receivables')
+      const resp = await api.get<ApiResponse<AgingBuckets>>('/api/v1/payments/reports/aging-receivables', { errorToast: false })
       return resp.data
     } catch {
       fetchFailed.value = true
@@ -315,7 +320,8 @@ export function usePaymentReports() {
   async function refunds(date_from: string, date_to: string): Promise<RefundsReport | null> {
     try {
       const resp = await api.get<ApiResponse<RefundsReport>>(
-        `/api/v1/payments/reports/refunds?date_from=${date_from}&date_to=${date_to}`
+        `/api/v1/payments/reports/refunds?date_from=${date_from}&date_to=${date_to}`,
+        { errorToast: false }
       )
       return resp.data
     } catch {
@@ -331,7 +337,8 @@ export function usePaymentReports() {
   ): Promise<PaymentsTrends | null> {
     try {
       const resp = await api.get<ApiResponse<PaymentsTrends>>(
-        `/api/v1/payments/reports/trends?date_from=${date_from}&date_to=${date_to}&granularity=${granularity}`
+        `/api/v1/payments/reports/trends?date_from=${date_from}&date_to=${date_to}&granularity=${granularity}`,
+        { errorToast: false }
       )
       return resp.data
     } catch {

--- a/backend/app/modules/payments/frontend/pages/payments/index.vue
+++ b/backend/app/modules/payments/frontend/pages/payments/index.vue
@@ -64,7 +64,8 @@ async function fetcher(q: {
   if (q.filters.date_to) params.set('date_to', q.filters.date_to)
   if (q.sort) params.set('sort', q.sort)
 
-  const response = await api.get<PaginatedResponse<PaymentRecord>>(`/api/v1/payments?${params.toString()}`)
+  // useListQuery surfaces failures via the `error` banner.
+  const response = await api.get<PaginatedResponse<PaymentRecord>>(`/api/v1/payments?${params.toString()}`, { errorToast: false })
   // Client-side multi-method filter (until backend accepts list).
   let data = response.data
   if (q.filters.method.length > 1) {
@@ -221,186 +222,149 @@ function formatDate(s: string | undefined): string {
 </script>
 
 <template>
-  <DataListLayout
-    :title="t('payments.list.title')"
-    :subtitle="t('payments.list.subtitle')"
-    :loading="isLoading"
-    :empty="!payments.length"
-    :error="error"
-    :page="page"
-    :page-size="pageSize"
-    :total="total"
-    :total-pages="totalPages"
-    @update:page="(v) => (page = v)"
-  >
-    <template #actions>
-      <UButton
-        v-if="can(PERMISSIONS.payments.recordWrite)"
-        color="primary"
-        icon="i-lucide-plus"
-        @click="showCreate = true"
-      >
-        {{ t('payments.list.new') }}
-      </UButton>
-    </template>
-
-    <template #toolbar>
-      <FilterBar
-        :active-count="activeFilterCount"
-        @reset="resetFilters"
-      >
-        <template #search>
-          <SearchBar
-            :model-value="filters.q"
-            :placeholder="t('payments.list.searchPlaceholder')"
-            max-width="max-w-sm"
-            @update:model-value="(v) => setFilter('q', v)"
-          />
-        </template>
-
-        <FilterChipMulti
-          :model-value="filters.method"
-          :items="methodItems"
-          :label="t('payments.list.filter.method')"
-          icon="i-lucide-credit-card"
-          @update:model-value="(v) => setFilter('method', v)"
-        />
-
-        <FilterDateRange v-model="dateRange" />
-
-        <FilterEntityPicker
-          :model-value="filters.patient_id"
-          :label="t('payments.list.filter.patient')"
-          icon="i-lucide-user"
-          :fetcher="patientFetcher"
-          :resolve="patientResolver"
-          @update:model-value="(v) => setFilter('patient_id', v)"
-        />
-
-        <FilterToggle
-          :model-value="filters.has_refunds"
-          :label="t('payments.list.filter.hasRefunds')"
-          icon="i-lucide-rotate-ccw"
-          @update:model-value="(v) => setFilter('has_refunds', Boolean(v))"
-        />
-
-        <FilterToggle
-          :model-value="filters.has_unallocated"
-          :label="t('payments.list.filter.hasUnallocated')"
-          icon="i-lucide-piggy-bank"
-          @update:model-value="(v) => setFilter('has_unallocated', Boolean(v))"
-        />
-
-        <template #right>
-          <SortMenu
-            :model-value="sort"
-            :options="sortOptions"
-            @update:model-value="(v) => (sort = v)"
-          />
-        </template>
-      </FilterBar>
-    </template>
-
-    <template #empty>
-      <EmptyState
-        icon="i-lucide-wallet"
-        :title="t('payments.list.empty')"
-      >
-        <template
-          v-if="!activeFilterCount && !filters.q && can(PERMISSIONS.payments.recordWrite)"
-          #actions
+  <div>
+    <DataListLayout
+      :title="t('payments.list.title')"
+      :subtitle="t('payments.list.subtitle')"
+      :loading="isLoading"
+      :empty="!payments.length"
+      :error="error"
+      :page="page"
+      :page-size="pageSize"
+      :total="total"
+      :total-pages="totalPages"
+      @update:page="(v) => (page = v)"
+    >
+      <template #actions>
+        <UButton
+          v-if="can(PERMISSIONS.payments.recordWrite)"
+          color="primary"
+          icon="i-lucide-plus"
+          @click="showCreate = true"
         >
-          <UButton
-            color="primary"
-            icon="i-lucide-plus"
-            @click="showCreate = true"
-          >
-            {{ t('payments.list.new') }}
-          </UButton>
-        </template>
-      </EmptyState>
-    </template>
+          {{ t('payments.list.new') }}
+        </UButton>
+      </template>
 
-    <template #rows>
-      <DataListItem
-        v-for="p in payments"
-        :key="p.id"
-      >
-        <template #row>
-          <div class="shrink-0">
-            <UAvatar
-              :alt="p.patient?.first_name ?? '?'"
-              size="sm"
+      <template #toolbar>
+        <FilterBar
+          :active-count="activeFilterCount"
+          @reset="resetFilters"
+        >
+          <template #search>
+            <SearchBar
+              :model-value="filters.q"
+              :placeholder="t('payments.list.searchPlaceholder')"
+              max-width="max-w-sm"
+              @update:model-value="(v) => setFilter('q', v)"
             />
-          </div>
-          <div class="flex-1 min-w-0">
-            <div class="text-ui text-default flex items-center gap-2 flex-wrap">
-              {{ patientName(p.patient) }}
-            </div>
-            <div class="text-caption text-subtle flex items-center gap-2 flex-wrap">
-              <span>{{ formatDate(p.payment_date) }}</span>
-              <span class="inline-flex items-center gap-1">
-                <UIcon
-                  :name="methodIcon(p.method)"
-                  class="w-3.5 h-3.5"
-                />
-                {{ t(`payments.methods.${p.method}`) }}
-              </span>
-              <span
-                v-if="p.reference"
-                class="truncate max-w-[160px]"
-                :title="p.reference"
-              >· {{ p.reference }}</span>
-            </div>
-          </div>
-          <div class="shrink-0 hidden sm:flex flex-col items-end gap-0.5 max-w-[200px]">
-            <span
-              v-for="a in allocationBreakdown(p)"
-              :key="a.label"
-              class="text-caption text-subtle tnum"
-            >
-              {{ a.amount }} <span class="opacity-60">· {{ a.label }}</span>
-            </span>
-          </div>
-          <div class="shrink-0 text-right min-w-[100px]">
-            <Money
-              :value="p.amount"
-              strong
-            />
-            <div
-              v-if="Number(p.refunded_total) > 0"
-              class="text-caption text-danger tnum"
-            >
-              − {{ formatCurrency(p.refunded_total) }}
-            </div>
-          </div>
-          <UButton
-            v-if="can(PERMISSIONS.payments.recordRefund) && Number(p.net_amount) > 0"
-            variant="soft"
-            color="warning"
-            size="xs"
-            icon="i-lucide-rotate-ccw"
-            :aria-label="t('payments.detail.refund')"
-            :title="t('payments.detail.refund')"
-            @click="openRefund(p)"
+          </template>
+
+          <FilterChipMulti
+            :model-value="filters.method"
+            :items="methodItems"
+            :label="t('payments.list.filter.method')"
+            icon="i-lucide-credit-card"
+            @update:model-value="(v) => setFilter('method', v)"
           />
-        </template>
 
-        <template #card>
-          <div class="flex items-center justify-between gap-2">
-            <div class="min-w-0 flex-1">
-              <div class="font-medium text-default truncate">
+          <FilterDateRange v-model="dateRange" />
+
+          <FilterEntityPicker
+            :model-value="filters.patient_id"
+            :label="t('payments.list.filter.patient')"
+            icon="i-lucide-user"
+            :fetcher="patientFetcher"
+            :resolve="patientResolver"
+            @update:model-value="(v) => setFilter('patient_id', v)"
+          />
+
+          <FilterToggle
+            :model-value="filters.has_refunds"
+            :label="t('payments.list.filter.hasRefunds')"
+            icon="i-lucide-rotate-ccw"
+            @update:model-value="(v) => setFilter('has_refunds', Boolean(v))"
+          />
+
+          <FilterToggle
+            :model-value="filters.has_unallocated"
+            :label="t('payments.list.filter.hasUnallocated')"
+            icon="i-lucide-piggy-bank"
+            @update:model-value="(v) => setFilter('has_unallocated', Boolean(v))"
+          />
+
+          <template #right>
+            <SortMenu
+              :model-value="sort"
+              :options="sortOptions"
+              @update:model-value="(v) => (sort = v)"
+            />
+          </template>
+        </FilterBar>
+      </template>
+
+      <template #empty>
+        <EmptyState
+          icon="i-lucide-wallet"
+          :title="t('payments.list.empty')"
+        >
+          <template
+            v-if="!activeFilterCount && !filters.q && can(PERMISSIONS.payments.recordWrite)"
+            #actions
+          >
+            <UButton
+              color="primary"
+              icon="i-lucide-plus"
+              @click="showCreate = true"
+            >
+              {{ t('payments.list.new') }}
+            </UButton>
+          </template>
+        </EmptyState>
+      </template>
+
+      <template #rows>
+        <DataListItem
+          v-for="p in payments"
+          :key="p.id"
+        >
+          <template #row>
+            <div class="shrink-0">
+              <UAvatar
+                :alt="p.patient?.first_name ?? '?'"
+                size="sm"
+              />
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="text-ui text-default flex items-center gap-2 flex-wrap">
                 {{ patientName(p.patient) }}
               </div>
-              <div class="text-caption text-subtle truncate flex items-center gap-1">
-                <UIcon
-                  :name="methodIcon(p.method)"
-                  class="w-3.5 h-3.5"
-                />
-                {{ formatDate(p.payment_date) }} · {{ t(`payments.methods.${p.method}`) }}
+              <div class="text-caption text-subtle flex items-center gap-2 flex-wrap">
+                <span>{{ formatDate(p.payment_date) }}</span>
+                <span class="inline-flex items-center gap-1">
+                  <UIcon
+                    :name="methodIcon(p.method)"
+                    class="w-3.5 h-3.5"
+                  />
+                  {{ t(`payments.methods.${p.method}`) }}
+                </span>
+                <span
+                  v-if="p.reference"
+                  class="truncate max-w-[160px]"
+                  :title="p.reference"
+                >· {{ p.reference }}</span>
               </div>
             </div>
-            <div class="text-right shrink-0">
+            <div class="shrink-0 hidden sm:flex flex-col items-end gap-0.5 max-w-[200px]">
+              <span
+                v-for="a in allocationBreakdown(p)"
+                :key="a.label"
+                class="text-caption text-subtle tnum"
+              >
+                {{ a.amount }} <span class="opacity-60">· {{ a.label }}</span>
+              </span>
+            </div>
+            <div class="shrink-0 text-right min-w-[100px]">
               <Money
                 :value="p.amount"
                 strong
@@ -412,51 +376,90 @@ function formatDate(s: string | undefined): string {
                 − {{ formatCurrency(p.refunded_total) }}
               </div>
             </div>
-          </div>
-          <div
-            v-if="allocationBreakdown(p).length"
-            class="flex flex-wrap gap-1"
-          >
-            <UBadge
-              v-for="a in allocationBreakdown(p)"
-              :key="a.label"
-              color="neutral"
-              variant="subtle"
-              size="xs"
-            >
-              {{ a.amount }} · {{ a.label }}
-            </UBadge>
-          </div>
-          <div
-            v-if="can(PERMISSIONS.payments.recordRefund) && Number(p.net_amount) > 0"
-            class="flex justify-end"
-          >
             <UButton
+              v-if="can(PERMISSIONS.payments.recordRefund) && Number(p.net_amount) > 0"
               variant="soft"
               color="warning"
               size="xs"
               icon="i-lucide-rotate-ccw"
+              :aria-label="t('payments.detail.refund')"
+              :title="t('payments.detail.refund')"
               @click="openRefund(p)"
+            />
+          </template>
+
+          <template #card>
+            <div class="flex items-center justify-between gap-2">
+              <div class="min-w-0 flex-1">
+                <div class="font-medium text-default truncate">
+                  {{ patientName(p.patient) }}
+                </div>
+                <div class="text-caption text-subtle truncate flex items-center gap-1">
+                  <UIcon
+                    :name="methodIcon(p.method)"
+                    class="w-3.5 h-3.5"
+                  />
+                  {{ formatDate(p.payment_date) }} · {{ t(`payments.methods.${p.method}`) }}
+                </div>
+              </div>
+              <div class="text-right shrink-0">
+                <Money
+                  :value="p.amount"
+                  strong
+                />
+                <div
+                  v-if="Number(p.refunded_total) > 0"
+                  class="text-caption text-danger tnum"
+                >
+                  − {{ formatCurrency(p.refunded_total) }}
+                </div>
+              </div>
+            </div>
+            <div
+              v-if="allocationBreakdown(p).length"
+              class="flex flex-wrap gap-1"
             >
-              {{ t('payments.detail.refund') }}
-            </UButton>
-          </div>
-        </template>
-      </DataListItem>
-    </template>
-  </DataListLayout>
+              <UBadge
+                v-for="a in allocationBreakdown(p)"
+                :key="a.label"
+                color="neutral"
+                variant="subtle"
+                size="xs"
+              >
+                {{ a.amount }} · {{ a.label }}
+              </UBadge>
+            </div>
+            <div
+              v-if="can(PERMISSIONS.payments.recordRefund) && Number(p.net_amount) > 0"
+              class="flex justify-end"
+            >
+              <UButton
+                variant="soft"
+                color="warning"
+                size="xs"
+                icon="i-lucide-rotate-ccw"
+                @click="openRefund(p)"
+              >
+                {{ t('payments.detail.refund') }}
+              </UButton>
+            </div>
+          </template>
+        </DataListItem>
+      </template>
+    </DataListLayout>
 
-  <PaymentCreateModal
-    v-model:open="showCreate"
-    @created="handleCreated"
-  />
+    <PaymentCreateModal
+      v-model:open="showCreate"
+      @created="handleCreated"
+    />
 
-  <RefundConfirmModal
-    v-if="refundTarget"
-    v-model:open="showRefund"
-    :payment-id="refundTarget.id"
-    :default-amount="refundTarget.net_amount"
-    :default-method="refundTarget.method"
-    @refunded="handleRefunded"
-  />
+    <RefundConfirmModal
+      v-if="refundTarget"
+      v-model:open="showRefund"
+      :payment-id="refundTarget.id"
+      :default-amount="refundTarget.net_amount"
+      :default-method="refundTarget.method"
+      @refunded="handleRefunded"
+    />
+  </div>
 </template>

--- a/backend/app/modules/periodontogram/CHANGELOG.md
+++ b/backend/app/modules/periodontogram/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - fix(#101): flushPending no longer swallows failures — failed payloads return to the pending buffer, closing the exam aborts with an explanation, and retrying re-flushes.
 
 - feat(#131): German (de) locale for the module's frontend layer.

--- a/backend/app/modules/periodontogram/frontend/composables/usePeriodontogram.ts
+++ b/backend/app/modules/periodontogram/frontend/composables/usePeriodontogram.ts
@@ -37,7 +37,9 @@ export function usePeriodontogram(patientId: () => string) {
     error.value = null
     try {
       const response = await api.get<ApiResponse<PerioTimelineResponse>>(
-        `/api/v1/periodontogram/patients/${patientId()}/timeline`
+        `/api/v1/periodontogram/patients/${patientId()}/timeline`,
+        // The view renders `error` as an inline alert — no auto-toast.
+        { errorToast: false }
       )
       timeline.value = response.data
     } catch (e) {

--- a/backend/app/modules/periodontogram/frontend/composables/usePeriodontogramSession.ts
+++ b/backend/app/modules/periodontogram/frontend/composables/usePeriodontogramSession.ts
@@ -96,7 +96,9 @@ export function usePeriodontogramSession() {
     _schedule(`tooth:${toothNumber}`, patch as Record<string, unknown>, async (payload) => {
       await api.patch<ApiResponse<PerioTooth>>(
         `/api/v1/periodontogram/snapshots/${snapshotId}/teeth/${toothNumber}`,
-        payload
+        payload,
+        // Failures surface via the `lastError` toast watcher in the chart.
+        { errorToast: false }
       )
     })
   }
@@ -113,7 +115,9 @@ export function usePeriodontogramSession() {
       async (payload) => {
         await api.patch<ApiResponse<PerioSite>>(
           `/api/v1/periodontogram/snapshots/${snapshotId}/teeth/${toothNumber}/sites/${siteCode}`,
-          payload
+          payload,
+          // Failures surface via the `lastError` toast watcher in the chart.
+          { errorToast: false }
         )
       }
     )
@@ -145,13 +149,17 @@ export function usePeriodontogramSession() {
           const toothNumber = Number(key.slice('tooth:'.length))
           await api.patch(
             `/api/v1/periodontogram/snapshots/${snapshotId}/teeth/${toothNumber}`,
-            payload
+            payload,
+            // Caller toasts from the boolean result — keep single-toast.
+            { errorToast: false }
           )
         } else if (key.startsWith('site:')) {
           const [, toothStr, siteCode] = key.split(':')
           await api.patch(
             `/api/v1/periodontogram/snapshots/${snapshotId}/teeth/${toothStr}/sites/${siteCode}`,
-            payload
+            payload,
+            // Caller toasts from the boolean result — keep single-toast.
+            { errorToast: false }
           )
         }
       } catch {

--- a/backend/app/modules/recalls/CHANGELOG.md
+++ b/backend/app/modules/recalls/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - fix(#101): cancel and mark-done confirm before closing a recall (no undo endpoint exists); cancel gets destructive styling.
 
 

--- a/backend/app/modules/recalls/frontend/components/SetRecallModal.vue
+++ b/backend/app/modules/recalls/frontend/components/SetRecallModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import type { RecallReason, RecallPriority, Recall } from '../composables/useRecalls'
+import { errorDetail } from '~~/app/utils/error'
 
 interface Props {
   open: boolean
@@ -133,7 +134,7 @@ async function save() {
   } catch (err: unknown) {
     toast.add({
       title: t('common.error'),
-      description: (err as { data?: { detail?: string } })?.data?.detail ?? '',
+      description: errorDetail(err),
       color: 'error'
     })
   } finally {

--- a/backend/app/modules/recalls/frontend/composables/useRecalls.ts
+++ b/backend/app/modules/recalls/frontend/composables/useRecalls.ts
@@ -169,7 +169,8 @@ export function useRecalls() {
   }
 
   async function create(payload: RecallCreatePayload): Promise<ApiOk<Recall>> {
-    return await api.post<ApiOk<Recall>>('/api/v1/recalls/', payload)
+    // Caller (SetRecallModal) catches and toasts the failure itself.
+    return await api.post<ApiOk<Recall>>('/api/v1/recalls/', payload, { errorToast: false })
   }
 
   async function update(id: string, payload: RecallUpdatePayload): Promise<ApiOk<Recall>> {
@@ -177,10 +178,11 @@ export function useRecalls() {
   }
 
   async function snooze(id: string, months: number, note?: string): Promise<ApiOk<Recall>> {
+    // Caller (RecallRow) catches and toasts the failure itself.
     return await api.post<ApiOk<Recall>>(`/api/v1/recalls/${id}/snooze`, {
       months,
       reason_note: note ?? null
-    })
+    }, { errorToast: false })
   }
 
   async function cancel(id: string, note?: string): Promise<ApiOk<Recall>> {
@@ -194,9 +196,11 @@ export function useRecalls() {
   }
 
   async function logAttempt(id: string, payload: AttemptCreatePayload): Promise<ApiOk<RecallContactAttempt>> {
+    // Callers (LogAttemptForm, RecallRow) catch and toast themselves.
     return await api.post<ApiOk<RecallContactAttempt>>(
       `/api/v1/recalls/${id}/attempts`,
-      payload
+      payload,
+      { errorToast: false }
     )
   }
 
@@ -225,7 +229,8 @@ export function useRecalls() {
   }
 
   async function updateSettings(payload: Partial<RecallSettings>): Promise<ApiOk<RecallSettings>> {
-    return await api.put<ApiOk<RecallSettings>>('/api/v1/recalls/settings', payload)
+    // Caller (RecallSettingsPanel) catches and toasts itself.
+    return await api.put<ApiOk<RecallSettings>>('/api/v1/recalls/settings', payload, { errorToast: false })
   }
 
   async function dashboardStats(): Promise<ApiOk<RecallDashboardStats>> {

--- a/backend/app/modules/reports/CHANGELOG.md
+++ b/backend/app/modules/reports/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - fix(#101): report dashboards render an error banner with Retry on fetch failure instead of 0 € / empty charts (shared fetch-failed flag across the 24 fetchers + dashboard snapshot).
 
 - fix(#242): patient billing KPI "Trabajo completado" is no longer permanently 0. The `completed` budget status was removed in 2026-04, so `get_patient_summary` now derives `work_completed` from **fully invoiced** accepted quotes (every line's `invoiced_quantity` ≥ `quantity`), and `work_in_progress` becomes the complement (accepted, not yet fully invoiced) so the two KPIs partition the accepted total.

--- a/backend/app/modules/reports/frontend/composables/useReports.ts
+++ b/backend/app/modules/reports/frontend/composables/useReports.ts
@@ -224,7 +224,8 @@ export function useReports() {
   ): Promise<BillingSummary | null> {
     try {
       const response = await api.get<ApiResponse<BillingSummary>>(
-        `/api/v1/reports/billing/summary?date_from=${dateFrom}&date_to=${dateTo}`
+        `/api/v1/reports/billing/summary?date_from=${dateFrom}&date_to=${dateTo}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -237,7 +238,8 @@ export function useReports() {
   async function fetchOverdueInvoices(): Promise<OverdueInvoice[]> {
     try {
       const response = await api.get<ApiResponse<OverdueInvoice[]>>(
-        '/api/v1/reports/billing/overdue'
+        '/api/v1/reports/billing/overdue',
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -253,7 +255,8 @@ export function useReports() {
   ): Promise<PaymentMethodSummary[]> {
     try {
       const response = await api.get<ApiResponse<PaymentMethodSummary[]>>(
-        `/api/v1/reports/billing/by-payment-method?date_from=${dateFrom}&date_to=${dateTo}`
+        `/api/v1/reports/billing/by-payment-method?date_from=${dateFrom}&date_to=${dateTo}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -269,7 +272,8 @@ export function useReports() {
   ): Promise<ProfessionalBillingSummary[]> {
     try {
       const response = await api.get<ApiResponse<ProfessionalBillingSummary[]>>(
-        `/api/v1/reports/billing/by-professional?date_from=${dateFrom}&date_to=${dateTo}`
+        `/api/v1/reports/billing/by-professional?date_from=${dateFrom}&date_to=${dateTo}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -285,7 +289,8 @@ export function useReports() {
   ): Promise<VatSummaryItem[]> {
     try {
       const response = await api.get<ApiResponse<VatSummaryItem[]>>(
-        `/api/v1/reports/billing/vat-summary?date_from=${dateFrom}&date_to=${dateTo}`
+        `/api/v1/reports/billing/vat-summary?date_from=${dateFrom}&date_to=${dateTo}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -298,7 +303,8 @@ export function useReports() {
   async function fetchNumberingGaps(): Promise<NumberingGap[]> {
     try {
       const response = await api.get<ApiResponse<NumberingGap[]>>(
-        '/api/v1/reports/billing/gaps'
+        '/api/v1/reports/billing/gaps',
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -318,7 +324,8 @@ export function useReports() {
   ): Promise<BudgetSummary | null> {
     try {
       const response = await api.get<ApiResponse<BudgetSummary>>(
-        `/api/v1/reports/budgets/summary?date_from=${dateFrom}&date_to=${dateTo}`
+        `/api/v1/reports/budgets/summary?date_from=${dateFrom}&date_to=${dateTo}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -334,7 +341,8 @@ export function useReports() {
   ): Promise<BudgetByProfessional[]> {
     try {
       const response = await api.get<ApiResponse<BudgetByProfessional[]>>(
-        `/api/v1/reports/budgets/by-professional?date_from=${dateFrom}&date_to=${dateTo}`
+        `/api/v1/reports/budgets/by-professional?date_from=${dateFrom}&date_to=${dateTo}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -351,7 +359,8 @@ export function useReports() {
   ): Promise<BudgetByTreatment[]> {
     try {
       const response = await api.get<ApiResponse<BudgetByTreatment[]>>(
-        `/api/v1/reports/budgets/by-treatment?date_from=${dateFrom}&date_to=${dateTo}&limit=${limit}`
+        `/api/v1/reports/budgets/by-treatment?date_from=${dateFrom}&date_to=${dateTo}&limit=${limit}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -367,7 +376,8 @@ export function useReports() {
   ): Promise<BudgetByStatus[]> {
     try {
       const response = await api.get<ApiResponse<BudgetByStatus[]>>(
-        `/api/v1/reports/budgets/by-status?date_from=${dateFrom}&date_to=${dateTo}`
+        `/api/v1/reports/budgets/by-status?date_from=${dateFrom}&date_to=${dateTo}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -387,7 +397,8 @@ export function useReports() {
   ): Promise<SchedulingSummary | null> {
     try {
       const response = await api.get<ApiResponse<SchedulingSummary>>(
-        `/api/v1/reports/scheduling/summary?date_from=${dateFrom}&date_to=${dateTo}`
+        `/api/v1/reports/scheduling/summary?date_from=${dateFrom}&date_to=${dateTo}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -403,7 +414,8 @@ export function useReports() {
   ): Promise<FirstVisitsSummary | null> {
     try {
       const response = await api.get<ApiResponse<FirstVisitsSummary>>(
-        `/api/v1/reports/scheduling/first-visits?date_from=${dateFrom}&date_to=${dateTo}`
+        `/api/v1/reports/scheduling/first-visits?date_from=${dateFrom}&date_to=${dateTo}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -419,7 +431,8 @@ export function useReports() {
   ): Promise<HoursByProfessional[]> {
     try {
       const response = await api.get<ApiResponse<HoursByProfessional[]>>(
-        `/api/v1/reports/scheduling/by-professional?date_from=${dateFrom}&date_to=${dateTo}`
+        `/api/v1/reports/scheduling/by-professional?date_from=${dateFrom}&date_to=${dateTo}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -435,7 +448,8 @@ export function useReports() {
   ): Promise<CabinetUtilization[]> {
     try {
       const response = await api.get<ApiResponse<CabinetUtilization[]>>(
-        `/api/v1/reports/scheduling/by-cabinet?date_from=${dateFrom}&date_to=${dateTo}`
+        `/api/v1/reports/scheduling/by-cabinet?date_from=${dateFrom}&date_to=${dateTo}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -451,7 +465,8 @@ export function useReports() {
   ): Promise<DayOfWeekStats[]> {
     try {
       const response = await api.get<ApiResponse<DayOfWeekStats[]>>(
-        `/api/v1/reports/scheduling/by-day-of-week?date_from=${dateFrom}&date_to=${dateTo}`
+        `/api/v1/reports/scheduling/by-day-of-week?date_from=${dateFrom}&date_to=${dateTo}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -479,7 +494,8 @@ export function useReports() {
   ): Promise<WaitingTimeStats | null> {
     try {
       const response = await api.get<ApiResponse<WaitingTimeStats>>(
-        `/api/v1/reports/scheduling/waiting-times?${_buildAnalyticsQuery(dateFrom, dateTo, filters)}`
+        `/api/v1/reports/scheduling/waiting-times?${_buildAnalyticsQuery(dateFrom, dateTo, filters)}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -496,7 +512,8 @@ export function useReports() {
   ): Promise<PunctualityStats | null> {
     try {
       const response = await api.get<ApiResponse<PunctualityStats>>(
-        `/api/v1/reports/scheduling/punctuality?${_buildAnalyticsQuery(dateFrom, dateTo, filters)}`
+        `/api/v1/reports/scheduling/punctuality?${_buildAnalyticsQuery(dateFrom, dateTo, filters)}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -513,7 +530,8 @@ export function useReports() {
   ): Promise<DurationVarianceStats | null> {
     try {
       const response = await api.get<ApiResponse<DurationVarianceStats>>(
-        `/api/v1/reports/scheduling/duration-variance?${_buildAnalyticsQuery(dateFrom, dateTo, filters)}`
+        `/api/v1/reports/scheduling/duration-variance?${_buildAnalyticsQuery(dateFrom, dateTo, filters)}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -530,7 +548,8 @@ export function useReports() {
   ): Promise<AppointmentFunnel | null> {
     try {
       const response = await api.get<ApiResponse<AppointmentFunnel>>(
-        `/api/v1/reports/scheduling/funnel?${_buildAnalyticsQuery(dateFrom, dateTo, filters)}`
+        `/api/v1/reports/scheduling/funnel?${_buildAnalyticsQuery(dateFrom, dateTo, filters)}`,
+        { errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -554,7 +573,7 @@ export function useReports() {
     try {
       const response = await api.get<ApiResponse<PaymentsSummaryReport>>(
         `/api/v1/payments/reports/summary?date_from=${dateFrom}&date_to=${dateTo}`,
-        { signal: options?.signal }
+        { signal: options?.signal, errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -574,7 +593,7 @@ export function useReports() {
     try {
       const response = await api.get<ApiResponse<PaymentsTrends>>(
         `/api/v1/payments/reports/trends?date_from=${dateFrom}&date_to=${dateTo}&granularity=${granularity}`,
-        { signal: options?.signal }
+        { signal: options?.signal, errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -593,7 +612,7 @@ export function useReports() {
     try {
       const response = await api.get<ApiResponse<PaymentsMethodBreakdown[]>>(
         `/api/v1/payments/reports/by-method?date_from=${dateFrom}&date_to=${dateTo}`,
-        { signal: options?.signal }
+        { signal: options?.signal, errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -612,7 +631,7 @@ export function useReports() {
     try {
       const response = await api.get<ApiResponse<PaymentsProfessionalBreakdown[]>>(
         `/api/v1/payments/reports/by-professional?date_from=${dateFrom}&date_to=${dateTo}`,
-        { signal: options?.signal }
+        { signal: options?.signal, errorToast: false }
       )
       return response.data
     } catch (e) {
@@ -629,7 +648,7 @@ export function useReports() {
     try {
       const response = await api.get<ApiResponse<PaymentsAgingBuckets>>(
         '/api/v1/payments/reports/aging-receivables',
-        { signal: options?.signal }
+        { signal: options?.signal, errorToast: false }
       )
       return response.data
     } catch (e) {

--- a/backend/app/modules/schedules/CHANGELOG.md
+++ b/backend/app/modules/schedules/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#131): German (de) locale for the module's frontend layer.
 - feat(#144, #132): Polish (pl) and Italian (it) locales for the module's frontend layer.
 - docs(#91): `events.py` header states the real contract — handlers are only subscribed while the module is installed.

--- a/backend/app/modules/schedules/frontend/components/settings/ClinicHoursPage.vue
+++ b/backend/app/modules/schedules/frontend/components/settings/ClinicHoursPage.vue
@@ -121,10 +121,9 @@ async function saveOverride() {
     overrides.value = await fetchOverrides()
     showOverrideModal.value = false
   } catch (err: unknown) {
-    const fetchError = err as { data?: { message?: string } }
     toast.add({
       title: t('common.error'),
-      description: fetchError.data?.message ?? '',
+      description: errorDetail(err),
       color: 'error'
     })
   }

--- a/backend/app/modules/schedules/frontend/components/settings/ProfessionalSchedulesPage.vue
+++ b/backend/app/modules/schedules/frontend/components/settings/ProfessionalSchedulesPage.vue
@@ -141,10 +141,9 @@ async function saveOverride() {
     overrides.value = await fetchOverrides(selectedProfessional.value)
     showOverrideModal.value = false
   } catch (err: unknown) {
-    const fetchError = err as { data?: { message?: string } }
     toast.add({
       title: t('common.error'),
-      description: fetchError.data?.message ?? '',
+      description: errorDetail(err),
       color: 'error'
     })
   }

--- a/backend/app/modules/schedules/frontend/composables/useClinicHours.ts
+++ b/backend/app/modules/schedules/frontend/composables/useClinicHours.ts
@@ -46,7 +46,8 @@ export function useClinicHours() {
   }
 
   async function updateHours(payload: { timezone?: string, days: WeekdayShifts[] }): Promise<ClinicHours> {
-    const res = await api.put<ApiResponse<ClinicHours>>('/api/v1/schedules/clinic-hours', payload)
+    // Callers catch and toast the failure themselves.
+    const res = await api.put<ApiResponse<ClinicHours>>('/api/v1/schedules/clinic-hours', payload, { errorToast: false })
     return res.data
   }
 
@@ -62,12 +63,14 @@ export function useClinicHours() {
   }
 
   async function createOverride(payload: ClinicOverridePayload): Promise<ClinicOverride> {
-    const res = await api.post<ApiResponse<ClinicOverride>>('/api/v1/schedules/clinic-overrides', payload)
+    // Callers catch and toast the failure themselves.
+    const res = await api.post<ApiResponse<ClinicOverride>>('/api/v1/schedules/clinic-overrides', payload, { errorToast: false })
     return res.data
   }
 
   async function updateOverride(id: string, payload: ClinicOverridePayload): Promise<ClinicOverride> {
-    const res = await api.put<ApiResponse<ClinicOverride>>(`/api/v1/schedules/clinic-overrides/${id}`, payload)
+    // Callers catch and toast the failure themselves.
+    const res = await api.put<ApiResponse<ClinicOverride>>(`/api/v1/schedules/clinic-overrides/${id}`, payload, { errorToast: false })
     return res.data
   }
 

--- a/backend/app/modules/schedules/frontend/composables/useProfessionalHours.ts
+++ b/backend/app/modules/schedules/frontend/composables/useProfessionalHours.ts
@@ -39,7 +39,8 @@ export function useProfessionalHours() {
   }
 
   async function updateHours(userId: string, days: WeekdayShifts[]): Promise<ProfessionalHours> {
-    const res = await api.put<ApiResponse<ProfessionalHours>>(`/api/v1/schedules/professionals/${userId}/hours`, { days })
+    // Callers catch and toast the failure themselves.
+    const res = await api.put<ApiResponse<ProfessionalHours>>(`/api/v1/schedules/professionals/${userId}/hours`, { days }, { errorToast: false })
     return res.data
   }
 
@@ -55,12 +56,14 @@ export function useProfessionalHours() {
   }
 
   async function createOverride(userId: string, payload: ProfessionalOverridePayload): Promise<ProfessionalOverride> {
-    const res = await api.post<ApiResponse<ProfessionalOverride>>(`/api/v1/schedules/professionals/${userId}/overrides`, payload)
+    // Callers catch and toast the failure themselves.
+    const res = await api.post<ApiResponse<ProfessionalOverride>>(`/api/v1/schedules/professionals/${userId}/overrides`, payload, { errorToast: false })
     return res.data
   }
 
   async function updateOverride(userId: string, id: string, payload: ProfessionalOverridePayload): Promise<ProfessionalOverride> {
-    const res = await api.put<ApiResponse<ProfessionalOverride>>(`/api/v1/schedules/professionals/${userId}/overrides/${id}`, payload)
+    // Callers catch and toast the failure themselves.
+    const res = await api.put<ApiResponse<ProfessionalOverride>>(`/api/v1/schedules/professionals/${userId}/overrides/${id}`, payload, { errorToast: false })
     return res.data
   }
 

--- a/backend/app/modules/staff_tasks/CHANGELOG.md
+++ b/backend/app/modules/staff_tasks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — staff_tasks module
 
+## Unreleased
+
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 ## 0.1.0 — initial release
 
 - Staff handoff board: internal task CRUD with a guarded status

--- a/backend/app/modules/staff_tasks/frontend/composables/useStaffTasks.ts
+++ b/backend/app/modules/staff_tasks/frontend/composables/useStaffTasks.ts
@@ -58,16 +58,18 @@ export function useStaffTasks() {
     return await api.get<ApiPaged<StaffTask>>(url)
   }
 
+  // The tasks page toasts its own message in the catch for these three
+  // (422 on an illegal status transition is an expected branch there).
   async function create(payload: StaffTaskCreatePayload): Promise<ApiOk<StaffTask>> {
-    return await api.post<ApiOk<StaffTask>>('/api/v1/staff_tasks/', payload)
+    return await api.post<ApiOk<StaffTask>>('/api/v1/staff_tasks/', payload, { errorToast: false })
   }
 
   async function update(id: string, payload: StaffTaskUpdatePayload): Promise<ApiOk<StaffTask>> {
-    return await api.patch<ApiOk<StaffTask>>(`/api/v1/staff_tasks/${id}`, payload)
+    return await api.patch<ApiOk<StaffTask>>(`/api/v1/staff_tasks/${id}`, payload, { errorToast: false })
   }
 
   async function remove(id: string): Promise<void> {
-    await api.del(`/api/v1/staff_tasks/${id}`)
+    await api.del(`/api/v1/staff_tasks/${id}`, { errorToast: false })
   }
 
   return { list, create, update, remove }

--- a/backend/app/modules/treatment_consumables/CHANGELOG.md
+++ b/backend/app/modules/treatment_consumables/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#144, #132): Polish (pl) and Italian (it) locales for the module's frontend layer.
 
 ## 0.1.0 — initial release

--- a/backend/app/modules/treatment_consumables/frontend/composables/useTreatmentConsumables.ts
+++ b/backend/app/modules/treatment_consumables/frontend/composables/useTreatmentConsumables.ts
@@ -35,13 +35,16 @@ export function useTreatmentConsumables() {
       if (v === undefined || v === null || v === '') continue
       qs.append(k, String(v))
     }
+    // Every caller (the treatment-consumables page) catches and toasts via
+    // its own `notifyError` (including the 409-duplicate copy) — suppress
+    // useApi's auto-toast to stay single-toast.
     const url = `/api/v1/treatment_consumables/${qs.toString() ? `?${qs.toString()}` : ''}`
-    return await api.get<ApiPaged<ConsumableLink>>(url)
+    return await api.get<ApiPaged<ConsumableLink>>(url, { errorToast: false })
   }
 
   async function linkOptions(q?: string): Promise<ApiOk<LinkOptions>> {
     const url = `/api/v1/treatment_consumables/link-options${q ? `?q=${encodeURIComponent(q)}` : ''}`
-    return await api.get<ApiOk<LinkOptions>>(url)
+    return await api.get<ApiOk<LinkOptions>>(url, { errorToast: false })
   }
 
   async function create(payload: {
@@ -50,7 +53,7 @@ export function useTreatmentConsumables() {
     quantity: string
     note?: string | null
   }): Promise<ApiOk<ConsumableLink>> {
-    return await api.post<ApiOk<ConsumableLink>>('/api/v1/treatment_consumables/', payload)
+    return await api.post<ApiOk<ConsumableLink>>('/api/v1/treatment_consumables/', payload, { errorToast: false })
   }
 
   // `note: ''` clears the stored note; omitting it leaves it untouched.
@@ -58,11 +61,11 @@ export function useTreatmentConsumables() {
     id: string,
     payload: { quantity: string, note?: string | null }
   ): Promise<ApiOk<ConsumableLink>> {
-    return await api.patch<ApiOk<ConsumableLink>>(`/api/v1/treatment_consumables/${id}`, payload)
+    return await api.patch<ApiOk<ConsumableLink>>(`/api/v1/treatment_consumables/${id}`, payload, { errorToast: false })
   }
 
   async function remove(id: string): Promise<void> {
-    await api.del(`/api/v1/treatment_consumables/${id}`)
+    await api.del(`/api/v1/treatment_consumables/${id}`, { errorToast: false })
   }
 
   return { list, linkOptions, create, update, remove }

--- a/backend/app/modules/treatment_plan/CHANGELOG.md
+++ b/backend/app/modules/treatment_plan/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - fix(#101): removing a plan item asks for confirmation naming the treatment.
 
 - feat(#207): the plan header links to the draft quote while the plan is `pending` (and the confirm toast carries a "view quote" action); *Programar cita* opens the appointment modal with the plan's pending treatments preselected (`?new=1&plan_id=`); a post-appointment follow-up prompt lists linked treatments the visit left unmarked and completes them in one click.

--- a/backend/app/modules/treatment_plan/frontend/components/clinical/notes/VisitNotePanel.vue
+++ b/backend/app/modules/treatment_plan/frontend/components/clinical/notes/VisitNotePanel.vue
@@ -43,7 +43,8 @@ async function save() {
     const next = body.value.trim()
     await api.patch(
       `/api/v1/agenda/appointment-treatments/${props.appointmentTreatmentId}`,
-      { notes: next }
+      { notes: next },
+      { errorToast: false }
     )
     toast.add({ title: t('treatmentPlans.visitNote.saved'), color: 'success' })
     emit('saved', next)

--- a/backend/app/modules/treatment_plan/frontend/composables/useTreatmentPlans.ts
+++ b/backend/app/modules/treatment_plan/frontend/composables/useTreatmentPlans.ts
@@ -70,7 +70,8 @@ export function useTreatmentPlans() {
       if (options.search) params.append('search', options.search)
 
       const response = await api.get<PaginatedResponse<TreatmentPlan>>(
-        `/api/v1/treatment_plan/treatment-plans?${params}`
+        `/api/v1/treatment_plan/treatment-plans?${params}`,
+        { errorToast: false }
       )
       plans.value = response.data
       total.value = response.total
@@ -97,7 +98,8 @@ export function useTreatmentPlans() {
     loading.value = true
     try {
       const response = await api.get<ApiResponse<TreatmentPlanDetail>>(
-        `/api/v1/treatment_plan/treatment-plans/${planId}`
+        `/api/v1/treatment_plan/treatment-plans/${planId}`,
+        { errorToast: false }
       )
       currentPlan.value = response.data
       return response.data
@@ -119,7 +121,8 @@ export function useTreatmentPlans() {
     try {
       const response = await api.post<ApiResponse<TreatmentPlan>>(
         '/api/v1/treatment_plan/treatment-plans',
-        data
+        data,
+        { errorToast: false }
       )
       toast.add({
         title: t('treatmentPlans.created'),
@@ -144,7 +147,8 @@ export function useTreatmentPlans() {
     try {
       const response = await api.put<ApiResponse<TreatmentPlan>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}`,
-        data
+        data,
+        { errorToast: false }
       )
       if (currentPlan.value?.id === planId) {
         currentPlan.value = { ...currentPlan.value, ...response.data }
@@ -172,7 +176,8 @@ export function useTreatmentPlans() {
     try {
       const response = await api.patch<ApiResponse<TreatmentPlan>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}/status`,
-        data
+        data,
+        { errorToast: false }
       )
       if (currentPlan.value?.id === planId) {
         currentPlan.value = { ...currentPlan.value, ...response.data }
@@ -198,7 +203,7 @@ export function useTreatmentPlans() {
   async function deletePlan(planId: string) {
     loading.value = true
     try {
-      await api.del(`/api/v1/treatment_plan/treatment-plans/${planId}`)
+      await api.del(`/api/v1/treatment_plan/treatment-plans/${planId}`, { errorToast: false })
       plans.value = plans.value.filter(p => p.id !== planId)
       if (currentPlan.value?.id === planId) {
         currentPlan.value = null
@@ -226,7 +231,8 @@ export function useTreatmentPlans() {
     try {
       const response = await api.post<ApiResponse<PlannedTreatmentItem>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}/items`,
-        data
+        data,
+        { errorToast: false }
       )
       if (currentPlan.value?.id === planId) {
         currentPlan.value.items.push(response.data)
@@ -254,7 +260,8 @@ export function useTreatmentPlans() {
     try {
       const response = await api.put<ApiResponse<PlannedTreatmentItem>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}/items/${itemId}`,
-        data
+        data,
+        { errorToast: false }
       )
       if (currentPlan.value?.id === planId) {
         const idx = currentPlan.value.items.findIndex(i => i.id === itemId)
@@ -292,7 +299,8 @@ export function useTreatmentPlans() {
     loading.value = true
     try {
       await api.del(
-        `/api/v1/treatment_plan/treatment-plans/${planId}/items/${itemId}`
+        `/api/v1/treatment_plan/treatment-plans/${planId}/items/${itemId}`,
+        { errorToast: false }
       )
       if (currentPlan.value?.id === planId) {
         currentPlan.value.items = currentPlan.value.items.filter(
@@ -332,7 +340,8 @@ export function useTreatmentPlans() {
     try {
       const response = await api.patch<ApiResponse<TreatmentPlanDetail>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}/items/reorder`,
-        { item_ids: itemIds }
+        { item_ids: itemIds },
+        { errorToast: false }
       )
       currentPlan.value = response.data
       return response.data
@@ -359,7 +368,8 @@ export function useTreatmentPlans() {
     try {
       const response = await api.patch<ApiResponse<PlannedTreatmentItem>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}/items/${itemId}/complete`,
-        data
+        data,
+        { errorToast: false }
       )
       if (currentPlan.value?.id === planId) {
         const idx = currentPlan.value.items.findIndex(i => i.id === itemId)
@@ -394,7 +404,8 @@ export function useTreatmentPlans() {
     try {
       const response = await api.patch<ApiResponse<PlannedTreatmentItem>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}/items/${itemId}/sessions/${sessionId}/complete`,
-        payload
+        payload,
+        { errorToast: false }
       )
       if (currentPlan.value?.id === planId) {
         const idx = currentPlan.value.items.findIndex(i => i.id === itemId)
@@ -423,7 +434,8 @@ export function useTreatmentPlans() {
     try {
       const response = await api.patch<ApiResponse<PlannedTreatmentItem>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}/items/${itemId}/sessions/${sessionId}/cancel`,
-        payload
+        payload,
+        { errorToast: false }
       )
       if (currentPlan.value?.id === planId) {
         const idx = currentPlan.value.items.findIndex(i => i.id === itemId)
@@ -448,7 +460,8 @@ export function useTreatmentPlans() {
     try {
       const response = await api.post<ApiResponse<TreatmentPlan>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}/link-budget`,
-        data
+        data,
+        { errorToast: false }
       )
       if (currentPlan.value?.id === planId) {
         currentPlan.value = { ...currentPlan.value, ...response.data }
@@ -475,7 +488,9 @@ export function useTreatmentPlans() {
     loading.value = true
     try {
       await api.post<ApiResponse<{ synced: boolean }>>(
-        `/api/v1/treatment_plan/treatment-plans/${planId}/sync-budget`
+        `/api/v1/treatment_plan/treatment-plans/${planId}/sync-budget`,
+        undefined,
+        { errorToast: false }
       )
       toast.add({
         title: t('treatmentPlans.budgetSynced'),
@@ -499,7 +514,9 @@ export function useTreatmentPlans() {
     loading.value = true
     try {
       const response = await api.post<ApiResponse<GenerateBudgetResponse>>(
-        `/api/v1/treatment_plan/treatment-plans/${planId}/generate-budget`
+        `/api/v1/treatment_plan/treatment-plans/${planId}/generate-budget`,
+        undefined,
+        { errorToast: false }
       )
       if (currentPlan.value?.id === planId) {
         currentPlan.value.budget_id = response.data.budget_id
@@ -536,7 +553,9 @@ export function useTreatmentPlans() {
     loading.value = true
     try {
       const response = await api.post<ApiResponse<TreatmentPlan>>(
-        `/api/v1/treatment_plan/treatment-plans/${planId}/confirm`
+        `/api/v1/treatment_plan/treatment-plans/${planId}/confirm`,
+        undefined,
+        { errorToast: false }
       )
       // Confirming provisions a draft quote — link straight to it from
       // the toast so reception doesn't have to dig it out of the
@@ -563,7 +582,9 @@ export function useTreatmentPlans() {
     loading.value = true
     try {
       const response = await api.post<ApiResponse<TreatmentPlan>>(
-        `/api/v1/treatment_plan/treatment-plans/${planId}/reopen`
+        `/api/v1/treatment_plan/treatment-plans/${planId}/reopen`,
+        undefined,
+        { errorToast: false }
       )
       toast.add({ title: t('treatmentPlans.reopened'), color: 'success' })
       return response.data
@@ -584,7 +605,8 @@ export function useTreatmentPlans() {
     try {
       const response = await api.post<ApiResponse<TreatmentPlan>>(
         `/api/v1/treatment_plan/treatment-plans/${planId}/close`,
-        payload
+        payload,
+        { errorToast: false }
       )
       toast.add({ title: t('treatmentPlans.closed'), color: 'success' })
       return response.data
@@ -601,7 +623,9 @@ export function useTreatmentPlans() {
     loading.value = true
     try {
       const response = await api.post<ApiResponse<TreatmentPlan>>(
-        `/api/v1/treatment_plan/treatment-plans/${planId}/reactivate`
+        `/api/v1/treatment_plan/treatment-plans/${planId}/reactivate`,
+        undefined,
+        { errorToast: false }
       )
       toast.add({ title: t('treatmentPlans.reactivated'), color: 'success' })
       return response.data
@@ -621,7 +645,8 @@ export function useTreatmentPlans() {
     try {
       await api.post(
         `/api/v1/treatment_plan/treatment-plans/${planId}/contact-log`,
-        payload
+        payload,
+        { errorToast: false }
       )
       toast.add({ title: t('treatmentPlans.contactLogged'), color: 'success' })
       return true

--- a/backend/app/modules/verifactu/CHANGELOG.md
+++ b/backend/app/modules/verifactu/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#131): German (de) locale for the module's frontend layer.
 
 - feat(#144, #132): Polish (pl) and Italian (it) locales for the module's frontend layer.

--- a/backend/app/modules/verifactu/frontend/composables/useVerifactu.ts
+++ b/backend/app/modules/verifactu/frontend/composables/useVerifactu.ts
@@ -167,11 +167,13 @@ export const useVerifactu = () => {
       return r.data
     },
     async updateProducer(body: ProducerInfoUpdate) {
-      const r = await api.put<ApiResponse<VerifactuSettings>>('/api/v1/verifactu/producer', body)
+      // Callers render the failure inline on the producer page.
+      const r = await api.put<ApiResponse<VerifactuSettings>>('/api/v1/verifactu/producer', body, { errorToast: false })
       return r.data
     },
     async revokeDeclaration() {
-      const r = await api.del<ApiResponse<VerifactuSettings>>('/api/v1/verifactu/producer/declaracion')
+      // Caller renders the failure inline on the producer page.
+      const r = await api.del<ApiResponse<VerifactuSettings>>('/api/v1/verifactu/producer/declaracion', { errorToast: false })
       return r.data
     },
     async getActiveCertificate() {
@@ -186,7 +188,8 @@ export const useVerifactu = () => {
       const fd = new FormData()
       fd.append('file', file)
       fd.append('password', password)
-      const r = await api.post<ApiResponse<VerifactuCertificate>>('/api/v1/verifactu/certificate', fd)
+      // Caller renders the failure inline on the certificate page.
+      const r = await api.post<ApiResponse<VerifactuCertificate>>('/api/v1/verifactu/certificate', fd, { errorToast: false })
       return r.data
     },
     async listRecords(params: { page?: number, page_size?: number, state?: string, tipo_factura?: string, invoice_id?: string } = {}) {
@@ -214,8 +217,11 @@ export const useVerifactu = () => {
     },
     async retryRecord(id: string, opts: { regenerate?: boolean } = {}) {
       const qs = opts.regenerate === false ? '?regenerate=false' : ''
+      // Callers toast the AEAT/queue failure themselves (errorMessage).
       const r = await api.post<ApiResponse<VerifactuRecord>>(
-        `/api/v1/verifactu/queue/${id}/retry${qs}`
+        `/api/v1/verifactu/queue/${id}/retry${qs}`,
+        undefined,
+        { errorToast: false }
       )
       return r.data
     },
@@ -255,9 +261,11 @@ export const useVerifactu = () => {
       vat_type_id: string,
       body: { classification: string | null, exemption_cause?: string | null, notes?: string | null }
     ) {
+      // Caller toasts the failure itself (errorMessage).
       const r = await api.put<ApiResponse<VatClassificationItem>>(
         `/api/v1/verifactu/vat-mapping/${vat_type_id}`,
-        body
+        body,
+        { errorToast: false }
       )
       return r.data
     }

--- a/backend/app/modules/whatsapp_kapso/CHANGELOG.md
+++ b/backend/app/modules/whatsapp_kapso/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
+
 - feat(#287): NOTIFICATION_TYPES gains invoice_sent/budget_reminder/recall_reminder (i18n labels); new getting-started rule warns when the clinic prefers WhatsApp but Kapso isn't connected.
 
 

--- a/backend/app/modules/whatsapp_kapso/frontend/composables/useKapso.ts
+++ b/backend/app/modules/whatsapp_kapso/frontend/composables/useKapso.ts
@@ -43,7 +43,8 @@ export function useKapso() {
   async function saveSettings(payload: Record<string, unknown>) {
     saving.value = true
     try {
-      const res = await api.put<ApiResponse<KapsoSettings>>(`${BASE}/settings`, payload)
+      // The settings page toasts errorDetail(e) in its own catch.
+      const res = await api.put<ApiResponse<KapsoSettings>>(`${BASE}/settings`, payload, { errorToast: false })
       settings.value = res.data
       return true
     } finally {
@@ -54,7 +55,7 @@ export function useKapso() {
   async function syncTemplates() {
     syncing.value = true
     try {
-      const res = await api.post<ApiResponse<KapsoTemplate[]>>(`${BASE}/templates/sync`, {})
+      const res = await api.post<ApiResponse<KapsoTemplate[]>>(`${BASE}/templates/sync`, {}, { errorToast: false })
       templates.value = res.data
       return res.data
     } finally {
@@ -67,13 +68,14 @@ export function useKapso() {
       notification_type: notificationType,
       locale,
       template_name: templateName
-    })
+    }, { errorToast: false })
   }
 
   async function testConnection(toNumber: string, templateName: string, language = 'es') {
     const res = await api.post<ApiResponse<{ success: boolean, error: string | null }>>(
       `${BASE}/test`,
-      { to_number: toNumber, template_name: templateName, language }
+      { to_number: toNumber, template_name: templateName, language },
+      { errorToast: false }
     )
     return res.data
   }

--- a/backend/app/modules/whatsapp_kapso/frontend/plugins/settings.client.ts
+++ b/backend/app/modules/whatsapp_kapso/frontend/plugins/settings.client.ts
@@ -44,7 +44,9 @@ export default defineNuxtPlugin(() => {
       const state = useKapsoOnboardingState()
       try {
         const res = await api.get<{ data: { preferred_channel?: string, available_channels?: string[] } }>(
-          '/api/v1/notifications/settings'
+          '/api/v1/notifications/settings',
+          // Background onboarding probe — must never toast on failure.
+          { errorToast: false }
         )
         const d = res.data
         state.value = {

--- a/frontend/app/components/settings/modules/ModuleDetailModal.vue
+++ b/frontend/app/components/settings/modules/ModuleDetailModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ModuleInfo, ModuleOperationLogEntry } from '~/types'
 import type { UiColor } from '~/config/severity'
+import { errorMessage } from '~/utils/error'
 
 interface Props {
   open: boolean
@@ -29,8 +30,7 @@ async function fetchLog() {
   try {
     logEntries.value = await operations(props.module.name, 20)
   } catch (err: unknown) {
-    const e = err as { data?: { detail?: string }, message?: string }
-    logError.value = e?.data?.detail ?? e?.message ?? t('common.error')
+    logError.value = errorMessage(err, t('common.error'))
     logEntries.value = []
   } finally {
     loadingLog.value = false

--- a/frontend/app/components/shared/PatientVisualSelector.vue
+++ b/frontend/app/components/shared/PatientVisualSelector.vue
@@ -162,7 +162,8 @@ watch(() => form.phone, (val) => {
       })
       const response = await api.get<PaginatedResponse<Patient>>(
         `/api/v1/patients?${params.toString()}`,
-        { signal: ctrl.signal }
+        // Background duplicate probe — never toast from here.
+        { signal: ctrl.signal, errorToast: false }
       )
       if (ctrl.signal.aborted) return
       const match = response.data.find(
@@ -199,7 +200,8 @@ async function submitCreate() {
     const response = await api.post<ApiResponse<Patient>>(
       '/api/v1/patients',
       payload,
-      { signal: ctrl.signal }
+      // The catch renders createError inline in the form.
+      { signal: ctrl.signal, errorToast: false }
     )
     if (ctrl.signal.aborted) return
     const created = response.data

--- a/frontend/app/composables/useApi.ts
+++ b/frontend/app/composables/useApi.ts
@@ -1,4 +1,5 @@
 import type { ApiResponse, PaginatedResponse } from '~/types'
+import { errorDetail } from '~/utils/error'
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
@@ -18,6 +19,14 @@ interface UseApiOptions {
   // Optional AbortSignal so callers can cancel in-flight requests
   // (debounced lookups, component unmount, etc.).
   signal?: AbortSignal
+  // 400/409/422 toast the backend's own message by default before
+  // rethrowing (#101 — an uncaught rethrow used to be a silent
+  // failure). Callers that surface the error themselves (their own
+  // toast, inline form error, modal copy) pass ``errorToast: false``
+  // to keep single-toast behaviour. 404 never auto-toasts: it is
+  // routinely semantic ("not signed", probe-style reads) and its
+  // handling belongs to the caller.
+  errorToast?: boolean
 }
 
 function _withQuery(path: string, query?: UseApiOptions['query']): string {
@@ -46,7 +55,7 @@ export function useApi() {
     path: string,
     options: UseApiOptions = {}
   ): Promise<T> {
-    const { skipAuth, method, body, headers: optionHeaders, signal, query } = options
+    const { skipAuth, method, body, headers: optionHeaders, signal, query, errorToast = true } = options
 
     const headers: Record<string, string> = {
       ...(optionHeaders || {})
@@ -107,16 +116,33 @@ export function useApi() {
       }
 
       if (fetchError.statusCode === 404) {
+        // Semantic more often than exceptional (probe-reads, "not
+        // signed", lookups) — never auto-toast; the caller owns it.
         throw error
       }
 
-      if (fetchError.statusCode === 409) {
-        // Conflict - let the caller handle it
+      if (
+        errorToast
+        && (fetchError.statusCode === 400
+          || fetchError.statusCode === 409
+          || fetchError.statusCode === 422)
+      ) {
+        // Surface the backend's own message so a rethrow nobody catches
+        // is no longer silent (#101). Callers that present the error
+        // themselves suppress this with ``errorToast: false``.
+        toast.add({
+          title: t('common.error'),
+          description: errorDetail(error) ?? t('common.serverError'),
+          color: 'error'
+        })
         throw error
       }
 
-      if (fetchError.statusCode === 422) {
-        // Validation error - let the caller handle it
+      if (
+        fetchError.statusCode === 400
+        || fetchError.statusCode === 409
+        || fetchError.statusCode === 422
+      ) {
         throw error
       }
 

--- a/frontend/app/composables/useClinic.ts
+++ b/frontend/app/composables/useClinic.ts
@@ -50,7 +50,8 @@ export function useClinic() {
 
   async function updateClinic(data: ClinicUpdate): Promise<Clinic | null> {
     try {
-      const response = await api.put<ApiResponse<Clinic>>('/api/v1/auth/clinics', data)
+      // The catch below toasts the failure itself.
+      const response = await api.put<ApiResponse<Clinic>>('/api/v1/auth/clinics', data, { errorToast: false })
       currentClinic.value = response.data
       toast.add({
         title: t('common.success'),
@@ -89,7 +90,7 @@ export function useClinic() {
 
   async function createCabinet(data: CabinetCreate): Promise<Cabinet | null> {
     try {
-      const response = await api.post<ApiResponse<Cabinet>>('/api/v1/agenda/cabinets', data)
+      const response = await api.post<ApiResponse<Cabinet>>('/api/v1/agenda/cabinets', data, { errorToast: false })
       patchCabinets(list => [...list, response.data])
       toast.add({
         title: t('common.success'),
@@ -113,7 +114,7 @@ export function useClinic() {
       list.map(c => c.id === cabinetId ? { ...c, ...data } as Cabinet : c)
     )
     try {
-      const response = await api.put<ApiResponse<Cabinet>>(`/api/v1/agenda/cabinets/${cabinetId}`, data)
+      const response = await api.put<ApiResponse<Cabinet>>(`/api/v1/agenda/cabinets/${cabinetId}`, data, { errorToast: false })
       patchCabinets(list => list.map(c => c.id === cabinetId ? response.data : c))
       toast.add({
         title: t('common.success'),
@@ -138,7 +139,7 @@ export function useClinic() {
   async function deleteCabinet(cabinetId: string): Promise<boolean> {
     const rollback = patchCabinets(list => list.filter(c => c.id !== cabinetId))
     try {
-      await api.del(`/api/v1/agenda/cabinets/${cabinetId}`)
+      await api.del(`/api/v1/agenda/cabinets/${cabinetId}`, { errorToast: false })
       toast.add({
         title: t('common.success'),
         description: t('cabinet.toast.deleted'),

--- a/frontend/app/composables/useModuleAdmin.ts
+++ b/frontend/app/composables/useModuleAdmin.ts
@@ -6,6 +6,7 @@
  * restart, plus status and doctor polling.
  */
 
+import { errorMessage } from '~/utils/error'
 import type {
   ApiResponse,
   ModuleDoctorReport,
@@ -31,16 +32,17 @@ export function useModuleAdmin() {
     loading.value = true
     error.value = null
     try {
+      // Failures render via the page's error alert + the caller's toast.
       const [listResp, statusResp, doctorResp] = await Promise.all([
-        api.get<ApiResponse<ModuleInfo[]>>(MODULES_BASE),
-        api.get<ApiResponse<ModuleStatus>>(`${MODULES_BASE}/-/status`),
-        api.get<ApiResponse<ModuleDoctorReport>>(`${MODULES_BASE}/-/doctor`)
+        api.get<ApiResponse<ModuleInfo[]>>(MODULES_BASE, { errorToast: false }),
+        api.get<ApiResponse<ModuleStatus>>(`${MODULES_BASE}/-/status`, { errorToast: false }),
+        api.get<ApiResponse<ModuleDoctorReport>>(`${MODULES_BASE}/-/doctor`, { errorToast: false })
       ])
       modules.value = listResp.data
       status.value = statusResp.data
       doctor.value = doctorResp.data
     } catch (err: unknown) {
-      error.value = extractMessage(err)
+      error.value = errorMessage(err, 'unknown error')
       throw err
     } finally {
       loading.value = false
@@ -50,7 +52,10 @@ export function useModuleAdmin() {
   async function install(name: string, force = false): Promise<string[]> {
     const qs = force ? '?force=true' : ''
     const response = await api.post<ApiResponse<ModuleOperationResult>>(
-      `${MODULES_BASE}/${encodeURIComponent(name)}/install${qs}`
+      `${MODULES_BASE}/${encodeURIComponent(name)}/install${qs}`,
+      // Confirm modal renders the failure inline (confirmError).
+      null,
+      { errorToast: false }
     )
     await refresh()
     return response.data.scheduled
@@ -59,14 +64,18 @@ export function useModuleAdmin() {
   async function uninstall(name: string, force = false): Promise<void> {
     const qs = force ? '?force=true' : ''
     await api.post<ApiResponse<ModuleOperationResult>>(
-      `${MODULES_BASE}/${encodeURIComponent(name)}/uninstall${qs}`
+      `${MODULES_BASE}/${encodeURIComponent(name)}/uninstall${qs}`,
+      null,
+      { errorToast: false }
     )
     await refresh()
   }
 
   async function upgrade(name: string): Promise<string[]> {
     const response = await api.post<ApiResponse<ModuleOperationResult>>(
-      `${MODULES_BASE}/${encodeURIComponent(name)}/upgrade`
+      `${MODULES_BASE}/${encodeURIComponent(name)}/upgrade`,
+      null,
+      { errorToast: false }
     )
     await refresh()
     return response.data.scheduled
@@ -75,7 +84,7 @@ export function useModuleAdmin() {
   async function restart(): Promise<void> {
     applying.value = true
     try {
-      await api.post<ApiResponse<{ pid: number }>>(`${MODULES_BASE}/-/restart`)
+      await api.post<ApiResponse<{ pid: number }>>(`${MODULES_BASE}/-/restart`, null, { errorToast: false })
     } catch (err: unknown) {
       applying.value = false
       throw err
@@ -94,7 +103,8 @@ export function useModuleAdmin() {
 
     while (Date.now() - started < timeoutMs) {
       try {
-        const resp = await api.get<ApiResponse<ModuleStatus>>(`${MODULES_BASE}/-/status`)
+        // Expected to fail while the backend restarts — never toast.
+        const resp = await api.get<ApiResponse<ModuleStatus>>(`${MODULES_BASE}/-/status`, { errorToast: false })
         lastError = null
         if (resp.data.pending.length === 0) {
           status.value = resp.data
@@ -117,7 +127,9 @@ export function useModuleAdmin() {
 
   async function operations(name: string, limit = 20): Promise<ModuleOperationLogEntry[]> {
     const resp = await api.get<ApiResponse<ModuleOperationLogEntry[]>>(
-      `${MODULES_BASE}/${encodeURIComponent(name)}/-/operations?limit=${limit}`
+      `${MODULES_BASE}/${encodeURIComponent(name)}/-/operations?limit=${limit}`,
+      // Detail modal renders the failure inline (logError).
+      { errorToast: false }
     )
     return resp.data
   }
@@ -141,9 +153,4 @@ export function useModuleAdmin() {
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
-}
-
-function extractMessage(err: unknown): string {
-  const e = err as { data?: { detail?: string, message?: string }, message?: string }
-  return e?.data?.detail || e?.data?.message || e?.message || 'unknown error'
 }

--- a/frontend/app/composables/useUsers.ts
+++ b/frontend/app/composables/useUsers.ts
@@ -1,4 +1,5 @@
 import type { User, UserCreate, UserRole, UserUpdate, PaginatedResponse, ApiResponse } from '~/types'
+import { errorMessage } from '~/utils/error'
 
 export interface ClinicUser {
   id: string
@@ -51,7 +52,8 @@ export function useUsers() {
     error.value = null
 
     try {
-      const response = await api.post<ApiResponse<User>>('/api/v1/auth/users', data)
+      // The catch below toasts a status-specific message itself.
+      const response = await api.post<ApiResponse<User>>('/api/v1/auth/users', data, { errorToast: false })
       toast.add({
         title: t('common.success'),
         description: t('settings.messages.userCreated'),
@@ -70,7 +72,7 @@ export function useUsers() {
           color: 'error'
         })
       } else if (fetchError.statusCode === 422) {
-        error.value = fetchError.data?.message || fetchError.data?.detail || t('settings.errors.invalidData')
+        error.value = errorMessage(e, t('settings.errors.invalidData'))
         toast.add({
           title: t('common.error'),
           description: error.value,
@@ -96,7 +98,7 @@ export function useUsers() {
     error.value = null
 
     try {
-      const response = await api.put<ApiResponse<ClinicUser>>(`/api/v1/auth/users/${userId}`, data)
+      const response = await api.put<ApiResponse<ClinicUser>>(`/api/v1/auth/users/${userId}`, data, { errorToast: false })
       toast.add({
         title: t('common.success'),
         description: t('settings.messages.userUpdated'),
@@ -115,7 +117,7 @@ export function useUsers() {
           color: 'error'
         })
       } else if (fetchError.statusCode === 400) {
-        error.value = fetchError.data?.message || fetchError.data?.detail || t('settings.errors.operationNotAllowed')
+        error.value = errorMessage(e, t('settings.errors.operationNotAllowed'))
         toast.add({
           title: t('common.error'),
           description: error.value,
@@ -148,7 +150,7 @@ export function useUsers() {
     error.value = null
 
     try {
-      await api.del(`/api/v1/auth/users/${userId}`)
+      await api.del(`/api/v1/auth/users/${userId}`, { errorToast: false })
       toast.add({
         title: t('common.success'),
         description: t('settings.messages.userDeleted'),
@@ -160,7 +162,7 @@ export function useUsers() {
     } catch (e: unknown) {
       const fetchError = e as { statusCode?: number, data?: { message?: string, detail?: string } }
       if (fetchError.statusCode === 400) {
-        error.value = fetchError.data?.message || fetchError.data?.detail || t('settings.errors.operationNotAllowed')
+        error.value = errorMessage(e, t('settings.errors.operationNotAllowed'))
         toast.add({
           title: t('common.error'),
           description: error.value,
@@ -192,7 +194,9 @@ export function useUsers() {
   async function createInviteLink(userId: string): Promise<{ url: string, expiresAt: string } | null> {
     try {
       const response = await api.post<ApiResponse<{ token: string, expires_at: string }>>(
-        `/api/v1/auth/users/${userId}/invite-link`
+        `/api/v1/auth/users/${userId}/invite-link`,
+        null,
+        { errorToast: false }
       )
       const url = `${window.location.origin}/set-password?token=${encodeURIComponent(response.data.token)}`
       return { url, expiresAt: response.data.expires_at }

--- a/frontend/app/pages/set-password.vue
+++ b/frontend/app/pages/set-password.vue
@@ -37,7 +37,8 @@ async function onSubmit() {
     const res = await api.post<{ access_token: string, refresh_token: string }>(
       '/api/v1/auth/set-password',
       { token: token.value, password: password.value },
-      { skipAuth: true }
+      // The catch renders errorMessage inline on the form.
+      { skipAuth: true, errorToast: false }
     )
     await auth.applyTokens(res.access_token, res.refresh_token)
     toast.add({ title: t('setup.success'), color: 'success' })

--- a/frontend/app/pages/settings/modules/index.vue
+++ b/frontend/app/pages/settings/modules/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ModuleInfo } from '~/types'
 import { PERMISSIONS } from '~/config/permissions'
+import { errorMessage } from '~/utils/error'
 
 const { t } = useI18n()
 const toast = useToast()
@@ -42,10 +43,9 @@ onMounted(async () => {
   try {
     await admin.refresh()
   } catch (err: unknown) {
-    const e = err as { data?: { detail?: string }, message?: string }
     toast.add({
       title: t('common.error'),
-      description: e?.data?.detail ?? e?.message ?? t('common.networkError'),
+      description: errorMessage(err, t('common.networkError')),
       color: 'error'
     })
   }
@@ -127,8 +127,7 @@ async function onConfirm(force: boolean) {
       showConfirm.value = false
     }
   } catch (err: unknown) {
-    const e = err as { data?: { detail?: string }, message?: string }
-    const detail = e?.data?.detail ?? e?.message ?? t('common.error')
+    const detail = errorMessage(err, t('common.error'))
     confirmError.value = detail
     // If uninstall was blocked by reverse-deps or removable=false, offer force.
     if (
@@ -163,10 +162,9 @@ async function runApply() {
       })
     }
   } catch (err: unknown) {
-    const e = err as { data?: { detail?: string }, message?: string }
-    const msg = e?.message === 'restart-timeout'
+    const msg = (err as { message?: string })?.message === 'restart-timeout'
       ? t('settings.modules.restart.timeout')
-      : (e?.data?.detail ?? e?.message ?? t('settings.modules.restart.failed'))
+      : errorMessage(err, t('settings.modules.restart.failed'))
     toast.add({
       title: t('settings.modules.restart.failed'),
       description: msg,

--- a/frontend/app/pages/setup.vue
+++ b/frontend/app/pages/setup.vue
@@ -94,7 +94,8 @@ const taxIdWarning = computed(() =>
 onMounted(async () => {
   try {
     const res = await api.get<{ data: { countries: CountryPreset[], fallback: CountryPreset } }>(
-      '/api/v1/auth/setup/presets', { skipAuth: true }
+      // Convenience probe: the wizard degrades gracefully — never toast.
+      '/api/v1/auth/setup/presets', { skipAuth: true, errorToast: false }
     )
     presets.value = Object.fromEntries(res.data.countries.map(c => [c.code, c]))
     fallbackPreset.value = res.data.fallback
@@ -207,7 +208,9 @@ async function onSubmit() {
       language: isKnownCountry.value
         ? preset.value?.language
         : (COMM_LANGUAGES.includes(currentLocale.value) ? currentLocale.value : 'en')
-    }, { skipAuth: true })
+      // errorToast off: the catch renders errorMessage inline
+      // (409/422 have dedicated copy).
+    }, { skipAuth: true, errorToast: false })
 
     // ponytail: re-login con las credenciales recién creadas en vez de
     // inyectar los tokens a mano — una request barata y reusa fetchUser.

--- a/frontend/app/plugins/settings.registry.ts
+++ b/frontend/app/plugins/settings.registry.ts
@@ -183,8 +183,10 @@ export default defineNuxtPlugin(() => {
       const state = useState<{ loaded: boolean, professionals: number, others: number }>(
         'onboarding:team', () => ({ loaded: false, professionals: 0, others: 0 })
       )
+      // Background onboarding probe — never toast from here.
       const res = await api.get<{ data: Array<{ is_active: boolean, is_professional: boolean }> }>(
-        '/api/v1/auth/users'
+        '/api/v1/auth/users',
+        { errorToast: false }
       )
       const list = res.data.filter(u => u.is_active)
       state.value = {
@@ -216,7 +218,8 @@ export default defineNuxtPlugin(() => {
     load: async (api) => {
       const active = useActiveModulesState()
       if (active.value) return
-      const res = await api.get<ApiResponse<ActiveModule[]>>('/api/v1/modules/-/active')
+      // Background onboarding probe — never toast from here.
+      const res = await api.get<ApiResponse<ActiveModule[]>>('/api/v1/modules/-/active', { errorToast: false })
       active.value = res.data
     },
     when: () => {

--- a/frontend/tests/composables/usePeriodontogramSession.test.ts
+++ b/frontend/tests/composables/usePeriodontogramSession.test.ts
@@ -39,7 +39,10 @@ describe('usePeriodontogramSession — pending buffer survives failures', () => 
     expect(patchMock).toHaveBeenCalledTimes(1)
     expect(patchMock).toHaveBeenCalledWith(
       `/api/v1/periodontogram/snapshots/${SNAPSHOT_ID}/teeth/16/sites/MB`,
-      { probing_depth_mm: 5 }
+      { probing_depth_mm: 5 },
+      // The chart presents failures itself (lastError watcher / flush
+      // result) — useApi's 400/409/422 auto-toast is suppressed (#101).
+      { errorToast: false }
     )
     expect(session.dirty.value).toBe(false)
   })
@@ -63,7 +66,8 @@ describe('usePeriodontogramSession — pending buffer survives failures', () => 
     expect(patchMock).toHaveBeenCalledTimes(2)
     expect(patchMock).toHaveBeenLastCalledWith(
       `/api/v1/periodontogram/snapshots/${SNAPSHOT_ID}/teeth/16/sites/MB`,
-      { probing_depth_mm: 5 }
+      { probing_depth_mm: 5 },
+      { errorToast: false }
     )
     expect(session.dirty.value).toBe(false)
   })
@@ -83,7 +87,8 @@ describe('usePeriodontogramSession — pending buffer survives failures', () => 
     expect(flushed).toBe(true)
     expect(patchMock).toHaveBeenLastCalledWith(
       `/api/v1/periodontogram/snapshots/${SNAPSHOT_ID}/teeth/16/sites/MB`,
-      { probing_depth_mm: 5, bleeding_on_probing: true }
+      { probing_depth_mm: 5, bleeding_on_probing: true },
+      { errorToast: false }
     )
   })
 
@@ -106,7 +111,8 @@ describe('usePeriodontogramSession — pending buffer survives failures', () => 
     expect(flushed).toBe(true)
     expect(patchMock).toHaveBeenLastCalledWith(
       `/api/v1/periodontogram/snapshots/${SNAPSHOT_ID}/teeth/31`,
-      { mobility: 2 }
+      { mobility: 2 },
+      { errorToast: false }
     )
     expect(session.dirty.value).toBe(false)
   })


### PR DESCRIPTION
Fixes #101 — the last open workstream of the S5 audit (tranche 1 landed in #100; the error-states / input-preservation / destructive-confirms lists landed in #311).

## The contract (`useApi.ts`)

- **400 / 409 / 422** now toast `common.error` + the backend's own message (`errorDetail`) **before rethrowing** — a rethrow nobody catches is no longer a silent failure.
- Callers that present the failure themselves pass **`errorToast: false`** and keep single-toast behaviour.
- **404 never auto-toasts** — deliberately: it's routinely semantic in this codebase (probe reads, "not signed", lookups, module-absence degradation) and its handling belongs to the caller.
- 401 / 403 / 5xx / network handling unchanged.

## The audit — every call site, individually

**~417 `api.*` call sites** across the host and all module layers, classified per-site (not pattern-matched):

| Class | ~Count | Rule |
|---|---|---|
| Suppressed | ~230 | the surrounding code demonstrably presents the error (own toast, inline/form error the template renders, the #101 list-error banners) — or the failure is semantic control flow (the 24h-window 409, duplicate 409s, booking conflicts, background onboarding probes that must never toast) |
| Left default | ~180 | **silent before — the new toast IS the fix**: silent-fallback reads, catch-and-console paths, fire-and-forget mutations |
| Ambiguous | ~10 | resolved conservatively, each with a written rationale (e.g. verifactu `updateSettings`' mixed callers keep the default so the prod-switch 400 stays visible, accepting a possible brief double-present on its toggle path) |

**`errorMessage`/`errorDetail` adoption**: ~30 hand-built `e.data?.message`/`detail` reads replaced with the shared helpers; two local duplicates deleted (`useCatalog.apiErrorDetail`, `useModuleAdmin.extractMessage`).

## Drive-bys worth review attention

- **Both long-standing `vue/no-multiple-template-root` errors fixed** (payments + patients index pages wrapped in a single root — Nuxt page transitions want one anyway). Local eslint is now fully clean for the first time.
- `useBudgetSettings`' generic failure toast now carries the server detail.
- The periodontogram session unit test's exact-args assertions now encode the new contract.

## Verification

150/150 unit tests green; eslint clean on all 95 touched files; CHANGELOG entries in all 27 touched modules. The e2e suite exercises the busiest flows (booking, payments, patients) against the new default.