### PR TITLE
ci(frontend): npm ci instead of npm install so a drifted lockfile fails CI (#388)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Install portal dependencies
         working-directory: docs/portal
-        run: npm install --no-audit --no-fund
+        run: npm ci --no-audit --no-fund
 
       - name: Build portal
         working-directory: docs/portal
@@ -244,8 +244,12 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
+        # `npm ci`, never `npm install`, in CI (#388): install silently
+        # repairs a drifted package-lock.json and passes, then the
+        # release image's `npm ci` fails on the same lock. ci validates
+        # lock/package.json sync and is the npm twin of python-lock-freshness.
         working-directory: frontend
-        run: npm install
+        run: npm ci --no-audit --no-fund
 
       - name: Run ESLint
         working-directory: frontend
@@ -267,7 +271,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: frontend
-        run: npm install
+        run: npm ci --no-audit --no-fund
 
       - name: modules.json with every layer
         working-directory: frontend
@@ -289,7 +293,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: frontend
-        run: npm install
+        run: npm ci --no-audit --no-fund
 
       - name: Run tests
         working-directory: frontend
@@ -357,7 +361,7 @@ jobs:
       - name: Install frontend deps + Playwright browsers
         working-directory: frontend
         run: |
-          npm install
+          npm ci --no-audit --no-fund
           npx playwright install --with-deps chromium
 
       - name: Generate modules.json with host paths

--- a/docs/portal/Dockerfile
+++ b/docs/portal/Dockerfile
@@ -24,10 +24,9 @@ COPY docs/ ./docs/
 
 WORKDIR /build/docs/portal
 
-# Install deps and build the static site.
-# We use `npm install` rather than `npm ci` until a package-lock.json is
-# committed; the lockfile lands in a follow-up PR once the dep set settles.
-RUN npm install --no-audit --no-fund \
+# Install deps from the committed lockfile and build the static site
+# (`npm ci` fails on a drifted lock instead of silently repairing it — #388).
+RUN npm ci --no-audit --no-fund \
  && npm run build
 
 # ---- Runtime ----------------------------------------------------------------


### PR DESCRIPTION
Exactly the fix the issue proposes.

- All five frontend CI jobs (`frontend-lint`, `frontend-test`, `frontend-typecheck`, `docs-portal-build`, `e2e`) install with **`npm ci --no-audit --no-fund`** instead of `npm install`. `npm ci` refuses a `package-lock.json` that is out of sync with `package.json` — the same check `Dockerfile.prod` runs — so the #375 drift now fails on the PR instead of at release-image time. Also faster and deterministic. A comment on the first install step explains the rule.
- `docs/portal/Dockerfile` moves to `npm ci` too: its comment said "until a package-lock.json is committed", and the lockfile has been committed for a while (`npm ci --dry-run` passes there today).
- No separate `npm-lock-freshness` job: `npm ci` in every job *is* the guard, and there's no job that legitimately needs `npm install` (the e2e job only adds Playwright browsers via `npx playwright install`, which doesn't touch the lock).
- `frontend/Dockerfile` (dev image) deliberately keeps `npm install` — that's the image people add packages inside; the prod image already uses `npm ci`.

Verified both lockfiles are in sync on current main (`npm ci --dry-run` clean in `frontend/` and `docs/portal/`), so this turns green immediately and bites only on the next drift.

Closes #388.