### PR TITLE
feat(integrations): public read API, stable event ids, 6-trigger catalog with frozen samples (#65)

### DIFF
--- a/backend/app/modules/integrations/CHANGELOG.md
+++ b/backend/app/modules/integrations/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat(#65): the three flagged Phase-1 follow-ups — (1) **public read API** under `/api/v1/integrations/public/` consuming the `dp_` bearer tokens with per-scope authorization (`/ping` introspection for Zapier auth tests, patient search by phone/email/NIF/name + read, curated response shape, rate-limited); (2) **stable `event_id`** generated once per event and shared across every subscriber's delivery (payload top-level field; `int_0003` column, legacy rows fall back to the delivery id); (3) **trigger catalog expanded** to 6 events (`appointment.scheduled`/`.cancelled`, `budget.accepted`, `invoice.sent` join the original two), each with a frozen sample payload served by `GET /webhooks/triggers` and pinned by test.
+
 - Initial module (Phase 1 of issue #65): webhook subscription CRUD,
   outbox-backed delivery with retry/backoff/auto-disable, Stripe-style
   HMAC-SHA256 signing, and one working trigger (`patient.created`).

--- a/backend/app/modules/integrations/CLAUDE.md
+++ b/backend/app/modules/integrations/CLAUDE.md
@@ -1,12 +1,12 @@
 # integrations module
 
-Webhook subscriptions (REST Hooks) for third-party automations — issue
-#65. Phase 1: subscription CRUD, outbox-backed delivery with
-retry/backoff/auto-disable, Stripe-style HMAC signing, two working
-triggers (`patient.created`, `appointment.completed`), and API
-tokens. The public data-read API that will authenticate with those
-tokens, the full trigger catalog, and the Zapier/Make/n8n
-integrations are follow-up PRs, not in this module yet.
+Webhook subscriptions (REST Hooks) + the token-authenticated public
+read API for third-party automations — issue #65. Subscription CRUD,
+outbox-backed delivery with retry/backoff/auto-disable, Stripe-style
+HMAC signing, six triggers with frozen sample payloads, API tokens,
+and `/api/v1/integrations/public/*` consuming those tokens. The
+Zapier/Make/n8n apps themselves are follow-up work outside this
+module.
 
 ## What it does
 
@@ -17,12 +17,31 @@ subscriptions` and `/api/v1/integrations/tokens` (JWT +
 to one or more event types with a target URL; the module signs and
 delivers a JSON payload to that URL whenever a subscribed event fires.
 A clinic can also issue bearer API tokens (name + scopes), shown once
-on creation, revocable — no endpoint consumes them yet.
+on creation, revocable — consumed by the public read API below.
 
-Every payload carries `occurred_at`, but there's no frozen sample
-payload per trigger yet and no event id stable across subscribers
-(`WebhookDelivery.id` is per-subscription) — both are follow-up work
-(issue #65 §3), not in Phase 1.
+Every payload carries `occurred_at` and a top-level `event_id` that is
+**stable across subscribers** of the same event (generated once in
+`handlers._enqueue`; `WebhookDelivery.event_id`, `int_0003`) — the
+receiver's dedupe key. Each supported trigger has a frozen sample
+payload in `triggers.SAMPLE_PAYLOADS`, served by
+`GET /webhooks/triggers` and pinned to the catalog by test; treat the
+sample keys as a public contract (renames are breaking).
+
+## Public read API
+
+`public_router.py`, mounted at `/api/v1/integrations/public/`. Auth is
+`Authorization: Bearer dp_…` (SHA-256 hash lookup, revoked check,
+`last_used_at` stamped) — **not** JWT, so `require_permission` never
+applies; the token's `scopes` list authorizes instead
+(`patients:read`). Endpoints: `/ping` (introspection — Zapier's auth
+test), `/patients` search (phone/email/NIF format-tolerant match, `q`
+name substring — powers find-or-create), `/patients/{id}`. Responses
+use a curated `PublicPatientResponse`, narrower than the internal
+shape, and are rate-limited (120/minute). Importing
+`patients.models` is legal — `patients` is in `manifest.depends`.
+A trigger may only be added for an event whose publisher passes
+`db=` (the bus hard-raises otherwise, ADR 0019) — that is why
+`patient.updated` / `payment.recorded` are still out.
 
 ## Outbox
 

--- a/backend/app/modules/integrations/__init__.py
+++ b/backend/app/modules/integrations/__init__.py
@@ -84,5 +84,9 @@ class IntegrationsModule(BaseModule):
 
         return {
             EventType.PATIENT_CREATED: IntegrationsHandlers.on_patient_created,
+            EventType.APPOINTMENT_SCHEDULED: IntegrationsHandlers.on_appointment_scheduled,
             EventType.APPOINTMENT_COMPLETED: IntegrationsHandlers.on_appointment_completed,
+            EventType.APPOINTMENT_CANCELLED: IntegrationsHandlers.on_appointment_cancelled,
+            EventType.BUDGET_ACCEPTED: IntegrationsHandlers.on_budget_accepted,
+            EventType.INVOICE_SENT: IntegrationsHandlers.on_invoice_sent,
         }

--- a/backend/app/modules/integrations/gateway.py
+++ b/backend/app/modules/integrations/gateway.py
@@ -50,6 +50,7 @@ class WebhookGateway:
         clinic_id: UUID,
         event_type: str,
         payload: dict[str, Any],
+        event_id: UUID | None = None,
     ) -> list[WebhookDelivery]:
         """Queue one delivery per active subscription matching ``event_type``.
 
@@ -73,6 +74,7 @@ class WebhookGateway:
                 subscription_id=sub.id,
                 clinic_id=clinic_id,
                 event_type=event_type,
+                event_id=event_id,
                 payload=payload,
                 status="queued",
                 next_attempt_at=datetime.now(UTC),
@@ -146,6 +148,10 @@ class WebhookGateway:
         body = json.dumps(
             {
                 "event": delivery.event_type,
+                # Stable across subscribers of the same event — the dedupe
+                # key (#65 §1). Pre-int_0003 rows fall back to the
+                # per-delivery id, which is still stable across retries.
+                "event_id": str(delivery.event_id or delivery.id),
                 "delivery_id": str(delivery.id),
                 "data": delivery.payload,
             },

--- a/backend/app/modules/integrations/handlers.py
+++ b/backend/app/modules/integrations/handlers.py
@@ -5,14 +5,16 @@ each body queues WebhookDelivery rows on the publisher's own session —
 DB-only, no network I/O. The scheduled dispatch tick owns the network
 I/O, so a rolled-back request queues no delivery.
 
-Phase 1 ships two triggers end-to-end (issue #65) — the full trigger
-catalog (issue #65 §3) is a follow-up PR.
+One handler per supported trigger (triggers.py). Every event in the
+catalog is published with ``db=`` (transactional); a trigger for a
+fire-and-forget publish (e.g. ``patient.updated``) must first migrate
+its publisher to ``db=`` or the bus hard-raises at publish time.
 """
 
 import logging
 from datetime import UTC, datetime
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -47,10 +49,15 @@ class IntegrationsHandlers:
 
         # occurred_at: stamped here rather than trusting the publisher's own
         # payload to carry one, since not every EventType payload does.
-        payload = {**data, "occurred_at": datetime.now(UTC).isoformat()}
+        payload = {**data, "occurred_at": data.get("occurred_at") or datetime.now(UTC).isoformat()}
 
+        # One id per *event*, shared by every subscriber's delivery, so a
+        # receiver wired to two subscriptions can dedupe (issue #65 §1).
+        event_id = uuid4()
         async with db.begin_nested():
-            await WebhookGateway.enqueue_for_event(db, clinic_id, event_type, payload)
+            await WebhookGateway.enqueue_for_event(
+                db, clinic_id, event_type, payload, event_id=event_id
+            )
 
     @staticmethod
     async def on_patient_created(data: dict[str, Any], *, db: AsyncSession) -> None:
@@ -63,3 +70,27 @@ class IntegrationsHandlers:
         from app.core.events import EventType
 
         await IntegrationsHandlers._enqueue(EventType.APPOINTMENT_COMPLETED, data, db=db)
+
+    @staticmethod
+    async def on_appointment_scheduled(data: dict[str, Any], *, db: AsyncSession) -> None:
+        from app.core.events import EventType
+
+        await IntegrationsHandlers._enqueue(EventType.APPOINTMENT_SCHEDULED, data, db=db)
+
+    @staticmethod
+    async def on_appointment_cancelled(data: dict[str, Any], *, db: AsyncSession) -> None:
+        from app.core.events import EventType
+
+        await IntegrationsHandlers._enqueue(EventType.APPOINTMENT_CANCELLED, data, db=db)
+
+    @staticmethod
+    async def on_budget_accepted(data: dict[str, Any], *, db: AsyncSession) -> None:
+        from app.core.events import EventType
+
+        await IntegrationsHandlers._enqueue(EventType.BUDGET_ACCEPTED, data, db=db)
+
+    @staticmethod
+    async def on_invoice_sent(data: dict[str, Any], *, db: AsyncSession) -> None:
+        from app.core.events import EventType
+
+        await IntegrationsHandlers._enqueue(EventType.INVOICE_SENT, data, db=db)

--- a/backend/app/modules/integrations/migrations/versions/int_0003_event_id.py
+++ b/backend/app/modules/integrations/migrations/versions/int_0003_event_id.py
@@ -1,0 +1,32 @@
+"""integrations: stable event id on deliveries.
+
+Issue #65 §1 follow-up: every delivery row carries the id of the *event*
+that produced it, shared across all subscriptions, so receivers can
+dedupe. Nullable — pre-existing rows keep None and the dispatcher falls
+back to the delivery id.
+
+Revision ID: int_0003
+Revises: int_0002
+Create Date: 2026-08-31
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "int_0003"
+down_revision: str | None = "int_0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("webhook_deliveries", sa.Column("event_id", sa.UUID(), nullable=True))
+    op.create_index("ix_webhook_deliveries_event_id", "webhook_deliveries", ["event_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_webhook_deliveries_event_id", table_name="webhook_deliveries")
+    op.drop_column("webhook_deliveries", "event_id")

--- a/backend/app/modules/integrations/models.py
+++ b/backend/app/modules/integrations/models.py
@@ -81,6 +81,11 @@ class WebhookDelivery(Base, TimestampMixin):
     clinic_id: Mapped[UUID] = mapped_column(ForeignKey("clinics.id"), index=True)
 
     event_type: Mapped[str] = mapped_column(String(100), index=True)
+    # One id per *event*, shared across every subscription's delivery row
+    # for that event, so receivers can dedupe (issue #65 §1). Nullable:
+    # rows queued before int_0003 have none — the dispatcher falls back
+    # to the per-delivery id for those.
+    event_id: Mapped[UUID | None] = mapped_column(UUID(as_uuid=True), default=None, index=True)
     payload: Mapped[dict] = mapped_column(JSONB)
 
     status: Mapped[str] = mapped_column(

--- a/backend/app/modules/integrations/public_router.py
+++ b/backend/app/modules/integrations/public_router.py
@@ -1,0 +1,175 @@
+"""Token-authenticated public read API — mounted at ``/api/v1/integrations/public/``.
+
+The consumer surface for the ``dp_`` API tokens Phase 1 already issues
+(issue #65 §2/§5): Zapier / Make / n8n authenticate with
+``Authorization: Bearer dp_…`` — no JWT, no cookie — and read data scoped
+to the token's clinic and scopes. Read-only in this slice; write actions
+(§4) come with idempotency-key support later.
+
+Lives under the module prefix (``/api/v1/integrations/public/…``) because
+a module owns exactly one mount point — the path is part of the public
+contract now, so keep it stable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.router import limiter
+from app.core.schemas import ApiResponse, PaginatedApiResponse
+from app.database import get_db
+from app.modules.patients.models import Patient
+
+from .models import ApiToken
+from .schemas import PublicPatientResponse, PublicTokenInfo
+
+public_router = APIRouter()
+
+# One shared limit for the whole public surface; generous enough for a
+# polling Zap, tight enough that a runaway loop can't hammer the API.
+_RATE = "120/minute"
+
+
+async def _resolve_token(request: Request, db: AsyncSession) -> ApiToken:
+    auth = request.headers.get("Authorization", "")
+    scheme, _, credentials = auth.partition(" ")
+    if scheme.lower() != "bearer" or not credentials.startswith("dp_"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing or malformed API token (expected 'Authorization: Bearer dp_…')",
+        )
+    token_hash = hashlib.sha256(credentials.encode("utf-8")).hexdigest()
+    token = (
+        await db.execute(select(ApiToken).where(ApiToken.token_hash == token_hash))
+    ).scalar_one_or_none()
+    if token is None or token.revoked_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or revoked API token"
+        )
+    # Best-effort usage tracking; committed with the request's session.
+    token.last_used_at = datetime.now(UTC)
+    return token
+
+
+def require_token(*scopes: str):
+    """Dependency: authenticate a ``dp_`` bearer token and check scopes."""
+
+    async def dependency(
+        request: Request, db: Annotated[AsyncSession, Depends(get_db)]
+    ) -> ApiToken:
+        token = await _resolve_token(request, db)
+        missing = [s for s in scopes if s not in (token.scopes or [])]
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Token lacks required scope(s): {', '.join(missing)}",
+            )
+        return token
+
+    return dependency
+
+
+def _public_patient(p: Patient) -> PublicPatientResponse:
+    return PublicPatientResponse(
+        id=p.id,
+        first_name=p.first_name,
+        last_name=p.last_name,
+        phone=p.phone,
+        email=p.email,
+        national_id=p.national_id,
+        date_of_birth=p.date_of_birth,
+        status=p.status,
+        created_at=p.created_at,
+    )
+
+
+@public_router.get("/ping", response_model=ApiResponse[PublicTokenInfo])
+@limiter.limit(_RATE)
+async def ping(
+    request: Request,
+    token: Annotated[ApiToken, Depends(require_token())],
+) -> ApiResponse[PublicTokenInfo]:
+    """Token introspection — Zapier's auth test calls this."""
+    return ApiResponse(
+        data=PublicTokenInfo(
+            clinic_id=token.clinic_id, token_name=token.name, scopes=token.scopes or []
+        )
+    )
+
+
+@public_router.get("/patients", response_model=PaginatedApiResponse[PublicPatientResponse])
+@limiter.limit(_RATE)
+async def search_patients(
+    request: Request,
+    token: Annotated[ApiToken, Depends(require_token("patients:read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    phone: str | None = Query(default=None, max_length=32),
+    email: str | None = Query(default=None, max_length=255),
+    national_id: str | None = Query(default=None, max_length=50),
+    q: str | None = Query(default=None, max_length=100, description="Name substring"),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+) -> PaginatedApiResponse[PublicPatientResponse]:
+    """Find patients — powers Zapier's search / search-or-create pattern.
+
+    Exact-ish match on ``phone`` / ``email`` / ``national_id`` (whitespace
+    and case tolerant), substring on ``q`` against the full name.
+    """
+    stmt = select(Patient).where(Patient.clinic_id == token.clinic_id)
+    if phone:
+        normalized = phone.replace(" ", "").replace("-", "")
+        stmt = stmt.where(func.replace(func.replace(Patient.phone, " ", ""), "-", "") == normalized)
+    if email:
+        stmt = stmt.where(func.lower(Patient.email) == email.strip().lower())
+    if national_id:
+        stmt = stmt.where(func.upper(Patient.national_id) == national_id.strip().upper())
+    if q:
+        like = f"%{q.strip()}%"
+        stmt = stmt.where(
+            or_(
+                (Patient.first_name + " " + Patient.last_name).ilike(like),
+                Patient.first_name.ilike(like),
+                Patient.last_name.ilike(like),
+            )
+        )
+
+    total = (await db.execute(select(func.count()).select_from(stmt.subquery()))).scalar_one()
+    rows = (
+        (
+            await db.execute(
+                stmt.order_by(Patient.created_at.desc())
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return PaginatedApiResponse(
+        data=[_public_patient(p) for p in rows], total=total, page=page, page_size=page_size
+    )
+
+
+@public_router.get("/patients/{patient_id}", response_model=ApiResponse[PublicPatientResponse])
+@limiter.limit(_RATE)
+async def get_patient(
+    request: Request,
+    patient_id: UUID,
+    token: Annotated[ApiToken, Depends(require_token("patients:read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[PublicPatientResponse]:
+    patient = (
+        await db.execute(
+            select(Patient).where(Patient.clinic_id == token.clinic_id, Patient.id == patient_id)
+        )
+    ).scalar_one_or_none()
+    if patient is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Patient not found")
+    return ApiResponse(data=_public_patient(patient))

--- a/backend/app/modules/integrations/router.py
+++ b/backend/app/modules/integrations/router.py
@@ -23,15 +23,24 @@ from .schemas import (
     ApiTokenCreate,
     ApiTokenCreated,
     ApiTokenResponse,
+    TriggerInfo,
     WebhookSubscriptionCreate,
     WebhookSubscriptionCreated,
     WebhookSubscriptionResponse,
     WebhookSubscriptionUpdate,
 )
 from .service import IntegrationsService
+from .triggers import SAMPLE_PAYLOADS
 from .url_safety import UnsafeWebhookURLError
 
 router = APIRouter()
+
+# Token-authenticated public read surface (issue #65 §2/§5) — a separate
+# file because its auth model (dp_ bearer tokens) is different from the
+# JWT-gated admin CRUD below.
+from .public_router import public_router  # noqa: E402
+
+router.include_router(public_router, prefix="/public")
 
 
 async def _get_owned_subscription(db: AsyncSession, clinic_id: UUID, subscription_id: UUID):
@@ -167,3 +176,21 @@ async def revoke_token(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Token already revoked")
     token = await IntegrationsService.revoke_token(db, token)
     return ApiResponse(data=ApiTokenResponse.model_validate(token))
+
+
+@router.get("/webhooks/triggers", response_model=ApiResponse[list[TriggerInfo]])
+async def list_triggers(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("integrations.subscriptions.read"))],
+) -> ApiResponse[list[TriggerInfo]]:
+    """The subscribable trigger catalog with its frozen sample payloads.
+
+    What a Zapier/Make app (or the admin UI's picker) reads to know
+    which events exist and what fields each one carries.
+    """
+    return ApiResponse(
+        data=[
+            TriggerInfo(event_type=event_type, sample_payload=sample)
+            for event_type, sample in sorted(SAMPLE_PAYLOADS.items())
+        ]
+    )

--- a/backend/app/modules/integrations/schemas.py
+++ b/backend/app/modules/integrations/schemas.py
@@ -11,7 +11,7 @@ resolver (see ``url_safety.py``). It's validated in ``service.py``
 instead, at create/update, before the row is written.
 """
 
-from datetime import datetime
+from datetime import date, datetime
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
@@ -107,3 +107,34 @@ class ApiTokenCreated(ApiTokenResponse):
     """Create response only — carries the plaintext token exactly once."""
 
     token: str = Field(description="Shown once. Store it now; it cannot be retrieved again.")
+
+
+class TriggerInfo(BaseModel):
+    """One row of the public trigger catalog (issue #65 §3)."""
+
+    event_type: str
+    sample_payload: dict
+
+
+class PublicTokenInfo(BaseModel):
+    """Token introspection for /public/ping (Zapier's auth test)."""
+
+    clinic_id: UUID
+    token_name: str
+    scopes: list[str]
+
+
+class PublicPatientResponse(BaseModel):
+    """Curated public shape — deliberately narrower than the internal
+    PatientResponse. Adding a field is fine; renaming/removing one is a
+    breaking change to every integration in the wild."""
+
+    id: UUID
+    first_name: str
+    last_name: str
+    phone: str | None
+    email: str | None
+    national_id: str | None
+    date_of_birth: date | None
+    status: str
+    created_at: datetime

--- a/backend/app/modules/integrations/triggers.py
+++ b/backend/app/modules/integrations/triggers.py
@@ -1,7 +1,7 @@
 """Event types and API token scopes this module actually supports.
 
-Phase 1 ships two working triggers end-to-end (issue #65). Almost
-every other event issue #65 §3 wants already exists on the bus
+The trigger catalog covers the transactional publishers on the bus
+(issue #65 §3). Almost every other event #65 wants already exists there
 (``core/events/types.py``) — adding it here means only "declare a new
 transactional handler in handlers.py", no new bus infra. Keeping this
 list separate from ``EventType`` (which has ~60 events, most
@@ -18,7 +18,70 @@ we never have to migrate free-text scopes later once one exists.
 from app.core.events import EventType
 
 SUPPORTED_EVENT_TYPES: frozenset[str] = frozenset(
-    {EventType.PATIENT_CREATED, EventType.APPOINTMENT_COMPLETED}
+    {
+        EventType.PATIENT_CREATED,
+        EventType.APPOINTMENT_SCHEDULED,
+        EventType.APPOINTMENT_COMPLETED,
+        EventType.APPOINTMENT_CANCELLED,
+        EventType.BUDGET_ACCEPTED,
+        EventType.INVOICE_SENT,
+    }
 )
+
+# Frozen sample payload per trigger (issue #65 §3): the stable fields a
+# Zapier/Make visual mapper binds against. Single source of truth — the
+# catalog endpoint serves these, and a test pins every supported trigger
+# to a sample whose keys mirror the real publisher payload. Adding a key
+# to a publisher payload is fine; renaming/removing one is a breaking
+# change to every Zap in the wild.
+SAMPLE_PAYLOADS: dict[str, dict] = {
+    EventType.PATIENT_CREATED: {
+        "patient_id": "0b0e2a1e-4f6a-4d38-9c53-1f4b7e2ad001",
+        "clinic_id": "7a1d2c3b-89ab-4cde-9012-3456789abc02",
+        "occurred_at": "2026-08-31T09:00:00+00:00",
+    },
+    EventType.APPOINTMENT_SCHEDULED: {
+        "appointment_id": "c2b4a6d8-1357-4f9b-8ace-024680bdf003",
+        "clinic_id": "7a1d2c3b-89ab-4cde-9012-3456789abc02",
+        "patient_id": "0b0e2a1e-4f6a-4d38-9c53-1f4b7e2ad001",
+        "professional_id": "d4e5f6a7-2468-4ace-b135-79bdf0246004",
+        "start_time": "2026-09-01T10:00:00+00:00",
+        "end_time": "2026-09-01T10:30:00+00:00",
+        "treatment_type": "revision",
+        "cabinet": "1",
+        "occurred_at": "2026-08-31T09:00:00+00:00",
+    },
+    EventType.APPOINTMENT_COMPLETED: {
+        "appointment_id": "c2b4a6d8-1357-4f9b-8ace-024680bdf003",
+        "clinic_id": "7a1d2c3b-89ab-4cde-9012-3456789abc02",
+        "patient_id": "0b0e2a1e-4f6a-4d38-9c53-1f4b7e2ad001",
+        "occurred_at": "2026-08-31T09:00:00+00:00",
+    },
+    EventType.APPOINTMENT_CANCELLED: {
+        "appointment_id": "c2b4a6d8-1357-4f9b-8ace-024680bdf003",
+        "clinic_id": "7a1d2c3b-89ab-4cde-9012-3456789abc02",
+        "patient_id": "0b0e2a1e-4f6a-4d38-9c53-1f4b7e2ad001",
+        "occurred_at": "2026-08-31T09:00:00+00:00",
+    },
+    EventType.BUDGET_ACCEPTED: {
+        "clinic_id": "7a1d2c3b-89ab-4cde-9012-3456789abc02",
+        "budget_id": "e6f7a8b9-3579-4bdf-9ace-13579bdf0005",
+        "patient_id": "0b0e2a1e-4f6a-4d38-9c53-1f4b7e2ad001",
+        "budget_number": "P-2026-0042",
+        "total": "1250.00",
+        "accepted_by": "d4e5f6a7-2468-4ace-b135-79bdf0246004",
+        "accepted_via": "staff",
+        "plan_id": None,
+        "occurred_at": "2026-08-31T09:00:00+00:00",
+    },
+    EventType.INVOICE_SENT: {
+        "clinic_id": "7a1d2c3b-89ab-4cde-9012-3456789abc02",
+        "invoice_id": "f8a9b0c1-468a-4ce0-8bdf-2468ace00006",
+        "patient_id": "0b0e2a1e-4f6a-4d38-9c53-1f4b7e2ad001",
+        "send_method": "email",
+        "recipient_email": "patient@example.com",
+        "occurred_at": "2026-08-31T09:00:00+00:00",
+    },
+}
 
 SUPPORTED_TOKEN_SCOPES: frozenset[str] = frozenset({"patients:read"})

--- a/backend/tests/modules/integrations/test_public_api.py
+++ b/backend/tests/modules/integrations/test_public_api.py
@@ -1,0 +1,174 @@
+"""Public read API (dp_ bearer tokens), trigger catalog, stable event ids."""
+
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.email.encryption import encrypt_password
+from app.modules.integrations.handlers import IntegrationsHandlers
+from app.modules.integrations.models import ApiToken, WebhookDelivery, WebhookSubscription
+from app.modules.integrations.service import IntegrationsService
+from app.modules.integrations.triggers import SAMPLE_PAYLOADS, SUPPORTED_EVENT_TYPES
+from app.modules.patients.models import Patient
+
+PING = "/api/v1/integrations/public/ping"
+PATIENTS = "/api/v1/integrations/public/patients"
+
+
+async def _token(db, clinic_id, *, scopes=("patients:read",)) -> str:
+    _, plaintext = await IntegrationsService.create_token(
+        db, clinic_id, {"name": "zap", "scopes": list(scopes)}
+    )
+    await db.commit()
+    return plaintext
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _patient(db, clinic_id, **kw) -> Patient:
+    fields = dict(
+        clinic_id=clinic_id,
+        first_name="Ana",
+        last_name="García",
+        phone="+34 600 11 22 33",
+        email="Ana@Example.com",
+        national_id="12345678Z",
+    )
+    fields.update(kw)
+    p = Patient(**fields)
+    db.add(p)
+    await db.commit()
+    await db.refresh(p)
+    return p
+
+
+# --- auth ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ping_introspects_token(client: AsyncClient, db_session, test_clinic):
+    token = await _token(db_session, test_clinic.id)
+    res = await client.get(PING, headers=_auth(token))
+    assert res.status_code == 200, res.text
+    data = res.json()["data"]
+    assert data["clinic_id"] == str(test_clinic.id)
+    assert data["scopes"] == ["patients:read"]
+
+
+@pytest.mark.asyncio
+async def test_bad_and_revoked_tokens_are_401(client: AsyncClient, db_session, test_clinic):
+    res = await client.get(PING, headers=_auth("dp_not-a-real-token"))
+    assert res.status_code == 401
+
+    res = await client.get(PING)  # no header at all
+    assert res.status_code == 401
+
+    token = await _token(db_session, test_clinic.id)
+    row = (await db_session.execute(select(ApiToken))).scalars().first()
+    row.revoked_at = datetime.now(UTC)
+    await db_session.commit()
+    res = await client.get(PING, headers=_auth(token))
+    assert res.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_missing_scope_is_403(client: AsyncClient, db_session, test_clinic):
+    token = await _token(db_session, test_clinic.id, scopes=())
+    res = await client.get(PATIENTS, headers=_auth(token))
+    assert res.status_code == 403
+    assert "patients:read" in res.json()["message"]
+
+
+# --- patient search ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_by_phone_is_format_tolerant(client: AsyncClient, db_session, test_clinic):
+    await _patient(db_session, test_clinic.id)
+    token = await _token(db_session, test_clinic.id)
+
+    res = await client.get(PATIENTS, params={"phone": "+34600112233"}, headers=_auth(token))
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["total"] == 1
+    assert body["data"][0]["first_name"] == "Ana"
+
+
+@pytest.mark.asyncio
+async def test_search_by_email_and_nif_case_insensitive(
+    client: AsyncClient, db_session, test_clinic
+):
+    p = await _patient(db_session, test_clinic.id)
+    token = await _token(db_session, test_clinic.id)
+
+    res = await client.get(PATIENTS, params={"email": "ana@example.com"}, headers=_auth(token))
+    assert res.json()["total"] == 1
+
+    res = await client.get(PATIENTS, params={"national_id": "12345678z"}, headers=_auth(token))
+    assert res.json()["total"] == 1
+
+    res = await client.get(f"{PATIENTS}/{p.id}", headers=_auth(token))
+    assert res.status_code == 200
+    assert res.json()["data"]["id"] == str(p.id)
+
+
+@pytest.mark.asyncio
+async def test_search_no_match_and_unknown_id_404(client: AsyncClient, db_session, test_clinic):
+    token = await _token(db_session, test_clinic.id)
+    res = await client.get(PATIENTS, params={"phone": "+34999999999"}, headers=_auth(token))
+    assert res.json()["total"] == 0
+
+    res = await client.get(f"{PATIENTS}/00000000-0000-0000-0000-000000000000", headers=_auth(token))
+    assert res.status_code == 404
+
+
+# --- trigger catalog -----------------------------------------------------
+
+
+def test_every_supported_trigger_has_a_frozen_sample():
+    assert set(SAMPLE_PAYLOADS) == set(SUPPORTED_EVENT_TYPES)
+    for event_type, sample in SAMPLE_PAYLOADS.items():
+        assert "clinic_id" in sample, event_type
+        assert "occurred_at" in sample, event_type
+
+
+@pytest.mark.asyncio
+async def test_triggers_endpoint_serves_catalog(client: AsyncClient, auth_headers, test_clinic):
+    res = await client.get("/api/v1/integrations/webhooks/triggers", headers=auth_headers)
+    assert res.status_code == 200, res.text
+    rows = res.json()["data"]
+    assert {r["event_type"] for r in rows} == set(SUPPORTED_EVENT_TYPES)
+    assert all(r["sample_payload"].get("clinic_id") for r in rows)
+
+
+# --- stable event id -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_event_id_shared_across_subscribers(db_session: AsyncSession, test_clinic):
+    for n in (1, 2):
+        db_session.add(
+            WebhookSubscription(
+                clinic_id=test_clinic.id,
+                target_url=f"https://example.com/hook{n}",
+                event_types=["patient.created"],
+                secret_encrypted=encrypt_password("whsec"),
+            )
+        )
+    await db_session.commit()
+
+    await IntegrationsHandlers.on_patient_created(
+        {"clinic_id": str(test_clinic.id), "patient_id": "p1"}, db=db_session
+    )
+    await db_session.commit()
+
+    rows = (await db_session.execute(select(WebhookDelivery))).scalars().all()
+    assert len(rows) == 2
+    assert rows[0].event_id is not None
+    assert rows[0].event_id == rows[1].event_id
+    assert rows[0].id != rows[1].id

--- a/backend/tests/modules/integrations/test_uninstall_roundtrip.py
+++ b/backend/tests/modules/integrations/test_uninstall_roundtrip.py
@@ -2,9 +2,10 @@
 
 Mirrors patient_relationships/recalls/schedules/whatsapp_kapso: install
 -> uninstall -> reinstall must drop ONLY the integrations tables and
-leave every other module untouched. The module now owns two revisions
-(int_0001, int_0002 — added api_tokens), so the branch-scoped downgrade
-target is ``integrations@-2`` — the same form ``_downgrade_target_for``
+leave every other module untouched. The module now owns three revisions
+(int_0001, int_0002 — api_tokens, int_0003 — event_id), so the
+branch-scoped downgrade target is ``integrations@-3`` — the same form
+``_downgrade_target_for``
 resolves for the real uninstall path (``_count_owned_revisions``
 tracks this dynamically; this test's target is hardcoded and must be
 bumped whenever a revision is added to this branch). Marked
@@ -62,7 +63,7 @@ def test_integrations_uninstall_roundtrip_is_branch_scoped() -> None:
     )
     baseline_other = before - INTEGRATIONS_TABLES
 
-    _alembic("downgrade", "integrations@-2")
+    _alembic("downgrade", "integrations@-3")
     after_down = _list_tables()
     assert INTEGRATIONS_TABLES.isdisjoint(after_down), (
         f"integrations tables survived downgrade: {INTEGRATIONS_TABLES & after_down}"

--- a/docs/events-catalog.md
+++ b/docs/events-catalog.md
@@ -12,16 +12,16 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 |-------|----------|------------|-------------|
 | `agenda.visit_note_updated` | `EventType.AGENDA_VISIT_NOTE_UPDATED` | `agenda` | `patient_timeline` |
 | `appointment.cabinet_changed` | `EventType.APPOINTMENT_CABINET_CHANGED` | `agenda` | — |
-| `appointment.cancelled` | `EventType.APPOINTMENT_CANCELLED` | `agenda` | `activity_journal`, `copilot`, `notifications`, `patient_timeline`, `recalls`, `schedules` |
+| `appointment.cancelled` | `EventType.APPOINTMENT_CANCELLED` | `agenda` | `activity_journal`, `copilot`, `integrations`, `notifications`, `patient_timeline`, `recalls`, `schedules` |
 | `appointment.checked_in` | `EventType.APPOINTMENT_CHECKED_IN` | `agenda` | `activity_journal`, `patient_timeline` |
 | `appointment.completed` | `EventType.APPOINTMENT_COMPLETED` | `agenda` | `activity_journal`, `integrations`, `patient_timeline`, `recalls`, `treatment_plan` |
 | `appointment.confirmed` | `EventType.APPOINTMENT_CONFIRMED` | `agenda` | `activity_journal`, `patient_timeline` |
 | `appointment.in_treatment` | `EventType.APPOINTMENT_IN_TREATMENT` | `agenda` | `activity_journal`, `patient_timeline` |
 | `appointment.no_show` | `EventType.APPOINTMENT_NO_SHOW` | `agenda` | `activity_journal`, `patient_timeline` |
-| `appointment.scheduled` | `EventType.APPOINTMENT_SCHEDULED` | `agenda` | `activity_journal`, `notifications`, `patient_timeline`, `recalls`, `schedules` |
+| `appointment.scheduled` | `EventType.APPOINTMENT_SCHEDULED` | `agenda` | `activity_journal`, `integrations`, `notifications`, `patient_timeline`, `recalls`, `schedules` |
 | `appointment.status_changed` | `EventType.APPOINTMENT_STATUS_CHANGED` | `agenda` | — |
 | `appointment.updated` | `EventType.APPOINTMENT_UPDATED` | `agenda` | `schedules` |
-| `budget.accepted` | `EventType.BUDGET_ACCEPTED` | `budget` | `activity_journal`, `notifications`, `patient_timeline`, `treatment_plan` |
+| `budget.accepted` | `EventType.BUDGET_ACCEPTED` | `budget` | `activity_journal`, `integrations`, `notifications`, `patient_timeline`, `treatment_plan` |
 | `budget.cancelled` | `EventType.BUDGET_CANCELLED` | `budget` | `activity_journal`, `treatment_plan` |
 | `budget.created` | `EventType.BUDGET_CREATED` | — | — |
 | `budget.expired` | `EventType.BUDGET_EXPIRED` | `budget` | `patient_timeline` |
@@ -55,7 +55,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 | `invoice.issued` | `EventType.INVOICE_ISSUED` | `billing` | `patient_timeline` |
 | `invoice.paid` | `EventType.INVOICE_PAID` | `billing` | `patient_timeline`, `verifactu` |
 | `invoice.partial_paid` | `EventType.INVOICE_PARTIAL_PAID` | — | — |
-| `invoice.sent` | `EventType.INVOICE_SENT` | `billing` | `activity_journal`, `notifications` |
+| `invoice.sent` | `EventType.INVOICE_SENT` | `billing` | `activity_journal`, `integrations`, `notifications` |
 | `invoice.voided` | `EventType.INVOICE_VOIDED` | — | — |
 | `lab_order.status_changed` | `EventType.LAB_ORDER_STATUS_CHANGED` | `lab_orders` | `activity_journal` |
 | `media.attachment_linked` | `EventType.ATTACHMENT_LINKED` | `media` | — |
@@ -137,6 +137,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
 - **Subscribers:**
   - `activity_journal`
   - `copilot`
+  - `integrations`
   - `notifications`
   - `patient_timeline`
   - `recalls`
@@ -197,6 +198,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
   - `agenda` — `backend/app/modules/agenda/service.py:483`
 - **Subscribers:**
   - `activity_journal`
+  - `integrations`
   - `notifications`
   - `patient_timeline`
   - `recalls`
@@ -224,6 +226,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
   - `budget` — `backend/app/modules/budget/workflow.py:324`
 - **Subscribers:**
   - `activity_journal`
+  - `integrations`
   - `notifications`
   - `patient_timeline`
   - `treatment_plan`
@@ -488,6 +491,7 @@ Maintained by `backend/scripts/generate_catalogs.py`.
   - `billing` — `backend/app/modules/billing/router.py:712`
 - **Subscribers:**
   - `activity_journal`
+  - `integrations`
   - `notifications`
 
 ### `invoice.voided`

--- a/docs/modules-catalog.md
+++ b/docs/modules-catalog.md
@@ -21,7 +21,7 @@ Maintained by `backend/scripts/generate_catalogs.py`. CI fails if a manifest cha
 | `copilot` | 0.1.0 | official | — | auto | yes | 5 | 3 | 1 | yes |
 | `expenses` | 0.1.0 | community | — | manual | yes | 2 | 0 | 0 | yes |
 | `india_gst` | 0.1.0 | official | billing, catalog | manual | yes | 4 | 0 | 0 | yes |
-| `integrations` | 0.1.0 | official | patients | manual | yes | 4 | 0 | 2 | no |
+| `integrations` | 0.1.0 | official | patients | manual | yes | 4 | 0 | 6 | no |
 | `inventory` | 0.2.0 | community | — | manual | yes | 2 | 1 | 0 | yes |
 | `lab_orders` | 0.1.0 | community | patients, contacts | manual | yes | 2 | 1 | 0 | yes |
 | `media` | 0.2.0 | official | patients | auto | no | 4 | 7 | 1 | yes |
@@ -329,7 +329,11 @@ Webhook subscriptions (REST Hooks) for third-party automations.
   - `integrations.tokens.write`
 - **Events emitted:** —
 - **Events consumed:**
+  - `appointment.cancelled`
   - `appointment.completed`
+  - `appointment.scheduled`
+  - `budget.accepted`
+  - `invoice.sent`
   - `patient.created`
 - **Module CLAUDE.md:** [`backend/app/modules/integrations/CLAUDE.md`](../backend/app/modules/integrations/CLAUDE.md)
 

--- a/docs/technical/integrations/events.md
+++ b/docs/technical/integrations/events.md
@@ -18,6 +18,10 @@ _This module does not publish any events._
 |-------|---------|--------|
 | `patient.created` | `integrations.handlers.IntegrationsHandlers.on_patient_created` | Transactional — queues one `WebhookDelivery` row per active subscription listing this event, on the publisher's own session. No network I/O; the scheduled `dispatch_outbox` tick sends it. |
 | `appointment.completed` | `integrations.handlers.IntegrationsHandlers.on_appointment_completed` | Same shape as `on_patient_created` — queues one `WebhookDelivery` row per active subscription listing this event. |
+| `appointment.scheduled` | `integrations.handlers.IntegrationsHandlers.on_appointment_scheduled` | Same shape — queues deliveries for subscribers. |
+| `appointment.cancelled` | `integrations.handlers.IntegrationsHandlers.on_appointment_cancelled` | Same shape — queues deliveries for subscribers. |
+| `budget.accepted` | `integrations.handlers.IntegrationsHandlers.on_budget_accepted` | Same shape — queues deliveries for subscribers. |
+| `invoice.sent` | `integrations.handlers.IntegrationsHandlers.on_invoice_sent` | Same shape — queues deliveries for subscribers. |
 
 ## Adding a new event
 

--- a/docs/technical/integrations/permissions.md
+++ b/docs/technical/integrations/permissions.md
@@ -30,3 +30,17 @@ See `backend/app/core/auth/permissions.py` for the canonical role table.
 3. Add a row to the table above.
 4. Annotate the endpoint(s) with `Depends(require_permission(...))`.
 5. Update `frontend/app/config/permissions.ts` if it gates UI.
+
+## Trigger catalog
+
+`GET /api/v1/integrations/webhooks/triggers` is gated by
+`integrations.subscriptions.read` and serves the supported event types
+with their frozen sample payloads.
+
+## Public API (token-authenticated, no RBAC permission)
+
+`/api/v1/integrations/public/*` authenticates with `dp_` bearer tokens
+(`Authorization: Bearer dp_…`), not JWT — RBAC permissions do not apply.
+Authorization is the token's `scopes` list (`patients:read` gates the
+patient search/read endpoints; `/public/ping` needs a valid token only).
+Rate-limited per client (120/minute).


### PR DESCRIPTION
Drains the three follow-ups the integrations module's own docs flagged after Phase 1 (#65 §1/§2/§3/§5).

## 1. Public read API — the tokens finally have a consumer

`/api/v1/integrations/public/` (new `public_router.py`), authenticating with the `dp_` bearer tokens Phase 1 already issues — SHA-256 hash lookup, revoked check, `last_used_at` stamped, and the token's **scopes** authorize (`patients:read`); JWT/RBAC don't apply on this surface.

- `GET /public/ping` — token introspection (clinic, scopes). This is what a Zapier app calls as its auth test.
- `GET /public/patients` — the **find / search-or-create** primitive (§5): format-tolerant exact match on `phone` / `email` / `national_id`, substring `q` on the name, paginated, clinic-scoped by the token.
- `GET /public/patients/{id}` — curated `PublicPatientResponse`, deliberately narrower than the internal shape (adding fields is fine, renaming is breaking).
- Rate-limited 120/minute. Lives under the module prefix because a module owns one mount point — documented as the stable public path.

## 2. Stable `event_id` (§1 idempotency)

Generated **once per event** in `handlers._enqueue` and shared by every subscriber's delivery row (`int_0003` adds the column; nullable, legacy rows fall back to the per-delivery id). Delivered as a top-level payload field next to `delivery_id` — receivers wired to multiple subscriptions can finally dedupe.

## 3. Trigger catalog: 2 → 6, each with a frozen sample

`appointment.scheduled`, `appointment.cancelled`, `budget.accepted`, `invoice.sent` join the original two. All four publishers pass `db=`, so the transactional handler contract holds (the bus hard-raises otherwise — which is exactly why `patient.updated` / `payment.recorded` are *not* included; they need their publishers migrated to `db=` first, happy to do that as a follow-up).

Frozen sample payloads (`triggers.SAMPLE_PAYLOADS`) mirror the real publisher shapes, are served by `GET /webhooks/triggers` (admin, for the Zapier visual mapper / a future subscription-UI picker), and a test pins `SUPPORTED_EVENT_TYPES == SAMPLE_PAYLOADS.keys()` so the catalog can't drift.

## Notes

- Uninstall roundtrip test target bumped `integrations@-2` → `@-3` per its own docstring contract; roundtrip green locally.
- Integrations suite 71/71 green locally; ruff clean; module docs/CLAUDE.md/CHANGELOG updated; events-catalog regenerated.
- Next slices on #65 after this: write actions with idempotency keys, then the thin Zapier app.

Refs #65.