### PR TITLE
docs: describe actual discover behaviour + future static-manifest direction (#323)

### DIFF
--- a/docs/technical/module-system-architecture.md
+++ b/docs/technical/module-system-architecture.md
@@ -408,7 +408,7 @@ Al reiniciar:
 
 En el `lifespan` de FastAPI, antes de aceptar tráfico:
 
-1. **Discover**: cargar todos los manifests (sin ejecutar código del módulo). Validar schema, `min_core_version`, que todas las `depends` existan como manifests descubiertos.
+1. **Discover**: cargar todos los manifests. Validar schema, `min_core_version`, que todas las `depends` existan como manifests descubiertos. *Nota (#323): hoy el manifest es un atributo de la clase `BaseModule`, así que discover **importa e instancia** cada módulo (instalado o no) para leerlo; los modelos de todos los módulos entran en `Base.metadata` en el arranque. El contrato estático original ("sin ejecutar código del módulo") es la dirección futura acordada — manifest fuera del código como única fuente de verdad e import diferido al mount — pendiente de un trigger real (primer módulo third-party vía PyPI).*
 2. **Reconciliar con DB**:
    - Módulo en disk y no en DB → insert como `uninstalled`.
    - Módulo en DB como `installed` pero no en disk → **error crítico, no arrancar**. Log explícito. Admin debe restaurar el paquete o marcar manualmente `uninstalled` con `python -m app.cli modules orphan <name>`.


### PR DESCRIPTION
The §5.2 discover step in `module-system-architecture.md` promised "cargar todos los manifests (sin ejecutar código del módulo)" — the implementation imports and instantiates every module to read its class-level manifest, so all modules' models land in `Base.metadata` at boot. Fix the paragraph to describe reality, with a note that the static-manifest contract (issue #323 proposal 2, variant b) is the agreed future direction, deferred until a real trigger.

Docs-only, per the decision posted on #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5CUr91iPR5gmSsiF64Jqc