### PR TITLE
fix(telephony): post-merge follow-ups from the #349 review (#64)

### DIFF
--- a/backend/app/modules/telephony/CHANGELOG.md
+++ b/backend/app/modules/telephony/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#64): the three post-merge review follow-ups from #349 — the first-event unique-constraint race adopts the winner's row via a savepoint instead of failing; the `callPop` poll is gated on a new cheap `GET /status` probe (10-min re-check) so unconfigured clinics don't pay the 15s cadence; the plugin's seen-ids set is capped at 200.
+
 - feat(#64): initial release — phase 1 of the CTI design: HMAC-verified
   inbound event webhook (any PBX / Zapier), E.164 normalization,
   caller→patient matching, persistent call log with live view and

--- a/backend/app/modules/telephony/CLAUDE.md
+++ b/backend/app/modules/telephony/CLAUDE.md
@@ -16,6 +16,7 @@ Routes at `/api/v1/telephony/`:
 | Method | Path | Auth |
 |---|---|---|
 | GET/PUT | `/settings` | `telephony.settings.read` / `.write` |
+| GET | `/status` | `telephony.calls.read` (pop-poll gate probe) |
 | GET | `/calls` | `telephony.calls.read` |
 | GET | `/calls/active` | `telephony.calls.read` (the pop poll) |
 | PUT | `/calls/{id}/note` | `telephony.calls.write` |
@@ -91,7 +92,13 @@ that generated it, rotation via `PUT /settings {"rotate_secret": true}`.
   call-flows/Zaps against it; version, don't rename.
 - The pop is polling (15s) by design in phase 1 — a realtime channel is
   the documented upgrade path in issue #64 §3, not something to bolt on
-  here ad hoc.
+  here ad hoc. The plugin gates the poll on `GET /status` (re-checked
+  every 10 min) so unconfigured clinics don't pay the 15s cadence, and
+  caps its seen-ids set at 200.
+- Two simultaneous *first* events of one call race past the SELECT; the
+  savepoint + `IntegrityError` adopt-the-winner path in
+  `ingest_event` is what keeps the loser from 500ing — don't "simplify"
+  it away.
 - Vendor adapters (aircall/3cx/twilio_voice) belong in their own
   community modules that POST into this gateway, not in this module.
 

--- a/backend/app/modules/telephony/frontend/plugins/callPop.client.ts
+++ b/backend/app/modules/telephony/frontend/plugins/callPop.client.ts
@@ -4,14 +4,33 @@
  * and toast each new ringing call once — non-blocking, never navigates
  * on its own; the action button opens the patient record (or the
  * patient search pre-filtered by the caller's number).
+ *
+ * The 15s poll only runs while the gateway reports itself configured
+ * and active (`GET /telephony/status`, re-checked every 10 minutes) —
+ * a clinic that never set up telephony costs one status probe per
+ * 10 minutes, not a request every 15 seconds.
  */
 import { PERMISSIONS } from '~~/app/config/permissions'
 
 const POLL_MS = 15000
+const STATUS_RECHECK_MS = 10 * 60 * 1000
+// Ringing calls age out of /calls/active within minutes; the id set only
+// needs to outlive that window, not the session.
+const SEEN_CAP = 200
 
 export default defineNuxtPlugin((nuxtApp) => {
   const seen = new Set<string>()
+  let gatewayActive: boolean | null = null
+  let lastStatusCheck = 0
   let timer: ReturnType<typeof setInterval> | undefined
+
+  function remember(id: string) {
+    seen.add(id)
+    if (seen.size > SEEN_CAP) {
+      // Sets iterate in insertion order — drop the oldest half.
+      for (const old of Array.from(seen).slice(0, SEEN_CAP / 2)) seen.delete(old)
+    }
+  }
 
   async function tick() {
     const { user } = useAuth()
@@ -19,6 +38,23 @@ export default defineNuxtPlugin((nuxtApp) => {
     if (!user.value || !can(PERMISSIONS.telephony.callsRead)) return
 
     const api = useApi()
+    const now = Date.now()
+    if (gatewayActive === null || now - lastStatusCheck > STATUS_RECHECK_MS) {
+      lastStatusCheck = now
+      try {
+        const res = await api.get<{ data: { active: boolean } }>(
+          '/api/v1/telephony/status',
+          { errorToast: false }
+        )
+        gatewayActive = res.data.active
+      } catch {
+        // Unknown state (transient error / module gone) — stay quiet and
+        // re-probe at the next status window instead of polling calls.
+        gatewayActive = false
+      }
+    }
+    if (!gatewayActive) return
+
     const toast = useToast()
     const t = (nuxtApp.$i18n as { t: (k: string) => string }).t
     try {
@@ -31,7 +67,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       }> }>('/api/v1/telephony/calls/active', { errorToast: false })
       for (const call of res.data) {
         if (call.status !== 'ringing' || seen.has(call.id)) continue
-        seen.add(call.id)
+        remember(call.id)
         toast.add({
           title: call.patient_name || t('telephony.calls.unknownCaller'),
           description: `${t('telephony.pop.incoming')} · ${call.from_number}`,

--- a/backend/app/modules/telephony/router.py
+++ b/backend/app/modules/telephony/router.py
@@ -89,6 +89,19 @@ async def update_settings(
     return ApiResponse(data=_settings_response(settings, secret=secret))
 
 
+@router.get("/status", response_model=ApiResponse[dict])
+async def gateway_status(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("telephony.calls.read"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[dict]:
+    """Cheap probe for the screen-pop plugin: is the gateway configured
+    and active for this clinic? Lets clients back off the 15s poll to a
+    slow re-check instead of hammering /calls/active for nothing."""
+    settings = await TelephonyService.get_settings(db, ctx.clinic_id)
+    return ApiResponse(data={"active": bool(settings and settings.is_active)})
+
+
 @router.get("/calls", response_model=PaginatedApiResponse[CallLogResponse])
 async def list_calls(
     ctx: Annotated[ClinicContext, Depends(get_clinic_context)],

--- a/backend/app/modules/telephony/service.py
+++ b/backend/app/modules/telephony/service.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
 from app.core.email.encryption import encrypt_password
@@ -166,7 +167,7 @@ class TelephonyService:
         now = datetime.now(UTC)
         if row is None:
             patient = await TelephonyService.match_patient(db, clinic_id, from_number)
-            row = CallLog(
+            fresh = CallLog(
                 clinic_id=clinic_id,
                 provider=provider,
                 call_id=call_id,
@@ -177,7 +178,24 @@ class TelephonyService:
                 patient_id=patient.id if patient else None,
                 started_at=_parse_ts(payload.get("started_at")) or now,
             )
-            db.add(row)
+            try:
+                # Savepoint: two simultaneous *first* events of one call can
+                # both miss the SELECT above; the unique constraint arbitrates
+                # and the loser adopts the winner's row instead of 500ing.
+                async with db.begin_nested():
+                    db.add(fresh)
+                    await db.flush()
+                row = fresh
+            except IntegrityError:
+                row = (
+                    await db.execute(
+                        select(CallLog).where(
+                            CallLog.clinic_id == clinic_id,
+                            CallLog.provider == provider,
+                            CallLog.call_id == call_id,
+                        )
+                    )
+                ).scalar_one()
 
         row.status = status
         if status == "answered" and row.answered_at is None:

--- a/backend/tests/modules/telephony/test_router.py
+++ b/backend/tests/modules/telephony/test_router.py
@@ -151,3 +151,18 @@ async def test_ingest_accepts_and_ignores_unusable_event(
     )
     assert res.status_code == 200
     assert res.json()["call_log_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_status_probe(client: AsyncClient, auth_headers, test_clinic):
+    res = await client.get("/api/v1/telephony/status", headers=auth_headers)
+    assert res.status_code == 200
+    assert res.json()["data"] == {"active": False}
+
+    await _configure(client, auth_headers)
+    res = await client.get("/api/v1/telephony/status", headers=auth_headers)
+    assert res.json()["data"] == {"active": True}
+
+    await client.put(SETTINGS, json={"is_active": False}, headers=auth_headers)
+    res = await client.get("/api/v1/telephony/status", headers=auth_headers)
+    assert res.json()["data"] == {"active": False}

--- a/backend/tests/modules/telephony/test_service.py
+++ b/backend/tests/modules/telephony/test_service.py
@@ -150,3 +150,50 @@ async def test_unknown_caller_event_published(db_session: AsyncSession, test_cli
         assert seen[0]["call_log_id"] == str(row.id)
     finally:
         event_bus.unsubscribe(EventType.CALL_UNKNOWN_CALLER, capture)
+
+
+@pytest.mark.asyncio
+async def test_first_event_race_adopts_winner_row(
+    db_session: AsyncSession, test_clinic, monkeypatch
+):
+    """Two simultaneous first events of one call: the loser of the unique
+    constraint must adopt the winner's row instead of raising."""
+    from sqlalchemy import text
+
+    settings = await _settings(db_session, test_clinic.id)
+
+    original = TelephonyService.match_patient
+
+    async def match_and_race(db, clinic_id, number):
+        # Simulate the concurrent writer landing between our SELECT (which
+        # found nothing) and our INSERT: the row exists by flush time.
+        await db.execute(
+            text(
+                "INSERT INTO telephony_call_logs "
+                "(id, clinic_id, provider, call_id, direction, from_number, status, "
+                " created_at, updated_at) "
+                "VALUES (gen_random_uuid(), :clinic, 'webhook', 'c-race', 'inbound', "
+                " '+34600112233', 'ringing', now(), now())"
+            ),
+            {"clinic": str(clinic_id)},
+        )
+        return await original(db, clinic_id, number)
+
+    monkeypatch.setattr(TelephonyService, "match_patient", match_and_race)
+    row = await TelephonyService.ingest_event(
+        db_session, settings, _event("call.answered", call_id="c-race")
+    )
+    assert row is not None
+    assert row.call_id == "c-race"
+    assert row.status == "answered"  # the update still applied to the winner's row
+
+    from sqlalchemy import func, select
+
+    from app.modules.telephony.models import CallLog
+
+    count = (
+        await db_session.execute(
+            select(func.count()).select_from(CallLog).where(CallLog.call_id == "c-race")
+        )
+    ).scalar_one()
+    assert count == 1

--- a/docs/technical/telephony/permissions.md
+++ b/docs/technical/telephony/permissions.md
@@ -11,7 +11,7 @@ Namespaced by the registry from the module's `get_permissions()`.
 |------------|-------|-----------|
 | `telephony.settings.read` | View gateway config | `GET /api/v1/telephony/settings` |
 | `telephony.settings.write` | Edit config, rotate secret | `PUT /api/v1/telephony/settings` |
-| `telephony.calls.read` | Call log, live view, pop poll | `GET /api/v1/telephony/calls`, `GET /api/v1/telephony/calls/active` |
+| `telephony.calls.read` | Call log, live view, pop poll | `GET /api/v1/telephony/calls`, `GET /api/v1/telephony/calls/active`, `GET /api/v1/telephony/status` |
 | `telephony.calls.write` | Annotate a call | `PUT /api/v1/telephony/calls/{id}/note` |
 
 `POST /api/v1/telephony/events/{clinic_id}` is public — authenticated by


### PR DESCRIPTION
The three non-blocking items from the #349 merge review, as promised:

1. **First-event unique race** — two simultaneous first events of one call both miss the SELECT; the insert now runs in a savepoint and the `IntegrityError` loser adopts the winner's row, then applies its update there. The regression test simulates the interleaving by injecting the competing row between SELECT and INSERT (via a patched `match_patient`), and asserts one row, updated status, no error.
2. **Poll gating** — new `GET /telephony/status` (gated by `calls.read`, so every popper role can probe it): `{active: bool}`. `callPop` checks it on start and every 10 minutes and only runs the 15s `/calls/active` poll while the gateway is configured and active. An unconfigured clinic now costs one probe per 10 minutes instead of a request every 15 seconds. Errors on the probe are treated as inactive-and-quiet, re-probed at the next window.
3. **Bounded `seen` set** — capped at 200, oldest half dropped (insertion-order Set iteration); entries only need to outlive the minutes-scale `/calls/active` window anyway.

Also: thanks again for the `MissingGreenlet` and `depends_on` catches on #349 — both lessons are baked into how I'll write the next module.

Telephony suite 17/17 locally (incl. the new race + status tests), ruff/eslint clean.

Refs #64.