### PR TITLE
ci(frontend): install with npm ci so lockfile drift fails CI (issue #388)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Install portal dependencies
         working-directory: docs/portal
-        run: npm install --no-audit --no-fund
+        run: npm ci --no-audit --no-fund
 
       - name: Build portal
         working-directory: docs/portal
@@ -245,7 +245,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: frontend
-        run: npm install
+        run: npm ci --no-audit --no-fund
 
       - name: Run ESLint
         working-directory: frontend
@@ -267,7 +267,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: frontend
-        run: npm install
+        run: npm ci --no-audit --no-fund
 
       - name: modules.json with every layer
         working-directory: frontend
@@ -289,7 +289,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: frontend
-        run: npm install
+        run: npm ci --no-audit --no-fund
 
       - name: Run tests
         working-directory: frontend
@@ -357,7 +357,7 @@ jobs:
       - name: Install frontend deps + Playwright browsers
         working-directory: frontend
         run: |
-          npm install
+          npm ci --no-audit --no-fund
           npx playwright install --with-deps chromium
 
       - name: Generate modules.json with host paths


### PR DESCRIPTION
## Overview

- Every frontend CI job installed with `npm install`, which silently repairs a
  drifted lockfile — so PR #375 shipped a lockfile that broke `npm ci` in
  `frontend/Dockerfile.prod` (the release-image path) with all CI green.
- This switches all five `npm install` sites in `ci.yml` to
  `npm ci --no-audit --no-fund`, so lockfile drift fails CI instead of the
  next tag build. No job adds packages at install time (Playwright browsers
  come from `npx playwright install`), so no job keeps `npm install`.

## Tasks done

- `ci(frontend): install with npm ci so lockfile drift fails CI` — `ci.yml`
  (docs-portal, frontend-lint, frontend-typecheck, frontend-test, e2e).

## Modules touched

- none (core/infra change).

## Checklist

- [x] PR title follows Conventional Commits
- [x] `scripts/dev-verify.sh --fast` green locally (8 pass; only the known
  MSYS `modules-json-freshness` toolchain flake, CI-authoritative)
- [x] YAML parses (12 jobs); no bare `npm install` left in `ci.yml`

## Test plan

- CI on this PR is the authority for workflow changes: the frontend jobs
  themselves exercise the new `npm ci` steps against the committed lockfiles.
- To prove the guard works, a follow-up with a deliberately drifted lockfile
  should fail `frontend-lint` at the install step.

## Closes

- Closes #388 (refs #375 where it bit, #371 for the uv-side precedent).

## Review

`@martinezsalmeron` for review/merge when convenient.
