### PR TITLE
perf(core): memoize Alembic branch-head resolution — one shared walk per process (#323)

### DIFF
--- a/backend/app/core/plugins/alembic_paths.py
+++ b/backend/app/core/plugins/alembic_paths.py
@@ -6,6 +6,7 @@ by Alembic at import time and is awkward to import from tests.
 
 from __future__ import annotations
 
+import functools
 import importlib.util
 import logging
 from collections.abc import Callable
@@ -60,7 +61,13 @@ def alembic_cfg_path() -> Path:
     return Path(__file__).resolve().parents[3] / "alembic.ini"
 
 
+@functools.lru_cache(maxsize=1)
 def _load_script_directory():
+    # Memoized (#323): building the ScriptDirectory parses every revision
+    # file; reconcile_with_db used to rebuild it once per module (~0.4s of
+    # repeated graph loading per boot). Revision files ship with the code
+    # and never change inside a running process, so one instance is safe.
+    # Tests that synthesize revision trees call clear_alembic_caches().
     cfg_path = alembic_cfg_path()
     if not cfg_path.is_file():
         return None
@@ -72,6 +79,37 @@ def _load_script_directory():
     except Exception as exc:  # pragma: no cover — defensive
         logger.warning("Could not load Alembic ScriptDirectory: %s", exc)
         return None
+
+
+@functools.lru_cache(maxsize=1)
+def _branch_heads_by_versions_dir() -> dict[Path, str]:
+    """One full-graph walk → {module versions dir: branch head} (#323).
+
+    ``walk_revisions`` goes heads→base, so the first revision seen for a
+    directory is the latest descendant — the branch head. Replaces one
+    full walk per module (35× the same 105-file graph) with a single
+    shared pass.
+    """
+    script = _load_script_directory()
+    if script is None:
+        return {}
+    heads: dict[Path, str] = {}
+    for rev in script.walk_revisions():
+        rev_path_str = getattr(rev, "path", None)
+        if not rev_path_str:
+            continue
+        try:
+            rev_dir = Path(rev_path_str).resolve().parent
+        except (OSError, ValueError):
+            continue
+        heads.setdefault(rev_dir, rev.revision)
+    return heads
+
+
+def clear_alembic_caches() -> None:
+    """Drop the memoized ScriptDirectory + branch-head map (tests only)."""
+    _load_script_directory.cache_clear()
+    _branch_heads_by_versions_dir.cache_clear()
 
 
 def resolve_module_branch_head(module: BaseModule) -> str | None:
@@ -90,22 +128,7 @@ def resolve_module_branch_head(module: BaseModule) -> str | None:
     versions_dir = _module_versions_dir(module)
     if versions_dir is None:
         return None
-
-    script = _load_script_directory()
-    if script is None:
-        return None
-
-    for rev in script.walk_revisions():
-        rev_path_str = getattr(rev, "path", None)
-        if not rev_path_str:
-            continue
-        try:
-            rev_dir = Path(rev_path_str).resolve().parent
-        except (OSError, ValueError):
-            continue
-        if rev_dir == versions_dir:
-            return rev.revision
-    return None
+    return _branch_heads_by_versions_dir().get(versions_dir)
 
 
 def module_branch_is_isolated(module: BaseModule) -> bool:


### PR DESCRIPTION
Part of #323 — **proposal 1**, zero behaviour change.

- `_load_script_directory` is `lru_cache`d: building the `ScriptDirectory` parses every revision file, and `reconcile_with_db` rebuilt it **once per module** (~0.37 s of repeated graph loading every boot). Revision files ship with the code and never change inside a running process.
- `resolve_module_branch_head` now consults a single memoized heads→base pass that maps every module `versions/` dir to its branch head — 35 full-graph walks collapse into **one**. Measured on this tree: **87 ms cold / 1 ms warm** for all 35 modules.
- `clear_alembic_caches()` for tests that synthesize revision trees.
- Verified on a local Postgres: alembic-branches, boot-targets, cli, install-flow, uninstall-roundtrip and boot-upgrade-roundtrip suites — 23 tests, unchanged and green.

**Proposal 2** (manifest readable without importing the module) is a module-authoring-contract decision with a real design fork — laid out on the issue ([comment](https://github.com/dentalpin/dentalpin/issues/323#issuecomment-5463050292)) with a recommendation (**move the manifest out of code** — single source of truth, restores the documented discover contract, drops uninstalled models from `Base.metadata`), awaiting your call before anyone implements 35 modules' worth of it.