### PR TITLE
chore(docker): frontend + docs-portal images on node:22-alpine, pinned by digest (#367)

### DIFF
--- a/docs/portal/Dockerfile
+++ b/docs/portal/Dockerfile
@@ -16,7 +16,7 @@
 #   - TLS:               Coolify (Let's Encrypt)
 
 # ---- Builder ----------------------------------------------------------------
-FROM node:20-alpine AS builder
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS builder
 WORKDIR /build
 
 # Copy the entire docs tree so VitePress can read it.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@
 # `npm run build` at image-build time with the default Node heap — the
 # 34-layer × 9-locale Nitro build needs >4GB (see Dockerfile.prod) — and
 # then discarded the output, because the dev container runs `npm run dev`.
-FROM node:20-alpine AS dev
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS dev
 
 WORKDIR /app
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS builder
 
 ARG API_BASE_URL=http://localhost:8000
 ENV API_BASE_URL=$API_BASE_URL
@@ -23,7 +23,7 @@ ENV NODE_OPTIONS="--max-old-space-size=6144"
 RUN npm run build
 
 
-FROM node:20-alpine
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32
 
 USER node
 


### PR DESCRIPTION
The four `FROM node:20-alpine` lines (`frontend/Dockerfile` dev, both `Dockerfile.prod` stages, and the `docs/portal` builder the issue asked to check) → `node:22-alpine@sha256:c610fc…` — today's multi-arch index digest, same pin-by-digest policy #371 applies to the backend image.

**Heap-budget check:** the e2e job's production build (`NODE_OPTIONS=--max-old-space-size=6144` + the RSS gate) has been running on Node 22 since #363 and passes, so the Nitro build fits; I could not docker-build locally (no Docker on this machine), so a `docker compose build frontend` on your side is the remaining proof for the image itself.

**On the #352 hygiene items I said I'd fold in** — investigated, nothing to commit:
- `npm audit fix` (non-force) would churn 318 packages and **still leave all 36 findings** — every remaining advisory needs a major bump (`--force`: vite/vitest/devtools majors), which is a deliberate upgrade, not hygiene. Details on #352.
- The Nuxt 3 → 4 and BSL wording fixes are already on main (the nine-language README pass in #314 reworded both); the only "Nuxt 3" left is in historical planning docs (`mvp-plan.md`, `todos.md`).

Closes #367.