### PR TITLE
chore: add .gitattributes for line-ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Adds a root .gitattributes with \* text=auto\ so text files are normalized to LF in the repository (canonical content is already LF) while Windows checkouts keep native CRLF.

Prevents the recurring phantom 'everything is modified' diff on Windows/cline-style tooling that rewrites working-tree files with CRLF.