### PR TITLE
fix(payments): post-merge follow-ups from #370 — concurrent idempotency race, IN methods in CollectAmountModal (#365)

### DIFF
--- a/backend/app/modules/payments/CHANGELOG.md
+++ b/backend/app/modules/payments/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(#365): the two post-merge follow-ups from #370 — two *concurrent* `record_payment` calls with one `idempotency_key` no longer 500 on the unique index (savepoint + `IntegrityError` → the loser adopts the winner's row), and the shared `CollectAmountModal` (budget / invoice collect flows) offers `upi` / `netbanking` behind the same IN gate; `useClinicCountry()` moved to the host so host and layer components share one gate.
+
 - feat(#365): payment-gateway prerequisites — `upi` + `netbanking` methods (IN-gated chip in the create modal, labels in all 9 locales); four `payments.*` extension slots (`collect.actions`, `list.row.meta`, `ledger.row.meta`, `detail.sections`) rendering nothing by default; `idempotency_key` on `record_payment` / `POST /payments` / the agent tool with a per-clinic partial unique index (`pay_0005`). The IN gate also covers the list's method filter (`useClinicCountry`), and the refund modal always offers the source payment's method.
 
 - fix(#126): ledger treatment names had a bare es → en fallback — items named only in other locales degraded to nothing; now resolved through the shared `app.core.i18n_names.catalog_name` chain with an any-non-empty catch-all.

--- a/backend/app/modules/payments/CLAUDE.md
+++ b/backend/app/modules/payments/CLAUDE.md
@@ -135,7 +135,12 @@ the public endpoints.
   hit returns the existing payment *before* any validation — the
   caller's retry gets the original row, allocations untouched. Unique
   per clinic via a partial index (`NOT NULL` only); `None`/empty never
-  collides.
+  collides. Two *concurrent* calls both miss that pre-check — the INSERT
+  runs in a savepoint and the `IntegrityError` loser re-reads and returns
+  the winner's row, so a gateway webhook retry storm is always safe.
+- **`useClinicCountry()` lives in the host** (`frontend/app/composables`),
+  not this layer: the shared `CollectAmountModal` needs the same IN gate
+  and host components can't import from a layer.
 
 - **No `is_voided` flag.** Total reverso is `Refund(amount=Payment.amount)`.
   Don't reintroduce the legacy flag — the report stack relies on

--- a/backend/app/modules/payments/workflow.py
+++ b/backend/app/modules/payments/workflow.py
@@ -14,6 +14,7 @@ from decimal import Decimal
 from uuid import UUID
 
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.events import EventType, event_bus
@@ -159,8 +160,28 @@ async def record_payment(
         recorded_by=recorded_by,
         idempotency_key=idempotency_key or None,
     )
-    db.add(payment)
-    await db.flush()  # need payment.id for allocations
+    if idempotency_key:
+        # Two *concurrent* calls with the same key both miss the pre-check
+        # above; the partial unique index arbitrates. Savepoint so the
+        # loser's failed INSERT doesn't poison the caller's transaction,
+        # then adopt the winner's row — same shape as telephony's ingest.
+        try:
+            async with db.begin_nested():
+                db.add(payment)
+                await db.flush()
+        except IntegrityError:
+            winner = (
+                await db.execute(
+                    select(Payment).where(
+                        Payment.clinic_id == clinic_id,
+                        Payment.idempotency_key == idempotency_key,
+                    )
+                )
+            ).scalar_one()
+            return winner
+    else:
+        db.add(payment)
+        await db.flush()  # need payment.id for allocations
 
     created_allocations: list[PaymentAllocation] = []
     for spec in allocations:

--- a/backend/tests/modules/payments/test_payment_create.py
+++ b/backend/tests/modules/payments/test_payment_create.py
@@ -240,3 +240,57 @@ async def test_india_methods_accepted(
         )
         assert resp.status_code == 201, resp.text
         assert resp.json()["data"]["method"] == method
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_concurrent_race_adopts_winner(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    monkeypatch,
+):
+    """Two concurrent record_payment calls with one key: the loser of the
+    unique index must return the winner's payment, not 500 (#365 follow-up)."""
+    from sqlalchemy import text
+
+    from app.modules.payments import workflow as wf
+
+    setup = await _setup_clinic(db_session, auth_headers, client)
+    original = wf._validate_allocations_for_clinic
+
+    async def validate_then_race(db, clinic_id, allocations):
+        # Runs after the pre-check SELECT and before the INSERT — inject the
+        # concurrent writer's row here so our INSERT collides.
+        await original(db, clinic_id, allocations)
+        await db.execute(
+            text(
+                "INSERT INTO payments (id, clinic_id, patient_id, amount, currency, method, "
+                " payment_date, recorded_by, idempotency_key, created_at, updated_at) "
+                "VALUES (gen_random_uuid(), :clinic, :patient, 80.00, 'EUR', 'card', "
+                " CURRENT_DATE, :user, 'gw-race-1', now(), now())"
+            ),
+            {
+                "clinic": setup["clinic_id"],
+                "patient": setup["patient_id"],
+                "user": setup["user_id"],
+            },
+        )
+
+    monkeypatch.setattr(wf, "_validate_allocations_for_clinic", validate_then_race)
+    resp = await client.post(
+        f"/api/v1/payments?clinic_id={setup['clinic_id']}",
+        headers=auth_headers,
+        json={
+            "patient_id": setup["patient_id"],
+            "amount": "80.00",
+            "method": "card",
+            "payment_date": date.today().isoformat(),
+            "allocations": [{"target_type": "on_account", "amount": "80.00"}],
+            "idempotency_key": "gw-race-1",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    listing = await client.get(
+        f"/api/v1/payments?clinic_id={setup['clinic_id']}", headers=auth_headers
+    )
+    assert listing.json()["total"] == 1

--- a/frontend/app/components/shared/CollectAmountModal.vue
+++ b/frontend/app/components/shared/CollectAmountModal.vue
@@ -50,14 +50,23 @@ interface MethodOption {
   icon: string
 }
 
-const METHODS: MethodOption[] = [
+// India-only methods appear for clinics whose server-side country is IN
+// (#365) — same gate as PaymentCreateModal / the payments list filter.
+const clinicCountry = useClinicCountry()
+const METHODS = computed<MethodOption[]>(() => [
   { value: 'cash', icon: 'i-lucide-banknote' },
   { value: 'card', icon: 'i-lucide-credit-card' },
   { value: 'bank_transfer', icon: 'i-lucide-landmark' },
   { value: 'direct_debit', icon: 'i-lucide-repeat' },
   { value: 'insurance', icon: 'i-lucide-shield' },
+  ...(clinicCountry.value === 'IN'
+    ? [
+        { value: 'upi' as PaymentMethod, icon: 'i-lucide-smartphone-nfc' },
+        { value: 'netbanking' as PaymentMethod, icon: 'i-lucide-landmark' }
+      ]
+    : []),
   { value: 'other', icon: 'i-lucide-more-horizontal' }
-]
+])
 
 const todayIso = () => new Date().toISOString().slice(0, 10)
 

--- a/frontend/app/composables/useClinicCountry.ts
+++ b/frontend/app/composables/useClinicCountry.ts
@@ -1,6 +1,10 @@
 /**
  * Server-side clinic country (ISO alpha-2) for method gating (#365).
  *
+ * Lives in the host (not the payments layer) because the shared
+ * ``CollectAmountModal`` needs the same gate and a host component cannot
+ * import from a module layer; layers auto-import it by name as before.
+ *
  * Read the same way ``india_gst``'s slot gate does — top-level
  * ``clinic.country`` or the legacy ``settings.country`` — never a
  * client-editable field. The shared ``Clinic`` type doesn't surface the


### PR DESCRIPTION
The two non-blocking follow-ups from the #370 merge review.

1. **Concurrent same-key race** — two `record_payment` calls with one `idempotency_key` both miss the pre-check SELECT and the second died on the partial unique index as a raw 500. The INSERT now runs in a savepoint; the `IntegrityError` loser re-reads and returns the winner's row (money was already safe, the retry is now graceful too). Same shape as the telephony ingest fix in #366. The test injects the competing row between the pre-check and the INSERT (via a patched `_validate_allocations_for_clinic`) and asserts 201 + `total == 1`.
2. **`CollectAmountModal`** (shared host component behind the budget / invoice collect flows) now offers `upi` / `netbanking` behind the same IN gate as the create modal and the list filter. Because a host component can't import from the payments layer, `useClinicCountry()` moves to `frontend/app/composables/` — layers auto-import it by name, so the two existing call sites are unchanged (documented in the payments CLAUDE.md gotchas).

Payments suite green (incl. the new race test), ruff/eslint clean, full `nuxt typecheck` over all layers clean.

Refs #365.