### PR TITLE
feat(integrations): /public/ping, last_used_at stamping, structured patient find (#65)

### DIFF
--- a/backend/app/modules/integrations/CHANGELOG.md
+++ b/backend/app/modules/integrations/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Phase 2 follow-up (ported from PR #348)
+
+- `GET /public/ping` — token introspection (clinic, name, scopes); the
+  auth test a Zapier/Make app calls. Valid token required, no scope.
+- Authenticated public requests now stamp `ApiToken.last_used_at`
+  (the column existed since `int_0002` but was never written).
+- `GET /public/patients` grows format-tolerant exact-match params
+  `phone` / `email` / `national_id` (whitespace/dash/case ignored) —
+  the find leg of the search-or-create pattern (issue #65 §5).
+  The generic `search` filter is unchanged.
+
 ### Phase 2 (issue #65)
 
 - **Six new webhook triggers** (appointment.scheduled, appointment.cancelled,

--- a/backend/app/modules/integrations/CLAUDE.md
+++ b/backend/app/modules/integrations/CLAUDE.md
@@ -19,7 +19,11 @@ delivers a JSON payload to that URL whenever a subscribed event fires.
 Token-authenticated public data-read API under `/api/v1/integrations/
 public/` — no JWT, authenticated by `Authorization: Bearer dp_...`,
 rate-limited per token (60/min + 1000/day, `X-RateLimit-*` headers),
-clinic-scoped off the token's `clinic_id`.
+clinic-scoped off the token's `clinic_id`. `GET /public/ping` is the
+token-introspection auth test (no scope); every authenticated request
+stamps the token's `last_used_at`; `GET /public/patients` accepts
+format-tolerant exact-match `phone`/`email`/`national_id` params (the
+search-or-create find primitive, issue #65 §5; ported from PR #348).
 
 Every payload carries `occurred_at`. Since Phase 2, each delivery also
 carries a stable `event_id` (same id across every subscription that

--- a/backend/app/modules/integrations/public.py
+++ b/backend/app/modules/integrations/public.py
@@ -20,19 +20,21 @@ Design notes:
 from __future__ import annotations
 
 import time
+from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
-from sqlalchemy import select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.schemas import ApiResponse, PaginatedApiResponse
 from app.database import get_db
 
+from ..patients.models import Patient
 from ..patients.service import PatientService
 from .models import ApiToken
-from .schemas import PublicPatientResponse
+from .schemas import PublicPatientResponse, PublicTokenInfo
 from .service import _TOKEN_PREFIX, _hash_token
 
 public_router = APIRouter()
@@ -134,6 +136,9 @@ async def get_api_token_context(
         )
 
     rate_headers = _rate_limit(token.id)
+    # Usage tracking for the admin token list — committed with the
+    # request's session on success.
+    token.last_used_at = datetime.now(UTC)
     return PublicTokenContext(token=token, rate_headers=rate_headers)
 
 
@@ -152,6 +157,21 @@ def require_scope(scope: str):
     return _scope_checker
 
 
+@public_router.get("/ping", response_model=ApiResponse[PublicTokenInfo])
+async def ping(
+    response: Response,
+    ctx: Annotated[PublicTokenContext, Depends(get_api_token_context)],
+) -> ApiResponse[PublicTokenInfo]:
+    """Token introspection — what a Zapier/Make app calls as its auth
+    test. Any valid (unrevoked) token may ping; no scope required."""
+    response.headers.update(ctx.rate_headers)
+    return ApiResponse(
+        data=PublicTokenInfo(
+            clinic_id=ctx.clinic_id, token_name=ctx.token.name, scopes=list(ctx.scopes)
+        )
+    )
+
+
 @public_router.get("/patients", response_model=PaginatedApiResponse[PublicPatientResponse])
 async def list_public_patients(
     response: Response,
@@ -159,12 +179,34 @@ async def list_public_patients(
     _: Annotated[None, Depends(require_scope("patients:read"))],
     db: Annotated[AsyncSession, Depends(get_db)],
     search: str | None = None,
+    phone: str | None = Query(default=None, max_length=32),
+    email: str | None = Query(default=None, max_length=255),
+    national_id: str | None = Query(default=None, max_length=50),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
 ) -> PaginatedApiResponse[PublicPatientResponse]:
-    patients, total = await PatientService.list_patients(
-        db, ctx.clinic_id, search=search, page=page, page_size=page_size
-    )
+    """List/find patients for the token's clinic.
+
+    ``phone`` / ``email`` / ``national_id`` are format-tolerant exact
+    matches (whitespace/dashes and case ignored) — the find leg of
+    Zapier's search-or-create pattern (issue #65 §5). ``search`` stays
+    the generic name/phone substring filter.
+    """
+    if phone or email or national_id:
+        patients, total = await _find_patients(
+            db,
+            ctx.clinic_id,
+            phone=phone,
+            email=email,
+            national_id=national_id,
+            search=search,
+            page=page,
+            page_size=page_size,
+        )
+    else:
+        patients, total = await PatientService.list_patients(
+            db, ctx.clinic_id, search=search, page=page, page_size=page_size
+        )
     response.headers.update(ctx.rate_headers)
     return PaginatedApiResponse(
         data=[PublicPatientResponse.model_validate(p) for p in patients],
@@ -172,6 +214,44 @@ async def list_public_patients(
         page=page,
         page_size=page_size,
     )
+
+
+async def _find_patients(
+    db: AsyncSession,
+    clinic_id: UUID,
+    *,
+    phone: str | None,
+    email: str | None,
+    national_id: str | None,
+    search: str | None,
+    page: int,
+    page_size: int,
+) -> tuple[list[Patient], int]:
+    """Format-tolerant exact-match lookup (the structured find primitive)."""
+    stmt = select(Patient).where(Patient.clinic_id == clinic_id)
+    if phone:
+        normalized = phone.replace(" ", "").replace("-", "")
+        stmt = stmt.where(func.replace(func.replace(Patient.phone, " ", ""), "-", "") == normalized)
+    if email:
+        stmt = stmt.where(func.lower(Patient.email) == email.strip().lower())
+    if national_id:
+        stmt = stmt.where(func.upper(Patient.national_id) == national_id.strip().upper())
+    if search:
+        like = f"%{search.strip()}%"
+        stmt = stmt.where(or_(Patient.first_name.ilike(like), Patient.last_name.ilike(like)))
+    total = (await db.execute(select(func.count()).select_from(stmt.subquery()))).scalar_one()
+    rows = (
+        (
+            await db.execute(
+                stmt.order_by(Patient.created_at.desc())
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return list(rows), total
 
 
 @public_router.get("/patients/{patient_id}", response_model=ApiResponse[PublicPatientResponse])

--- a/backend/app/modules/integrations/schemas.py
+++ b/backend/app/modules/integrations/schemas.py
@@ -109,6 +109,15 @@ class ApiTokenCreated(ApiTokenResponse):
     token: str = Field(description="Shown once. Store it now; it cannot be retrieved again.")
 
 
+class PublicTokenInfo(BaseModel):
+    """``GET /public/ping`` — token introspection for a consumer's auth
+    test (Zapier/Make call this to validate the pasted token)."""
+
+    clinic_id: UUID
+    token_name: str
+    scopes: list[str]
+
+
 class PublicPatientResponse(BaseModel):
     """Patient record exposed through the token-authenticated public API.
 

--- a/backend/tests/modules/integrations/test_public_api.py
+++ b/backend/tests/modules/integrations/test_public_api.py
@@ -221,3 +221,90 @@ async def test_cross_clinic_isolation(
     assert resp.status_code == 200
     names = [p["first_name"] for p in resp.json()["data"]]
     assert "Clinic A patient" not in names
+
+
+# --------------------------------------------------------------- #65 deltas
+# /ping introspection, last_used_at stamping, structured find params
+# (ported from PR #348).
+
+
+@pytest.mark.asyncio
+async def test_ping_introspects_token(client: AsyncClient, auth_headers: dict, test_clinic):
+    token = await _create_token(client, auth_headers, ["patients:read"])
+
+    resp = await client.get(
+        f"{PUBLIC_BASE}/ping", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()["data"]
+    assert body["clinic_id"] == str(test_clinic.id)
+    assert body["token_name"] == "test-public"
+    assert body["scopes"] == ["patients:read"]
+    assert "X-RateLimit-Remaining-Minute" in resp.headers
+
+    resp = await client.get(f"{PUBLIC_BASE}/ping")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_public_call_stamps_last_used_at(
+    client: AsyncClient, auth_headers: dict, test_clinic
+):
+    token = await _create_token(client, auth_headers, ["patients:read"])
+
+    listed = (await client.get(TOKENS_BASE, headers=auth_headers)).json()["data"]
+    assert listed[0]["last_used_at"] is None
+
+    resp = await client.get(
+        f"{PUBLIC_BASE}/ping", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 200
+
+    listed = (await client.get(TOKENS_BASE, headers=auth_headers)).json()["data"]
+    assert listed[0]["last_used_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_structured_find_is_format_tolerant(
+    client: AsyncClient, auth_headers: dict, test_clinic
+):
+    token = await _create_token(client, auth_headers, ["patients:read"])
+    resp = await client.post(
+        "/api/v1/patients",
+        json={
+            "first_name": "Marta",
+            "last_name": "Buscable",
+            "phone": "+34 600-99-88-77",
+            "email": "Marta.Buscable@Example.com",
+            "national_id": "12345678z",
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    await _create_patient(client, auth_headers, first_name="Otro", last_name="Paciente")
+
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = await client.get(
+        f"{PUBLIC_BASE}/patients", params={"phone": "+34600998877"}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["total"] == 1
+    assert resp.json()["data"][0]["first_name"] == "Marta"
+
+    resp = await client.get(
+        f"{PUBLIC_BASE}/patients",
+        params={"email": "  marta.buscable@example.COM "},
+        headers=headers,
+    )
+    assert resp.json()["total"] == 1
+
+    resp = await client.get(
+        f"{PUBLIC_BASE}/patients", params={"national_id": "12345678Z"}, headers=headers
+    )
+    assert resp.json()["total"] == 1
+
+    resp = await client.get(
+        f"{PUBLIC_BASE}/patients", params={"phone": "+34999999999"}, headers=headers
+    )
+    assert resp.json()["total"] == 0

--- a/docs/technical/integrations/permissions.md
+++ b/docs/technical/integrations/permissions.md
@@ -28,7 +28,11 @@ creation time. Enforced per-endpoint by the `require_scope()` dependency in
 
 | Scope | Allows | Required by |
 |-------|--------|-------------|
-| `patients:read` | Read patients for the token's clinic | `GET /api/v1/integrations/public/patients`, `GET /api/v1/integrations/public/patients/{id}` |
+| `patients:read` | Read patients for the token's clinic (incl. the structured `phone`/`email`/`national_id` find params) | `GET /api/v1/integrations/public/patients`, `GET /api/v1/integrations/public/patients/{id}` |
+
+`GET /api/v1/integrations/public/ping` (token introspection — the auth
+test a Zapier/Make app runs) requires a valid token but no scope.
+Every authenticated public request stamps the token's `last_used_at`.
 
 ## Role assignment
 


### PR DESCRIPTION
Ports the three pieces of #348 (ZoliQua) that #345's Phase 2 didn't cover — credited as co-author on the commit.

## What

1. **`GET /public/ping`** — token introspection (`clinic_id`, `token_name`, `scopes`). This is the auth test a Zapier/Make app runs against a pasted `dp_` token. Any valid unrevoked token; no scope required; rate-limit headers included.
2. **`last_used_at` stamping** — every authenticated public request now writes `ApiToken.last_used_at`. The column has existed since `int_0002` but nothing wrote it, so the admin token list always showed null.
3. **Structured patient find** — `GET /public/patients` accepts format-tolerant exact-match `phone` / `email` / `national_id` params (whitespace/dashes/case ignored): the find leg of the search-or-create pattern (issue #65 §5). The generic `search` substring filter is unchanged; structured params take precedence.

## Notes

- No migration, no new deps, no new events — `public.py` + `schemas.py` + tests + docs (module CLAUDE.md/CHANGELOG, permissions.md).
- Direct `Patient` model query for the find primitive (patients is in `manifest.depends`; the tolerant matching is integrations-specific, so it doesn't belong on `PatientService`).
- Integrations suite 92/92 green locally; ruff clean.

Refs #65. Closes the loose end from #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5CUr91iPR5gmSsiF64Jqc