### PR TITLE
fix(docker): dev stack no longer runs the prod Nitro build (4GB machines boot again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,9 @@ open a new one.
 
 ### Prerequisites
 
-- Docker and Docker Compose
+- Docker and Docker Compose (4GB RAM is enough for the dev stack; building
+  the production frontend image from `Dockerfile.prod` needs 6GB+ — see the
+  `NODE_OPTIONS` note there)
 - Python 3.11+ (for local backend development)
 - Node.js 18+ (for local frontend development)
 

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.venv
+__pycache__
+*.pyc
+.pytest_cache
+.mypy_cache
+.ruff_cache
+build
+dist
+*.egg-info
+*.dpm
+storage
+.env
+.env.*
+!.env.example

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,16 +52,18 @@ services:
   frontend:
     build:
       context: ./frontend
-      target: builder
-      args:
-        # The browser resolves this URL, so it must be reachable from the
-        # device running it. Set API_BASE_URL=http://<host-lan-ip>:8000 in
-        # .env (plus the same origin in ALLOWED_ORIGINS) to reach the app
-        # from a phone or another machine.
-        API_BASE_URL: ${API_BASE_URL:-http://localhost:8000}
+      # `dev` stops after `npm install` — no Nitro build at image-build
+      # time (that build needs >4GB heap, see frontend/Dockerfile.prod,
+      # and its output was discarded anyway: the container runs the dev
+      # server over the ./frontend bind mount).
+      target: dev
     environment:
       NITRO_HOST: 0.0.0.0
       NITRO_PORT: 3000
+      # The browser resolves this URL, so it must be reachable from the
+      # device running it. Set API_BASE_URL=http://<host-lan-ip>:8000 in
+      # .env (plus the same origin in ALLOWED_ORIGINS) to reach the app
+      # from a phone or another machine.
       NUXT_PUBLIC_API_BASE_URL: ${API_BASE_URL:-http://localhost:8000}
       NODE_OPTIONS: --max-old-space-size=4096
       # Set NUXT_DEVTOOLS=false for a stable local e2e run — devtools

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,11 @@
+.git
+node_modules
+.nuxt
+.output
+dist
+coverage
+test-results
+playwright-report
+.env
+.env.*
+!.env.example

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,38 +1,22 @@
-# Build stage
-FROM node:20-alpine AS builder
+# Dev image for docker-compose.yml. Source code arrives at runtime through
+# the ./frontend:/app bind mount; this image only provides node plus
+# node_modules (seeded into the anonymous /app/node_modules volume).
+#
+# Production images build from Dockerfile.prod with the repo root as
+# context. The multi-stage prod build that used to live here ran
+# `npm run build` at image-build time with the default Node heap — the
+# 34-layer × 9-locale Nitro build needs >4GB (see Dockerfile.prod) — and
+# then discarded the output, because the dev container runs `npm run dev`.
+FROM node:20-alpine AS dev
 
 WORKDIR /app
 
-# Build argument for API URL
-ARG API_BASE_URL=http://localhost:8000
-ENV API_BASE_URL=$API_BASE_URL
-
-# Copy package files
 COPY package*.json ./
-
-# Install dependencies
 RUN npm install
 
-# Copy source code
-COPY . .
-
-# Build the application
-RUN npm run build
-
-# Production stage
-FROM node:20-alpine
-
-WORKDIR /app
-
-# Copy built output
-COPY --from=builder /app/.output /app/.output
-
-# Set environment variables
-ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=3000
 
 EXPOSE 3000
 
-# Start the application
-CMD ["node", ".output/server/index.mjs"]
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
## Problem

`docker-compose up --build` stopped working on 4GB machines. The dev compose targeted the `builder` stage of `frontend/Dockerfile`, whose last step is `RUN npm run build` — a full production Nitro build that is documented to need >4GB heap (`Dockerfile.prod` pins `NODE_OPTIONS=--max-old-space-size=6144` since 7b171bf1, same in CI). The `NODE_OPTIONS: 4096` in compose is an `environment:` key, so it never reached the build. And the build result was **discarded**: the container runs `npm run dev` over the `./frontend` bind mount.

On top of that, neither dev context had a `.dockerignore` (the root one is never read for `./backend` / `./frontend` contexts), so every build streamed ~800MB: host `node_modules` (421MB, darwin binaries copied *over* the image's `npm install`), `backend/.venv` (181MB), a 142MB test fixture, 36MB of `__pycache__`.

## Changes

- **`frontend/Dockerfile`**: dev-only image that stops after `npm install`. The removed builder/prod stages were used by nothing else (release + Coolify build `Dockerfile.prod` with repo-root context) and were broken standalone anyway — `modules.json` points at `/module_layers`, which only exists via the runtime mount.
- **`docker-compose.yml`**: `target: dev`; drop the now-unused `API_BASE_URL` build arg (runtime env already carries it).
- **`frontend/.dockerignore` + `backend/.dockerignore`**: new. Backend build context drops **359MB → 26MB**; the backend one also applies to the release/Coolify image builds (excludes junk only).
- **README**: document RAM expectations (4GB dev / 6GB+ for the prod frontend image build).

## Verified

- `docker-compose build frontend`: **~20s**, no Nitro build, trivial memory.
- Backend build context: 26MB.
- `docker-compose up -d`: all three services healthy; `/health` 200, demo login OK.

Follow-ups (resource audit issues + architecture discussion) coming separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9ct3NXNbCc8xepof83BdY