### PR TITLE
style(integrations): reformat public-api test for unpinned ruff 0.16.5 (backend-lint)

### DIFF
--- a/backend/app/modules/integrations/CHANGELOG.md
+++ b/backend/app/modules/integrations/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### CI hygiene (ruff 0.16.5 drift)
+
+- Reformatted the two multi-line `client.get(...)` calls in
+  `tests/modules/integrations/test_public_api.py` that the newest (unpinned)
+  ruff `format --check` flags — keeps `backend-lint` green for any PR built on
+  the current tree.
+
 ### Phase 2 follow-up (ported from PR #348)
 
 - `GET /public/ping` — token introspection (clinic, name, scopes); the

--- a/backend/tests/modules/integrations/test_public_api.py
+++ b/backend/tests/modules/integrations/test_public_api.py
@@ -232,9 +232,7 @@ async def test_cross_clinic_isolation(
 async def test_ping_introspects_token(client: AsyncClient, auth_headers: dict, test_clinic):
     token = await _create_token(client, auth_headers, ["patients:read"])
 
-    resp = await client.get(
-        f"{PUBLIC_BASE}/ping", headers={"Authorization": f"Bearer {token}"}
-    )
+    resp = await client.get(f"{PUBLIC_BASE}/ping", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200, resp.text
     body = resp.json()["data"]
     assert body["clinic_id"] == str(test_clinic.id)
@@ -255,9 +253,7 @@ async def test_public_call_stamps_last_used_at(
     listed = (await client.get(TOKENS_BASE, headers=auth_headers)).json()["data"]
     assert listed[0]["last_used_at"] is None
 
-    resp = await client.get(
-        f"{PUBLIC_BASE}/ping", headers={"Authorization": f"Bearer {token}"}
-    )
+    resp = await client.get(f"{PUBLIC_BASE}/ping", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200
 
     listed = (await client.get(TOKENS_BASE, headers=auth_headers)).json()["data"]


### PR DESCRIPTION
## Overview
- Fixes the ackend-lint CI failure that now hits ANY new PR built on the current tree.
- CI's \pip install ruff\ is unpinned and now pulls **ruff 0.16.5**, whose formatter wants to collapse two multi-line \client.get(...)\ calls in the public-data API test (added by PR \#358\).

## Tasks done
- \style:\ reformatted the two multi-line calls in \ackend/tests/modules/integrations/test_public_api.py\ per ruff 0.16.5 (verified: whole \ackend/\ now passes \uff format --check\ + \uff check\ with 0.16.5 — 881 files clean).
- \docs:\ integrations CHANGELOG \## Unreleased\ entry.

## Modules touched
- \integrations\ (test + CHANGELOG only; no behaviour change).

## Checklist
- [x] \uff format --check backend/\ + \uff check backend/\ green with ruff 0.16.5
- [x] CHANGELOG updated
- No catalog/module/permission/event change → catalogs unaffected

## Test plan
- \uff format --check backend/ && ruff check backend/\ with ruff installed fresh (>=0.16.5).
- Unblocks \ackend-lint\ on every open/future PR based on \main\.

## Closes
- Refs #358 (regression source is its new test file).