### PR TITLE
test(manifest): fail CI when a module migrations dir is unregistered in alembic.ini

### DIFF
--- a/backend/tests/test_manifest_validator.py
+++ b/backend/tests/test_manifest_validator.py
@@ -7,8 +7,11 @@ grant that references a non-existent module permission, etc.
 
 from __future__ import annotations
 
+from configparser import ConfigParser
+
 from fastapi import APIRouter
 
+from app.core.plugins.alembic_paths import alembic_cfg_path
 from app.core.plugins.base import BaseModule
 from app.core.plugins.loader import discover_modules
 from app.core.plugins.manifest_validator import (
@@ -23,6 +26,44 @@ def test_every_shipped_module_passes_validation() -> None:
     modules = discover_modules()
     issues = validate_modules(modules)
     assert issues == [], "\n".join(f"{i.code}: {i.module_name}: {i.message}" for i in issues)
+
+
+def test_every_module_migrations_dir_is_registered_in_alembic_ini() -> None:
+    """M1 guard: every module migrations dir must be in the static version_locations.
+
+    The Alembic CLI resolves ``heads``/``history``/``upgrade`` from the
+    *static* ``version_locations`` in ``backend/alembic.ini``; env.py's
+    runtime discovery override is too late for graph building. A module
+    that ships ``migrations/versions/`` but is missing here breaks its own
+    ``alembic_roundtrip`` test ("X tables missing after upgrade heads")
+    even though the SQLAlchemy ``create_all`` suite passes.
+    """
+    config = ConfigParser()
+    cfg_path = alembic_cfg_path()
+    assert cfg_path.is_file(), f"missing {cfg_path}"
+    config.read(cfg_path)
+
+    registered = {
+        loc.strip() for loc in config.get("alembic", "version_locations").split(":") if loc.strip()
+    }
+
+    modules_root = cfg_path.parent / "app" / "modules"
+    missing: list[str] = []
+    for module_dir in sorted(modules_root.iterdir()):
+        if not module_dir.is_dir() or module_dir.name.startswith("_"):
+            continue
+        versions = module_dir / "migrations" / "versions"
+        if not versions.is_dir():
+            continue
+        expected = f"app/modules/{module_dir.name}/migrations/versions"
+        if expected not in registered:
+            missing.append(expected)
+
+    assert missing == [], (
+        "Modules with migrations not registered in [alembic] version_locations "
+        f"of {cfg_path.name}: {missing}. Append "
+        "':app/modules/<name>/migrations/versions' to the version_locations line."
+    )
 
 
 # --- Negative cases via stub modules --------------------------------------

--- a/docs/checklists/new-module.md
+++ b/docs/checklists/new-module.md
@@ -28,6 +28,7 @@ For deeper rationale on any line, follow the link.
 ## Migrations
 
 - [ ] Migrations live in `backend/app/modules/<name>/migrations/versions/`
+- [ ] Module's migrations directory registered in `backend/alembic.ini` `[alembic]` `version_locations` (M1 trap — the Alembic CLI resolves graphs from this static list; env.py's runtime discovery override is too late). Guard test: `test_every_module_migrations_dir_is_registered_in_alembic_ini`
 - [ ] First migration of the module sets `branch_labels = ("<name>",)`
 - [ ] No revision threads through another module's chain (uninstall safety, issue #56 — see ADR 0002)
 - [ ] Cross-module FKs only against modules in `manifest.depends`

--- a/docs/technical/creating-modules.md
+++ b/docs/technical/creating-modules.md
@@ -485,8 +485,16 @@ alembic revision --autogenerate \
 
 `backend/alembic.ini`'s `version_locations` lists every module's
 `migrations/versions` directory so `alembic history | heads | upgrade`
-find them before `env.py` runs. Because each branch adds a head, the
-round-trip tests use the plural form `alembic upgrade heads`. The
+find them before `env.py` runs. **This registration step is mandatory when
+you create a module's migration branch**: the Alembic CLI builds its graph
+from that *static* list, and `env.py`'s runtime discovery override is too
+late for graph resolution. Skip it and the module's `alembic_roundtrip`
+test fails ("X tables missing after upgrade heads") even though the
+SQLAlchemy `create_all` suite passes. A CI guard
+(`test_every_module_migrations_dir_is_registered_in_alembic_ini`) fails the
+manifest gate until the directory is appended to the list as
+`:app/modules/<name>/migrations/versions`. Because each branch adds a
+head, the round-trip tests use the plural form `alembic upgrade heads`. The
 container entrypoint runs `python -m app.cli db upgrade` instead, which
 names the core heads plus the branch head of every *installed* module —
 an uninstalled module's branch is never applied at boot (ADR 0020).


### PR DESCRIPTION
## Summary

- The Alembic CLI builds `heads` / `history` / `upgrade` graphs from the **static** `version_locations` in `backend/alembic.ini`; `env.py`'s runtime `discover_version_locations` override is too late for graph resolution.
- A module that ships `migrations/versions/` but forgets the registration breaks its own `alembic_roundtrip` test ("X tables missing after upgrade heads") while the SQLAlchemy `create_all` suite still passes — an expensive, confusing failure to diagnose.
- This PR makes that a **fast, permanent CI guard**: the manifest gate now fails any unregistered module branch with the exact fix in the message, before the slow roundtrip even runs.

## Tasks done

- `test:` **`test_every_module_migrations_dir_is_registered_in_alembic_ini`** in `backend/tests/test_manifest_validator.py` — parses `[alembic] version_locations` (colon-joined, whitespace-tolerant) and asserts every non-`_`-prefixed module's `migrations/versions` directory is registered. Host-run, DB-less, zero catalog churn.
- `docs:` **`docs/checklists/new-module.md`** — new Migrations checkbox: register the module's migrations dir in `version_locations` (+ guard-test name).
- `docs:` **`docs/technical/creating-modules.md`** §3 — prose now states registration is mandatory, explains the static-list-vs-runtime-order failure mode, the roundtrip symptom, and points at the guard test.

## Modules touched

none (core CI/dx hardening — test + docs only)

## Checklist

- [x] PR title follows Conventional Commits (`test:` / `docs:`)
- [x] `cd backend && ruff check . && ruff format --check .` passes
- [x] Tests added (behaviour changed: new CI guard)
- [x] No cross-module imports outside `manifest.depends` (no module code touched)

## Test plan

1. `python -m pytest tests/test_manifest_validator.py::test_every_module_migrations_dir_is_registered_in_alembic_ini` → passes.
2. Sanity: temporarily drop one module's `:app/modules/<name>/migrations/versions` entry from `backend/alembic.ini:11` → the guard fails with the module name and the append fix in the message.
3. CI `backend-manifest` gate stays green on this branch.

## Merge-to-list + maintainer

@martinezsalmeron — small CI-guard + docs hardening PR; ready for review/merge when convenient.