### PR TITLE
fix: realistic occlusal view + crown profile without root

### DIFF
--- a/backend/app/modules/odontogram/CHANGELOG.md
+++ b/backend/app/modules/odontogram/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - feat(i18n): the frontend layer's directional spacing, borders, text alignment and inset positioning now resolve against the document direction (physical→logical CSS utilities, Arabic RTL support).
 
+- feat(#48): realistic per-category occlusal outlines (incisor / canine / premolar / molar) with cusp-aware silhouettes; surface fills clipped to the outline; distal (D) sector is a full quad; molar fissures shortened to the central O so they no longer read as a missing-tooth overlay.
 
 - fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.
 

--- a/backend/app/modules/odontogram/frontend/components/odontogram/SurfaceSelectorPopup.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/SurfaceSelectorPopup.vue
@@ -68,16 +68,25 @@ const occlusalGroupTransform = computed(() => {
 
 // Get correct X position for M label based on quadrant
 // M (mesial) is always toward midline: left side of view for right teeth, right side for left teeth
-const mLabelX = computed(() => isLeftSide.value ? 43 : 4)
-// Get correct X position for D label based on quadrant
-const dLabelX = computed(() => isLeftSide.value ? 4 : 43)
-
-// Get correct Y position for V label based on arch
-// V (vestibular) faces outward: top for upper teeth, bottom for lower teeth
-const vLabelY = computed(() => isLower.value ? 47 : 8)
-// Get correct Y position for L label based on arch
-// L (lingual) faces inward: bottom for upper teeth, top for lower teeth
-const lLabelY = computed(() => isLower.value ? 8 : 47)
+// M/D/V/L/O labels sit at their surface centers, which stay inside the anatomical
+// outline. The labels render outside the mirror group, so apply the same quadrant
+// mirror the group transform applies.
+const labelAnchors = computed(() => {
+  const centers = occlusalPaths.value.surfaceCenters
+  const mirror = (point: { x: number, y: number }) => ({
+    x: isLeftSide.value ? 50 - point.x : point.x,
+    y: isLower.value ? 50 - point.y : point.y
+  })
+  const anchor = (surface: string, fallback: { x: number, y: number }) =>
+    mirror(centers[surface] ?? fallback)
+  return {
+    M: anchor('M', { x: 12, y: 25 }),
+    D: anchor('D', { x: 38, y: 25 }),
+    V: anchor('V', { x: 25, y: 12 }),
+    L: anchor('L', { x: 25, y: 38 }),
+    O: anchor('O', { x: 25, y: 25 })
+  }
+})
 const toothName = computed(() => {
   const nameKey = getToothNameKey(props.toothNumber)
   const positionKeys = getToothPositionKeys(props.toothNumber)
@@ -294,32 +303,32 @@ watch(() => props.open, (isOpen) => {
 
               <!-- Surface labels (outside transform to remain readable) -->
               <text
-                :x="mLabelX"
-                y="27"
+                :x="labelAnchors.M.x"
+                :y="labelAnchors.M.y"
                 class="surface-label"
                 @click="toggleSurface('M')"
               >M</text>
               <text
-                :x="dLabelX"
-                y="27"
+                :x="labelAnchors.D.x"
+                :y="labelAnchors.D.y"
                 class="surface-label"
                 @click="toggleSurface('D')"
               >D</text>
               <text
-                x="24"
-                :y="vLabelY"
+                :x="labelAnchors.V.x"
+                :y="labelAnchors.V.y"
                 class="surface-label"
                 @click="toggleSurface('V')"
               >V</text>
               <text
-                x="24"
-                :y="lLabelY"
+                :x="labelAnchors.L.x"
+                :y="labelAnchors.L.y"
                 class="surface-label"
                 @click="toggleSurface('L')"
               >L</text>
               <text
-                x="24"
-                y="28"
+                :x="labelAnchors.O.x"
+                :y="labelAnchors.O.y"
                 class="surface-label-center"
                 @click="toggleSurface('O')"
               >O</text>

--- a/backend/app/modules/odontogram/frontend/components/odontogram/SurfaceSelectorPopup.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/SurfaceSelectorPopup.vue
@@ -217,6 +217,9 @@ watch(() => props.open, (isOpen) => {
             >
               <!-- Pattern definition -->
               <defs>
+                <clipPath :id="`occlusal-surface-clip-${toothNumber}`">
+                  <path :d="occlusalPaths.outline" />
+                </clipPath>
                 <pattern
                   id="surface-pattern"
                   patternUnits="userSpaceOnUse"
@@ -237,41 +240,55 @@ watch(() => props.open, (isOpen) => {
 
               <!-- Tooth paths group with transform for quadrant symmetry -->
               <g :transform="occlusalGroupTransform">
-                <!-- Outline -->
+                <!-- Outline (fill under, stroke redrawn after surfaces) -->
                 <path
                   :d="occlusalPaths.outline"
                   fill="var(--odontogram-fill-shade)"
+                  stroke="none"
+                />
+
+                <!-- Surfaces (clickable), clipped so silhouette stays anatomical -->
+                <g :clip-path="`url(#occlusal-surface-clip-${toothNumber})`">
+                  <path
+                    v-for="(path, surface) in occlusalPaths.surfaces"
+                    :key="surface"
+                    :d="path"
+                    :fill="getSurfaceFill(surface as Surface)"
+                    :opacity="getSurfaceOpacity(surface as Surface)"
+                    :stroke="isSurfaceSelected(surface as Surface) ? treatmentColor : 'var(--odontogram-outline-light)'"
+                    :stroke-width="isSurfaceSelected(surface as Surface) ? 2 : 0.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    class="surface-path"
+                    @click="toggleSurface(surface as Surface)"
+                  />
+                </g>
+
+                <!-- Highlight details (fissures) — drawn after fills so they remain visible -->
+                <g
+                  :clip-path="`url(#occlusal-surface-clip-${toothNumber})`"
+                  pointer-events="none"
+                >
+                  <path
+                    v-for="(highlightPath, idx) in occlusalPaths.highlight"
+                    :key="`occlusal-highlight-${idx}`"
+                    :d="highlightPath"
+                    fill="none"
+                    stroke="var(--odontogram-detail)"
+                    stroke-width="0.75"
+                    stroke-linecap="round"
+                  />
+                </g>
+
+                <!-- Crisp outline on top so the anatomical edge is never covered -->
+                <path
+                  :d="occlusalPaths.outline"
+                  fill="none"
                   stroke="var(--odontogram-outline)"
                   stroke-width="1.25"
                   stroke-linecap="round"
                   stroke-linejoin="round"
-                />
-
-                <!-- Highlight details (fissures) -->
-                <path
-                  v-for="(highlightPath, idx) in occlusalPaths.highlight"
-                  :key="`occlusal-highlight-${idx}`"
-                  :d="highlightPath"
-                  fill="none"
-                  stroke="var(--odontogram-detail)"
-                  stroke-width="0.75"
-                  stroke-linecap="round"
                   pointer-events="none"
-                />
-
-                <!-- Surfaces (clickable) -->
-                <path
-                  v-for="(path, surface) in occlusalPaths.surfaces"
-                  :key="surface"
-                  :d="path"
-                  :fill="getSurfaceFill(surface as Surface)"
-                  :opacity="getSurfaceOpacity(surface as Surface)"
-                  :stroke="isSurfaceSelected(surface as Surface) ? treatmentColor : 'var(--odontogram-outline-light)'"
-                  :stroke-width="isSurfaceSelected(surface as Surface) ? 2 : 0.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  class="surface-path"
-                  @click="toggleSurface(surface as Surface)"
                 />
               </g>
 

--- a/backend/app/modules/odontogram/frontend/components/odontogram/ToothDualView.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/ToothDualView.vue
@@ -2,6 +2,7 @@
 import type { Surface, ToothTreatmentView, TreatmentStatus } from '~~/app/types'
 import {
   getOcclusalPath,
+  getOcclusalSurfaceCenter,
   getLateralPath,
   getToothTransform,
   getToothDisplayConfig,
@@ -845,8 +846,8 @@ const hasPlannedLateralTreatments = computed(() => {
                   <circle
                     v-for="surface in treatment.surfaces"
                     :key="`${treatment.id}-${surface}-dot`"
-                    :cx="surface === 'O' ? 25 : surface === 'M' ? 12 : surface === 'D' ? 38 : surface === 'V' ? 25 : 25"
-                    :cy="surface === 'O' ? 25 : surface === 'M' ? 25 : surface === 'D' ? 25 : surface === 'V' ? 12 : 38"
+                    :cx="getOcclusalSurfaceCenter(toothNumber, surface).x"
+                    :cy="getOcclusalSurfaceCenter(toothNumber, surface).y"
                     r="4"
                     :fill="getTreatmentColor(treatment.treatment_type)"
                     :fill-opacity="STATUS_STYLES[treatment.status]?.opacity ?? 1"

--- a/backend/app/modules/odontogram/frontend/components/odontogram/ToothDualView.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/ToothDualView.vue
@@ -230,6 +230,7 @@ function getPulpFillOpacity(): number {
 
 // Unique clip-path ID for this tooth
 const pulpClipId = computed(() => `pulp-clip-${props.toothNumber}`)
+const occlusalClipId = computed(() => `occlusal-clip-${props.toothNumber}`)
 
 // Parse viewBox to get dimensions for clip-path calculation
 const viewBoxDimensions = computed(() => {
@@ -771,6 +772,11 @@ const hasPlannedLateralTreatments = computed(() => {
       >
         <!-- SVG Patterns and Gradients Definition -->
         <defs v-html="PATTERN_DEFINITIONS" />
+        <defs>
+          <clipPath :id="occlusalClipId">
+            <path :d="occlusalPaths.outline" />
+          </clipPath>
+        </defs>
 
         <!-- Background - pointer-events none to let clicks pass through to surfaces -->
         <rect
@@ -793,22 +799,11 @@ const hasPlannedLateralTreatments = computed(() => {
           :opacity="toothOpacity"
         />
 
-        <!-- Highlight details (fissures, ridges) -->
-        <path
-          v-for="(highlightPath, idx) in occlusalPaths.highlight"
-          :key="`occlusal-highlight-${idx}`"
-          :d="highlightPath"
-          class="tooth-highlight"
-          stroke-width="0.6"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          fill="none"
-          pointer-events="none"
-          :opacity="toothOpacity"
-        />
-
-        <!-- Treatment overlays on occlusal view -->
-        <g class="treatment-overlays">
+        <!-- Treatment overlays on occlusal view (clipped to anatomical outline) -->
+        <g
+          class="treatment-overlays"
+          :clip-path="`url(#${occlusalClipId})`"
+        >
           <!-- Rule 2: Occlusal surface treatments (solid fill, dot, outline) -->
           <template
             v-for="treatment in occlusalSurfaceTreatments"
@@ -955,6 +950,36 @@ const hasPlannedLateralTreatments = computed(() => {
             </g>
           </template>
         </g>
+
+        <!-- Highlight details (fissures, ridges) — after fills so they stay visible; clipped to outline -->
+        <g
+          :clip-path="`url(#${occlusalClipId})`"
+          pointer-events="none"
+        >
+          <path
+            v-for="(highlightPath, idx) in occlusalPaths.highlight"
+            :key="`occlusal-highlight-${idx}`"
+            :d="highlightPath"
+            class="tooth-highlight"
+            stroke-width="0.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+            :opacity="toothOpacity"
+          />
+        </g>
+
+        <!-- Redraw outline stroke so the silhouette stays crisp over fills -->
+        <path
+          :d="occlusalPaths.outline"
+          class="tooth-occlusal"
+          fill="none"
+          stroke-width="1"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          pointer-events="none"
+          :opacity="toothOpacity"
+        />
 
         <!-- Missing tooth X overlay -->
         <g

--- a/backend/app/modules/odontogram/frontend/components/odontogram/ToothDualView.vue
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/ToothDualView.vue
@@ -972,7 +972,7 @@ const hasPlannedLateralTreatments = computed(() => {
         <!-- Redraw outline stroke so the silhouette stays crisp over fills -->
         <path
           :d="occlusalPaths.outline"
-          class="tooth-occlusal"
+          class="tooth-occlusal-edge"
           fill="none"
           stroke-width="1"
           stroke-linecap="round"
@@ -1119,6 +1119,13 @@ const hasPlannedLateralTreatments = computed(() => {
   fill: var(--odontogram-fill);
   stroke: var(--odontogram-outline);
   transition: fill 0.15s ease, stroke 0.15s ease;
+}
+
+/* Outline redrawn over treatment fills — stroke only, never repaint the fill. */
+.tooth-occlusal-edge {
+  fill: none;
+  stroke: var(--odontogram-outline);
+  transition: stroke 0.15s ease;
 }
 
 .tooth-root {

--- a/backend/app/modules/odontogram/frontend/components/odontogram/ToothSVGPaths.ts
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/ToothSVGPaths.ts
@@ -418,57 +418,153 @@ const LATERAL_PATHS_BY_POSITION: Record<ToothPosition, LateralPaths> = {
 
 // ============================================================================
 // OCCLUSAL VIEW PATHS (ViewBox: 0 0 50 50)
-// Circular design with 5 treatment zones: center (O) + 4 outer sectors (M,D,V,L)
-// All teeth in the same quadrant have identical shape, other quadrants are symmetric
+// Anatomically shaped outlines per tooth category with 5 treatment zones
+// (O center + M/D/V/L outer sectors). Quadrant symmetry via CSS transform.
 // ============================================================================
+
+interface Point {
+  x: number
+  y: number
+}
 
 interface OcclusalPaths {
   outline: string
   highlight: string[]
   surfaces: Record<string, string>
+  surfaceCenters: Record<string, Point>
 }
 
-// Circular surfaces for all teeth
-// Center: (25, 25), Outer radius: 22, Inner radius: 10
-// Diagonal dividers at 45°, 135°, 225°, 315°
-// Outer points: (41,9), (9,9), (9,41), (41,41)
-// Inner points: (32,18), (18,18), (18,32), (32,32)
-const CIRCULAR_SURFACES = {
-  // O (occlusal/incisal center): inner circle
-  O: 'M 35,25 A 10,10 0 1,1 15,25 A 10,10 0 1,1 35,25 Z',
-  // V (vestibular/buccal): top sector (45° to 135°)
-  V: 'M 32,18 L 41,9 A 22,22 0 0,0 9,9 L 18,18 A 10,10 0 0,1 32,18 Z',
-  // L (lingual/palatal): bottom sector (225° to 315°)
-  L: 'M 18,32 L 9,41 A 22,22 0 0,0 41,41 L 32,32 A 10,10 0 0,1 18,32 Z',
-  // M (mesial): left sector (135° to 225°)
-  M: 'M 18,18 L 9,9 A 22,22 0 0,0 9,41 L 18,32 A 10,10 0 0,1 18,18 Z',
-  // D (distal): right sector (315° to 45°)
-  D: 'M 32,32 L 41,41 A 22,22 0 0,0 41,9 L 32,18 A 10,10 0 0,1 32,32 Z'
+function pointStr(p: Point): string {
+  return `${p.x},${p.y}`
 }
 
-// Circular outline for all teeth
-const CIRCULAR_OUTLINE = 'M 25,3 A 22,22 0 1,1 25,47 A 22,22 0 1,1 25,3 Z'
+/** Build 5-sector surface paths from outer/inner corner points (Q1 orientation). */
+function buildOcclusalSurfaces(outer: Point[], inner: Point[]): Record<string, string> {
+  const [otl, otr, obr, obl] = outer
+  const [itl, itr, ibr, ibl] = inner
+  return {
+    O: `M ${pointStr(itr)} L ${pointStr(itl)} L ${pointStr(ibl)} L ${pointStr(ibr)} Z`,
+    V: `M ${pointStr(itl)} L ${pointStr(itr)} L ${pointStr(otr)} L ${pointStr(otl)} Z`,
+    L: `M ${pointStr(ibl)} L ${pointStr(obl)} L ${pointStr(obr)} L ${pointStr(ibr)} Z`,
+    M: `M ${pointStr(itl)} L ${pointStr(otl)} L ${pointStr(obl)} L ${pointStr(ibl)} Z`,
+    D: `M ${pointStr(itr)} L ${pointStr(obr)} L ${pointStr(otr)} L ${pointStr(itr)} Z`
+  }
+}
 
-// Radial dividers and inner circle (for visual reference, rendered as highlight lines)
-const CIRCULAR_DIVIDERS = [
-  'M 18,18 L 9,9', // Top-left diagonal
-  'M 32,18 L 41,9', // Top-right diagonal
-  'M 18,32 L 9,41', // Bottom-left diagonal
-  'M 32,32 L 41,41', // Bottom-right diagonal
-  'M 35,25 A 10,10 0 1,1 15,25 A 10,10 0 1,1 35,25' // Inner circle outline
+function buildOcclusalDividers(outer: Point[], inner: Point[]): string[] {
+  const [otl, otr, obr, obl] = outer
+  const [itl, itr, ibr, ibl] = inner
+  return [
+    `M ${pointStr(itl)} L ${pointStr(otl)}`,
+    `M ${pointStr(itr)} L ${pointStr(otr)}`,
+    `M ${pointStr(ibl)} L ${pointStr(obl)}`,
+    `M ${pointStr(ibr)} L ${pointStr(obr)}`,
+    `M ${pointStr(itr)} L ${pointStr(itl)} L ${pointStr(ibl)} L ${pointStr(ibr)} Z`
+  ]
+}
+
+function buildOcclusalPaths(
+  outline: string,
+  outer: Point[],
+  inner: Point[],
+  highlight: string[],
+  surfaceCenters: Record<string, Point>
+): OcclusalPaths {
+  return {
+    outline,
+    highlight,
+    surfaces: buildOcclusalSurfaces(outer, inner),
+    surfaceCenters
+  }
+}
+
+// Incisor — wide mesio-distal, narrow bucco-lingual (incisal edge toward V)
+const INCISOR_OUTER: Point[] = [
+  { x: 9, y: 16 }, { x: 41, y: 16 }, { x: 41, y: 34 }, { x: 9, y: 34 }
 ]
+const INCISOR_INNER: Point[] = [
+  { x: 20, y: 22 }, { x: 30, y: 22 }, { x: 30, y: 28 }, { x: 20, y: 28 }
+]
+const OCCLUSAL_INCISOR = buildOcclusalPaths(
+  'M 9,18 Q 9,14 13,14 L 37,14 Q 41,14 41,18 L 41,32 Q 41,36 37,36 L 13,36 Q 9,36 9,32 Z',
+  INCISOR_OUTER,
+  INCISOR_INNER,
+  [
+    'M 13,32 Q 25,34 37,32',
+    ...buildOcclusalDividers(INCISOR_OUTER, INCISOR_INNER)
+  ],
+  { O: { x: 25, y: 25 }, M: { x: 14, y: 25 }, D: { x: 36, y: 25 }, V: { x: 25, y: 17 }, L: { x: 25, y: 33 } }
+)
 
-// All teeth use the same circular occlusal view
+// Canine — cuspal diamond with buccal cusp toward V
+const CANINE_OUTER: Point[] = [
+  { x: 10, y: 9 }, { x: 40, y: 9 }, { x: 40, y: 41 }, { x: 10, y: 41 }
+]
+const CANINE_INNER: Point[] = [
+  { x: 20, y: 22 }, { x: 30, y: 22 }, { x: 30, y: 28 }, { x: 20, y: 28 }
+]
+const OCCLUSAL_CANINE = buildOcclusalPaths(
+  'M 25,8 Q 36,12 40,25 Q 36,38 25,42 Q 14,38 10,25 Q 14,12 25,8 Z',
+  CANINE_OUTER,
+  CANINE_INNER,
+  [
+    'M 25,8 L 25,28',
+    ...buildOcclusalDividers(CANINE_OUTER, CANINE_INNER)
+  ],
+  { O: { x: 25, y: 25 }, M: { x: 15, y: 25 }, D: { x: 35, y: 25 }, V: { x: 25, y: 14 }, L: { x: 25, y: 36 } }
+)
+
+// Premolar — oval with buccal and lingual cusps
+const PREMOLAR_OUTER: Point[] = [
+  { x: 13, y: 13 }, { x: 37, y: 13 }, { x: 37, y: 37 }, { x: 13, y: 37 }
+]
+const PREMOLAR_INNER: Point[] = [
+  { x: 20, y: 20 }, { x: 30, y: 20 }, { x: 30, y: 30 }, { x: 20, y: 30 }
+]
+const OCCLUSAL_PREMOLAR = buildOcclusalPaths(
+  'M 14,12 Q 25,10 36,12 Q 40,25 36,38 Q 25,40 14,38 Q 10,25 14,12 Z',
+  PREMOLAR_OUTER,
+  PREMOLAR_INNER,
+  [
+    'M 18,19 Q 25,17 32,19',
+    'M 20,31 Q 25,33 30,31',
+    'M 25,17 L 25,33',
+    ...buildOcclusalDividers(PREMOLAR_OUTER, PREMOLAR_INNER)
+  ],
+  { O: { x: 25, y: 25 }, M: { x: 15, y: 25 }, D: { x: 35, y: 25 }, V: { x: 25, y: 15 }, L: { x: 25, y: 35 } }
+)
+
+// Molar — squarish with four cusps and central cross fissure
+const MOLAR_OUTER: Point[] = [
+  { x: 11, y: 11 }, { x: 39, y: 11 }, { x: 39, y: 39 }, { x: 11, y: 39 }
+]
+const MOLAR_INNER: Point[] = [
+  { x: 19, y: 19 }, { x: 31, y: 19 }, { x: 31, y: 31 }, { x: 19, y: 31 }
+]
+const OCCLUSAL_MOLAR = buildOcclusalPaths(
+  'M 12,13 Q 12,11 14,11 L 36,11 Q 38,11 38,13 L 38,37 Q 38,39 36,39 L 14,39 Q 12,39 12,37 Z',
+  MOLAR_OUTER,
+  MOLAR_INNER,
+  [
+    'M 25,13 L 25,37',
+    'M 13,25 L 37,25',
+    'M 17,17 L 33,33',
+    'M 33,17 L 17,33',
+    ...buildOcclusalDividers(MOLAR_OUTER, MOLAR_INNER)
+  ],
+  { O: { x: 25, y: 25 }, M: { x: 13, y: 25 }, D: { x: 37, y: 25 }, V: { x: 25, y: 13 }, L: { x: 25, y: 37 } }
+)
+
 // Quadrant symmetry is handled by CSS transform (napkin unfolding)
 const OCCLUSAL_PATHS_BY_POSITION: Record<ToothPosition, OcclusalPaths> = {
-  1: { outline: CIRCULAR_OUTLINE, highlight: CIRCULAR_DIVIDERS, surfaces: CIRCULAR_SURFACES },
-  2: { outline: CIRCULAR_OUTLINE, highlight: CIRCULAR_DIVIDERS, surfaces: CIRCULAR_SURFACES },
-  3: { outline: CIRCULAR_OUTLINE, highlight: CIRCULAR_DIVIDERS, surfaces: CIRCULAR_SURFACES },
-  4: { outline: CIRCULAR_OUTLINE, highlight: CIRCULAR_DIVIDERS, surfaces: CIRCULAR_SURFACES },
-  5: { outline: CIRCULAR_OUTLINE, highlight: CIRCULAR_DIVIDERS, surfaces: CIRCULAR_SURFACES },
-  6: { outline: CIRCULAR_OUTLINE, highlight: CIRCULAR_DIVIDERS, surfaces: CIRCULAR_SURFACES },
-  7: { outline: CIRCULAR_OUTLINE, highlight: CIRCULAR_DIVIDERS, surfaces: CIRCULAR_SURFACES },
-  8: { outline: CIRCULAR_OUTLINE, highlight: CIRCULAR_DIVIDERS, surfaces: CIRCULAR_SURFACES }
+  1: OCCLUSAL_INCISOR,
+  2: OCCLUSAL_INCISOR,
+  3: OCCLUSAL_CANINE,
+  4: OCCLUSAL_PREMOLAR,
+  5: OCCLUSAL_PREMOLAR,
+  6: OCCLUSAL_MOLAR,
+  7: OCCLUSAL_MOLAR,
+  8: OCCLUSAL_MOLAR
 }
 
 // ============================================================================
@@ -494,6 +590,12 @@ export function getLateralPath(toothNumber: number): LateralPaths {
 
 export function getOcclusalPath(toothNumber: number): OcclusalPaths {
   return OCCLUSAL_PATHS_BY_POSITION[getShapePosition(toothNumber)]
+}
+
+/** Center point for dot-style occlusal treatment overlays. */
+export function getOcclusalSurfaceCenter(toothNumber: number, surface: string): Point {
+  const paths = getOcclusalPath(toothNumber)
+  return paths.surfaceCenters[surface] ?? { x: 25, y: 25 }
 }
 
 // ============================================================================

--- a/backend/app/modules/odontogram/frontend/components/odontogram/ToothSVGPaths.ts
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/ToothSVGPaths.ts
@@ -484,7 +484,7 @@ function buildOcclusalPaths(
 
 // Incisor — wide mesio-distal, narrow bucco-lingual; rounded MD corners, flatter labial edge
 const INCISOR_OUTER: Quad = [
-  { x: 6, y: 14 }, { x: 44, y: 14 }, { x: 44, y: 36 }, { x: 6, y: 36 }
+  { x: 6, y: 6 }, { x: 44, y: 6 }, { x: 44, y: 44 }, { x: 6, y: 44 }
 ]
 const INCISOR_INNER: Quad = [
   { x: 19, y: 21 }, { x: 31, y: 21 }, { x: 31, y: 29 }, { x: 19, y: 29 }
@@ -520,7 +520,7 @@ const OCCLUSAL_CANINE = buildOcclusalPaths(
 
 // Premolar — BL-elongated oval with buccal + lingual cusp lobes and a waist
 const PREMOLAR_OUTER: Quad = [
-  { x: 10, y: 7 }, { x: 40, y: 7 }, { x: 40, y: 43 }, { x: 10, y: 43 }
+  { x: 10, y: 4 }, { x: 40, y: 4 }, { x: 40, y: 46 }, { x: 10, y: 46 }
 ]
 const PREMOLAR_INNER: Quad = [
   { x: 20, y: 20 }, { x: 30, y: 20 }, { x: 30, y: 30 }, { x: 20, y: 30 }
@@ -540,7 +540,7 @@ const OCCLUSAL_PREMOLAR = buildOcclusalPaths(
 
 // Molar — rounded square with four cusp bulges; short central fissure only (not a missing-tooth X)
 const MOLAR_OUTER: Quad = [
-  { x: 8, y: 8 }, { x: 42, y: 8 }, { x: 42, y: 42 }, { x: 8, y: 42 }
+  { x: 6, y: 6 }, { x: 44, y: 6 }, { x: 44, y: 44 }, { x: 6, y: 44 }
 ]
 const MOLAR_INNER: Quad = [
   { x: 19, y: 19 }, { x: 31, y: 19 }, { x: 31, y: 31 }, { x: 19, y: 31 }

--- a/backend/app/modules/odontogram/frontend/components/odontogram/ToothSVGPaths.ts
+++ b/backend/app/modules/odontogram/frontend/components/odontogram/ToothSVGPaths.ts
@@ -420,12 +420,16 @@ const LATERAL_PATHS_BY_POSITION: Record<ToothPosition, LateralPaths> = {
 // OCCLUSAL VIEW PATHS (ViewBox: 0 0 50 50)
 // Anatomically shaped outlines per tooth category with 5 treatment zones
 // (O center + M/D/V/L outer sectors). Quadrant symmetry via CSS transform.
+// Outer quads may extend past the silhouette; callers clip fills to `outline`.
 // ============================================================================
 
 interface Point {
   x: number
   y: number
 }
+
+/** Four corners in order: top-left, top-right, bottom-right, bottom-left (Q1). */
+type Quad = [Point, Point, Point, Point]
 
 interface OcclusalPaths {
   outline: string
@@ -439,7 +443,7 @@ function pointStr(p: Point): string {
 }
 
 /** Build 5-sector surface paths from outer/inner corner points (Q1 orientation). */
-function buildOcclusalSurfaces(outer: Point[], inner: Point[]): Record<string, string> {
+function buildOcclusalSurfaces(outer: Quad, inner: Quad): Record<string, string> {
   const [otl, otr, obr, obl] = outer
   const [itl, itr, ibr, ibl] = inner
   return {
@@ -447,11 +451,11 @@ function buildOcclusalSurfaces(outer: Point[], inner: Point[]): Record<string, s
     V: `M ${pointStr(itl)} L ${pointStr(itr)} L ${pointStr(otr)} L ${pointStr(otl)} Z`,
     L: `M ${pointStr(ibl)} L ${pointStr(obl)} L ${pointStr(obr)} L ${pointStr(ibr)} Z`,
     M: `M ${pointStr(itl)} L ${pointStr(otl)} L ${pointStr(obl)} L ${pointStr(ibl)} Z`,
-    D: `M ${pointStr(itr)} L ${pointStr(obr)} L ${pointStr(otr)} L ${pointStr(itr)} Z`
+    D: `M ${pointStr(itr)} L ${pointStr(otr)} L ${pointStr(obr)} L ${pointStr(ibr)} Z`
   }
 }
 
-function buildOcclusalDividers(outer: Point[], inner: Point[]): string[] {
+function buildOcclusalDividers(outer: Quad, inner: Quad): string[] {
   const [otl, otr, obr, obl] = outer
   const [itl, itr, ibr, ibl] = inner
   return [
@@ -465,8 +469,8 @@ function buildOcclusalDividers(outer: Point[], inner: Point[]): string[] {
 
 function buildOcclusalPaths(
   outline: string,
-  outer: Point[],
-  inner: Point[],
+  outer: Quad,
+  inner: Quad,
   highlight: string[],
   surfaceCenters: Record<string, Point>
 ): OcclusalPaths {
@@ -478,81 +482,80 @@ function buildOcclusalPaths(
   }
 }
 
-// Incisor — wide mesio-distal, narrow bucco-lingual (incisal edge toward V)
-const INCISOR_OUTER: Point[] = [
-  { x: 9, y: 16 }, { x: 41, y: 16 }, { x: 41, y: 34 }, { x: 9, y: 34 }
+// Incisor — wide mesio-distal, narrow bucco-lingual; rounded MD corners, flatter labial edge
+const INCISOR_OUTER: Quad = [
+  { x: 6, y: 14 }, { x: 44, y: 14 }, { x: 44, y: 36 }, { x: 6, y: 36 }
 ]
-const INCISOR_INNER: Point[] = [
-  { x: 20, y: 22 }, { x: 30, y: 22 }, { x: 30, y: 28 }, { x: 20, y: 28 }
+const INCISOR_INNER: Quad = [
+  { x: 19, y: 21 }, { x: 31, y: 21 }, { x: 31, y: 29 }, { x: 19, y: 29 }
 ]
 const OCCLUSAL_INCISOR = buildOcclusalPaths(
-  'M 9,18 Q 9,14 13,14 L 37,14 Q 41,14 41,18 L 41,32 Q 41,36 37,36 L 13,36 Q 9,36 9,32 Z',
+  'M 7,17 C 7,12 12,10 18,10 L 32,10 C 38,10 43,12 43,17 L 44,33 C 44,38 39,40 34,40 L 16,40 C 11,40 6,38 6,33 Z',
   INCISOR_OUTER,
   INCISOR_INNER,
   [
-    'M 13,32 Q 25,34 37,32',
+    'M 14,33 Q 25,36 36,33',
     ...buildOcclusalDividers(INCISOR_OUTER, INCISOR_INNER)
   ],
-  { O: { x: 25, y: 25 }, M: { x: 14, y: 25 }, D: { x: 36, y: 25 }, V: { x: 25, y: 17 }, L: { x: 25, y: 33 } }
+  { O: { x: 25, y: 25 }, M: { x: 12, y: 25 }, D: { x: 38, y: 25 }, V: { x: 25, y: 15 }, L: { x: 25, y: 35 } }
 )
 
-// Canine — cuspal diamond with buccal cusp toward V
-const CANINE_OUTER: Point[] = [
-  { x: 10, y: 9 }, { x: 40, y: 9 }, { x: 40, y: 41 }, { x: 10, y: 41 }
+// Canine — pointed buccal cusp (V), wider mid-crown, rounded lingual base
+const CANINE_OUTER: Quad = [
+  { x: 7, y: 5 }, { x: 43, y: 5 }, { x: 43, y: 45 }, { x: 7, y: 45 }
 ]
-const CANINE_INNER: Point[] = [
+const CANINE_INNER: Quad = [
   { x: 20, y: 22 }, { x: 30, y: 22 }, { x: 30, y: 28 }, { x: 20, y: 28 }
 ]
 const OCCLUSAL_CANINE = buildOcclusalPaths(
-  'M 25,8 Q 36,12 40,25 Q 36,38 25,42 Q 14,38 10,25 Q 14,12 25,8 Z',
+  'M 25,5 Q 38,12 42,25 Q 38,37 28,43 Q 25,45 22,43 Q 12,37 8,25 Q 12,12 25,5 Z',
   CANINE_OUTER,
   CANINE_INNER,
   [
-    'M 25,8 L 25,28',
+    'M 25,12 L 25,26',
     ...buildOcclusalDividers(CANINE_OUTER, CANINE_INNER)
   ],
-  { O: { x: 25, y: 25 }, M: { x: 15, y: 25 }, D: { x: 35, y: 25 }, V: { x: 25, y: 14 }, L: { x: 25, y: 36 } }
+  { O: { x: 25, y: 25 }, M: { x: 14, y: 25 }, D: { x: 36, y: 25 }, V: { x: 25, y: 12 }, L: { x: 25, y: 38 } }
 )
 
-// Premolar — oval with buccal and lingual cusps
-const PREMOLAR_OUTER: Point[] = [
-  { x: 13, y: 13 }, { x: 37, y: 13 }, { x: 37, y: 37 }, { x: 13, y: 37 }
+// Premolar — BL-elongated oval with buccal + lingual cusp lobes and a waist
+const PREMOLAR_OUTER: Quad = [
+  { x: 10, y: 7 }, { x: 40, y: 7 }, { x: 40, y: 43 }, { x: 10, y: 43 }
 ]
-const PREMOLAR_INNER: Point[] = [
+const PREMOLAR_INNER: Quad = [
   { x: 20, y: 20 }, { x: 30, y: 20 }, { x: 30, y: 30 }, { x: 20, y: 30 }
 ]
 const OCCLUSAL_PREMOLAR = buildOcclusalPaths(
-  'M 14,12 Q 25,10 36,12 Q 40,25 36,38 Q 25,40 14,38 Q 10,25 14,12 Z',
+  'M 17,8 C 25,4 33,8 36,14 C 40,20 40,24 37,27 C 40,30 40,36 36,40 C 30,45 20,45 14,40 C 10,36 10,30 13,27 C 10,24 10,20 14,14 C 15,10 17,8 17,8 Z',
   PREMOLAR_OUTER,
   PREMOLAR_INNER,
   [
-    'M 18,19 Q 25,17 32,19',
-    'M 20,31 Q 25,33 30,31',
-    'M 25,17 L 25,33',
+    'M 20,18 Q 25,16 30,18',
+    'M 21,32 Q 25,34 29,32',
+    'M 25,18 L 25,32',
     ...buildOcclusalDividers(PREMOLAR_OUTER, PREMOLAR_INNER)
   ],
-  { O: { x: 25, y: 25 }, M: { x: 15, y: 25 }, D: { x: 35, y: 25 }, V: { x: 25, y: 15 }, L: { x: 25, y: 35 } }
+  { O: { x: 25, y: 25 }, M: { x: 14, y: 25 }, D: { x: 36, y: 25 }, V: { x: 25, y: 12 }, L: { x: 25, y: 38 } }
 )
 
-// Molar — squarish with four cusps and central cross fissure
-const MOLAR_OUTER: Point[] = [
-  { x: 11, y: 11 }, { x: 39, y: 11 }, { x: 39, y: 39 }, { x: 11, y: 39 }
+// Molar — rounded square with four cusp bulges; short central fissure only (not a missing-tooth X)
+const MOLAR_OUTER: Quad = [
+  { x: 8, y: 8 }, { x: 42, y: 8 }, { x: 42, y: 42 }, { x: 8, y: 42 }
 ]
-const MOLAR_INNER: Point[] = [
+const MOLAR_INNER: Quad = [
   { x: 19, y: 19 }, { x: 31, y: 19 }, { x: 31, y: 31 }, { x: 19, y: 31 }
 ]
 const OCCLUSAL_MOLAR = buildOcclusalPaths(
-  'M 12,13 Q 12,11 14,11 L 36,11 Q 38,11 38,13 L 38,37 Q 38,39 36,39 L 14,39 Q 12,39 12,37 Z',
+  'M 14,10 C 18,6 22,7 25,8 C 28,7 32,6 36,10 C 42,14 43,18 42,22 C 43,25 43,28 42,31 C 43,35 42,39 36,42 C 32,45 28,44 25,43 C 22,44 18,45 14,42 C 8,39 7,35 8,31 C 7,28 7,25 8,22 C 7,18 8,14 14,10 Z',
   MOLAR_OUTER,
   MOLAR_INNER,
   [
-    'M 25,13 L 25,37',
-    'M 13,25 L 37,25',
-    'M 17,17 L 33,33',
-    'M 33,17 L 17,33',
+    // Keep fissures inside the central O so they do not read as a missing-tooth overlay
+    'M 25,20 L 25,30',
+    'M 20,25 L 30,25',
     ...buildOcclusalDividers(MOLAR_OUTER, MOLAR_INNER)
   ],
-  { O: { x: 25, y: 25 }, M: { x: 13, y: 25 }, D: { x: 37, y: 25 }, V: { x: 25, y: 13 }, L: { x: 25, y: 37 } }
+  { O: { x: 25, y: 25 }, M: { x: 12, y: 25 }, D: { x: 38, y: 25 }, V: { x: 25, y: 12 }, L: { x: 25, y: 38 } }
 )
 
 // Quadrant symmetry is handled by CSS transform (napkin unfolding)

--- a/frontend/tests/odontogram/toothOcclusalPaths.test.ts
+++ b/frontend/tests/odontogram/toothOcclusalPaths.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { getOcclusalPath } from '../../module_layers/odontogram/frontend/components/odontogram/ToothSVGPaths'
+
+describe('getOcclusalPath', () => {
+  it('returns category-specific outlines for incisor, canine, premolar, and molar', () => {
+    const incisor = getOcclusalPath(11).outline
+    const canine = getOcclusalPath(13).outline
+    const premolar = getOcclusalPath(14).outline
+    const molar = getOcclusalPath(16).outline
+
+    expect(incisor).not.toBe(canine)
+    expect(canine).not.toBe(premolar)
+    expect(premolar).not.toBe(molar)
+    expect(incisor).not.toBe(molar)
+  })
+
+  it('exposes all five standard surface paths per tooth', () => {
+    const surfaces = getOcclusalPath(26).surfaces
+    expect(Object.keys(surfaces).sort()).toEqual(['D', 'L', 'M', 'O', 'V'])
+    for (const path of Object.values(surfaces)) {
+      expect(path.startsWith('M ')).toBe(true)
+    }
+  })
+})

--- a/frontend/tests/odontogram/toothOcclusalPaths.test.ts
+++ b/frontend/tests/odontogram/toothOcclusalPaths.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { getOcclusalPath } from '../../module_layers/odontogram/frontend/components/odontogram/ToothSVGPaths'
 
+/** Count vertices in an M/L/.../Z polygon path (coordinate pairs). */
+function vertexCount(path: string): number {
+  return (path.match(/-?\d+(?:\.\d+)?,-?\d+(?:\.\d+)?/g) ?? []).length
+}
+
 describe('getOcclusalPath', () => {
   it('returns category-specific outlines for incisor, canine, premolar, and molar', () => {
     const incisor = getOcclusalPath(11).outline
@@ -19,6 +24,16 @@ describe('getOcclusalPath', () => {
     expect(Object.keys(surfaces).sort()).toEqual(['D', 'L', 'M', 'O', 'V'])
     for (const path of Object.values(surfaces)) {
       expect(path.startsWith('M ')).toBe(true)
+    }
+  })
+
+  it('builds each surface as a closed quad (4 vertices)', () => {
+    for (const tooth of [11, 13, 14, 16]) {
+      const surfaces = getOcclusalPath(tooth).surfaces
+      for (const [name, path] of Object.entries(surfaces)) {
+        expect(vertexCount(path), `${tooth} surface ${name}`).toBe(4)
+        expect(path.trim().endsWith('Z')).toBe(true)
+      }
     }
   })
 })

--- a/frontend/tests/odontogram/toothOcclusalPaths.test.ts
+++ b/frontend/tests/odontogram/toothOcclusalPaths.test.ts
@@ -1,9 +1,77 @@
 import { describe, expect, it } from 'vitest'
-import { getOcclusalPath } from '../../module_layers/odontogram/frontend/components/odontogram/ToothSVGPaths'
+import { getOcclusalPath } from '#module-layers/odontogram/frontend/components/odontogram/ToothSVGPaths'
 
 /** Count vertices in an M/L/.../Z polygon path (coordinate pairs). */
 function vertexCount(path: string): number {
   return (path.match(/-?\d+(?:\.\d+)?,-?\d+(?:\.\d+)?/g) ?? []).length
+}
+
+interface Point { x: number, y: number }
+
+/** Sample every M/L/C/Q segment so curve extremes are included in the bounds. */
+function samplePath(path: string): Point[] {
+  const tokens = path.match(/[MCLQZ]|-?\d+(?:\.\d+)?/g) ?? []
+  const points: Point[] = []
+  let index = 0
+  let command = ''
+  let current: Point = { x: 0, y: 0 }
+  let start: Point = current
+  const number = () => Number(tokens[index++])
+
+  while (index < tokens.length) {
+    const token = tokens[index]!
+    if (/^[MCLQZ]$/.test(token)) {
+      command = token
+      index += 1
+      continue
+    }
+    if (command === 'M' || command === 'L') {
+      current = { x: number(), y: number() }
+      if (command === 'M') start = current
+      points.push(current)
+    } else if (command === 'C') {
+      const control1 = { x: number(), y: number() }
+      const control2 = { x: number(), y: number() }
+      const target = { x: number(), y: number() }
+      for (let step = 0; step <= 32; step++) {
+        const t = step / 32
+        const mt = 1 - t
+        points.push({
+          x: mt ** 3 * current.x + 3 * mt * mt * t * control1.x + 3 * mt * t * t * control2.x + t ** 3 * target.x,
+          y: mt ** 3 * current.y + 3 * mt * mt * t * control1.y + 3 * mt * t * t * control2.y + t ** 3 * target.y
+        })
+      }
+      current = target
+    } else if (command === 'Q') {
+      const control = { x: number(), y: number() }
+      const target = { x: number(), y: number() }
+      for (let step = 0; step <= 32; step++) {
+        const t = step / 32
+        const mt = 1 - t
+        points.push({
+          x: mt * mt * current.x + 2 * mt * t * control.x + t * t * target.x,
+          y: mt * mt * current.y + 2 * mt * t * control.y + t * t * target.y
+        })
+      }
+      current = target
+    } else if (command === 'Z') {
+      points.push(start)
+      current = start
+      index += 1
+    } else {
+      index += 1
+    }
+  }
+  return points
+}
+
+function bounds(points: Point[]) {
+  return {
+    minX: Math.min(...points.map(p => p.x)),
+    minY: Math.min(...points.map(p => p.y)),
+    maxX: Math.max(...points.map(p => p.x)),
+    maxY: Math.max(...points.map(p => p.y))
+  }
 }
 
 describe('getOcclusalPath', () => {
@@ -34,6 +102,20 @@ describe('getOcclusalPath', () => {
         expect(vertexCount(path), `${tooth} surface ${name}`).toBe(4)
         expect(path.trim().endsWith('Z')).toBe(true)
       }
+    }
+  })
+
+  it('over-sizes the outer quad so each surface band encloses the outline bounding box', () => {
+    for (const tooth of [11, 13, 14, 16]) {
+      const { outline, surfaces } = getOcclusalPath(tooth)
+      const outlineBounds = bounds(samplePath(outline))
+      const surfaceBounds = bounds(Object.values(surfaces).flatMap(samplePath))
+      // Outer corners extend past the silhouette (callers clip fills to outline),
+      // so the incisal, cervical and lateral bands are fillable and clickable.
+      expect(surfaceBounds.minX, `${tooth} minX`).toBeLessThanOrEqual(outlineBounds.minX)
+      expect(surfaceBounds.minY, `${tooth} minY`).toBeLessThanOrEqual(outlineBounds.minY)
+      expect(surfaceBounds.maxX, `${tooth} maxX`).toBeGreaterThanOrEqual(outlineBounds.maxX)
+      expect(surfaceBounds.maxY, `${tooth} maxY`).toBeGreaterThanOrEqual(outlineBounds.maxY)
     }
   })
 })


### PR DESCRIPTION
Fixes #48

Replaced the generic circular occlusal view with anatomically distinct incisor, canine, premolar, and molar outlines (still 5 surfaces); crown-only lateral view in the surface popup was already present; 17-zone expansion was not included as it requires a larger backend change.

No local test suite detected.

---
This change was prepared with AI assistance under human direction and review.