### PR TITLE
feat(payroll): delete empty draft periods and draft entries (issue #390)

### DIFF
--- a/backend/app/modules/payroll/CHANGELOG.md
+++ b/backend/app/modules/payroll/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Draft corrections (issue #390): `DELETE /entries/{id}` and
+  `DELETE /periods/{id}` (204, `payroll.write`) — entries delete while
+  their period is draft (409 after close); periods delete while draft
+  AND empty (409 otherwise). Closed/paid records stay immutable.
 - Initial module (roadmap issue #229, approved v1): staff payroll with
   encrypted bank/tax data, monthly periods, raw entries, reports.
 - 3 tables on own Alembic branch (`payr_0001`, no `depends_on`):

--- a/backend/app/modules/payroll/CLAUDE.md
+++ b/backend/app/modules/payroll/CLAUDE.md
@@ -17,10 +17,12 @@ Routes mounted at `/api/v1/payroll/` (all `payroll.*`-gated, admin only).
 - `POST   /periods`           — open a `YYYY-MM` draft period (201); `payroll.write`
 - `GET    /periods/{id}`      — single period; `payroll.read`
 - `POST   /periods/{id}/status` — draft → closed → paid; `payroll.write`
+- `DELETE /periods/{id}`      — delete an empty draft period (204); `payroll.write`
 - `GET    /periods/{id}/entries` — entries of a period; `payroll.read`
 - `POST   /entries`           — raw entry (201, draft periods only); `payroll.write`
 - `GET    /entries/{id}`      — single entry; `payroll.read`
 - `PATCH  /entries/{id}`      — edit a draft entry; `payroll.write`
+- `DELETE /entries/{id}`      — delete a draft entry (204); `payroll.write`
 - `GET    /reports/monthly?month=` — period rollup; `payroll.reports.read`
 - `GET    /reports/annual?year=`   — year rollup; `payroll.reports.read`
 
@@ -86,8 +88,11 @@ roundtrip uninstall test.
 - **Entries mutate only in draft periods** (409 otherwise); periods move
   strictly draft → closed → paid (409 on skips).
 - **`net` is validated, not computed** — unbalanced books are a 422.
-- **No hard deletes anywhere** — profiles deactivate via `is_active`;
-  periods/entries are immutable records (L7).
+- **No hard deletes except draft corrections (issue #390).** Profiles
+  deactivate via `is_active`; `DELETE /entries/{id}` and
+  `DELETE /periods/{id}` (204) work only in `draft` periods (409
+  otherwise; non-empty periods 409). Closed/paid records stay immutable
+  (L7).
 
 ## CHANGELOG
 

--- a/backend/app/modules/payroll/router.py
+++ b/backend/app/modules/payroll/router.py
@@ -153,6 +153,18 @@ async def transition_period(
     return ApiResponse(data=PayrollPeriodResponse.model_validate(row))
 
 
+@router.delete("/periods/{period_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_period(
+    period_id: UUID,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("payroll.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> None:
+    """Delete an empty draft period (issue #390). 409 when closed/paid or
+    when entries exist; the lookup is clinic-scoped so foreign ids are 404."""
+    await PeriodService.delete_period(db, ctx.clinic_id, period_id)
+
+
 # ---------------------------------------------------------------------------
 # Entries
 # ---------------------------------------------------------------------------
@@ -217,6 +229,21 @@ async def update_entry(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found")
     row = await EntryService.update_entry(db, row, data)
     return ApiResponse(data=PayrollEntryResponse.model_validate(row))
+
+
+@router.delete("/entries/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_entry(
+    entry_id: UUID,
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("payroll.write"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> None:
+    """Delete a draft-period entry (issue #390) — e.g. added to the wrong
+    user. 409 once the period leaves draft."""
+    row = await EntryService.get_entry(db, ctx.clinic_id, entry_id)
+    if not row:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found")
+    await EntryService.delete_entry(db, row)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/modules/payroll/service.py
+++ b/backend/app/modules/payroll/service.py
@@ -250,6 +250,39 @@ class PeriodService:
         )
         return row
 
+    @staticmethod
+    async def delete_period(db: AsyncSession, clinic_id: UUID, period_id: UUID) -> None:
+        """Delete an EMPTY draft period (issue #390).
+
+        Closed/paid periods are formal records and stay immutable; a period
+        with entries keeps them addressable. No event: drafts are pre-formal.
+        """
+        row = await PeriodService.get_period(db, clinic_id, period_id)
+        if row is None:
+            raise HTTPException(http_status.HTTP_404_NOT_FOUND, "period not found")
+        if row.status != "draft":
+            raise HTTPException(
+                http_status.HTTP_409_CONFLICT,
+                "only draft periods can be deleted",
+            )
+        entry_count = (
+            await db.execute(
+                select(func.count())
+                .select_from(PayrollEntry)
+                .where(
+                    PayrollEntry.clinic_id == clinic_id,
+                    PayrollEntry.period_id == period_id,
+                )
+            )
+        ).scalar_one()
+        if entry_count:
+            raise HTTPException(
+                http_status.HTTP_409_CONFLICT,
+                "period has entries; remove them first",
+            )
+        await db.delete(row)
+        await db.commit()
+
 
 def _assert_balanced(gross: Decimal, deductions: Decimal, net: Decimal) -> None:
     if net != gross - deductions:
@@ -328,6 +361,15 @@ class EntryService:
         await db.commit()
         await db.refresh(row)
         return row
+
+    @staticmethod
+    async def delete_entry(db: AsyncSession, row: PayrollEntry) -> None:
+        """Delete a draft-period entry (issue #390) — e.g. added to the wrong
+        user. Reuses the draft guard: 404 on a missing period, 409 once the
+        period leaves draft."""
+        await EntryService._assert_draft_period(db, row.clinic_id, row.period_id)
+        await db.delete(row)
+        await db.commit()
 
     @staticmethod
     async def list_entries(

--- a/backend/tests/modules/payroll/test_payroll.py
+++ b/backend/tests/modules/payroll/test_payroll.py
@@ -282,3 +282,88 @@ async def test_http_masked_and_admin_only(
     assert (
         await client.get("/api/v1/payroll/reports/annual?year=2026", headers=headers)
     ).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_entry_draft_only(db_session: AsyncSession, test_clinic: Clinic):
+    # Bind ids upfront (M15): rollbacks below expire every instance.
+    clinic_id = test_clinic.id
+    user = await _make_user(db_session, clinic_id)
+    user_id = user.id
+    period = await _make_period(db_session, clinic_id)
+    period_id = period.id
+    entry = await _make_entry(db_session, clinic_id, period_id, user_id)
+    entry_id = entry.id
+    # Draft entry deletes cleanly and is gone afterwards.
+    await EntryService.delete_entry(db_session, entry)
+    assert await EntryService.get_entry(db_session, clinic_id, entry_id) is None
+    # Re-add, close the period: the delete now conflicts.
+    entry = await _make_entry(db_session, clinic_id, period_id, user_id)
+    entry_id = entry.id
+    period = await PeriodService.get_period(db_session, clinic_id, period_id)
+    assert period is not None
+    await PeriodService.transition(db_session, period, PeriodTransition(status="closed"))
+    entry = await EntryService.get_entry(db_session, clinic_id, entry_id)
+    assert entry is not None
+    with pytest.raises(HTTPException) as exc:
+        await EntryService.delete_entry(db_session, entry)
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_delete_period_empty_draft_only(db_session: AsyncSession, test_clinic: Clinic):
+    clinic_id = test_clinic.id
+    user = await _make_user(db_session, clinic_id)
+    user_id = user.id
+    # Unknown ids are 404 (never leak existence across clinics).
+    with pytest.raises(HTTPException) as exc:
+        await PeriodService.delete_period(db_session, clinic_id, uuid4())
+    assert exc.value.status_code == 404
+    # A period with entries cannot go even while draft.
+    full = await _make_period(db_session, clinic_id, "2026-01")
+    full_id = full.id
+    await _make_entry(db_session, clinic_id, full_id, user_id)
+    with pytest.raises(HTTPException) as exc:
+        await PeriodService.delete_period(db_session, clinic_id, full_id)
+    assert exc.value.status_code == 409
+    # An empty draft period deletes; a closed one conflicts.
+    empty = await _make_period(db_session, clinic_id, "2026-02")
+    empty_id = empty.id
+    await PeriodService.delete_period(db_session, clinic_id, empty_id)
+    assert await PeriodService.get_period(db_session, clinic_id, empty_id) is None
+    doomed = await _make_period(db_session, clinic_id, "2026-03")
+    doomed_id = doomed.id
+    doomed = await PeriodService.transition(db_session, doomed, PeriodTransition(status="closed"))
+    with pytest.raises(HTTPException) as exc:
+        await PeriodService.delete_period(db_session, clinic_id, doomed_id)
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_http_delete_draft_guards(
+    client: AsyncClient, auth_headers: dict, test_clinic: Clinic, db_session: AsyncSession
+):
+    clinic_id = test_clinic.id
+    user = await _make_user(db_session, clinic_id)
+    period = await _make_period(db_session, clinic_id)
+    entry = await _make_entry(db_session, clinic_id, period.id, user.id)
+    entry_id, period_id = entry.id, period.id
+    # Entry deletes with 204 while draft; unknown ids 404.
+    gone = await client.delete(f"/api/v1/payroll/entries/{entry_id}", headers=auth_headers)
+    assert gone.status_code == 204, gone.text
+    assert await EntryService.get_entry(db_session, clinic_id, entry_id) is None
+    assert (
+        await client.delete(f"/api/v1/payroll/entries/{uuid4()}", headers=auth_headers)
+    ).status_code == 404
+    # Empty draft period deletes with 204; unknown ids 404.
+    assert (
+        await client.delete(f"/api/v1/payroll/periods/{period_id}", headers=auth_headers)
+    ).status_code == 204
+    assert (
+        await client.delete(f"/api/v1/payroll/periods/{uuid4()}", headers=auth_headers)
+    ).status_code == 404
+    # Closed periods refuse with 409.
+    period = await _make_period(db_session, clinic_id, "2026-04")
+    period = await PeriodService.transition(db_session, period, PeriodTransition(status="closed"))
+    closed = await client.delete(f"/api/v1/payroll/periods/{period.id}", headers=auth_headers)
+    assert closed.status_code == 409, closed.text

--- a/backend/tests/modules/payroll/test_payroll.py
+++ b/backend/tests/modules/payroll/test_payroll.py
@@ -367,3 +367,15 @@ async def test_http_delete_draft_guards(
     period = await PeriodService.transition(db_session, period, PeriodTransition(status="closed"))
     closed = await client.delete(f"/api/v1/payroll/periods/{period.id}", headers=auth_headers)
     assert closed.status_code == 409, closed.text
+    # Entries of a closed period refuse with 409 at HTTP level too: create
+    # while draft, close, then delete.
+    late = await _make_period(db_session, clinic_id, "2026-05")
+    late_id = late.id
+    user2 = await _make_user(db_session, clinic_id)
+    stuck = await _make_entry(db_session, clinic_id, late_id, user2.id)
+    stuck_id = stuck.id
+    late = await PeriodService.get_period(db_session, clinic_id, late_id)
+    assert late is not None
+    await PeriodService.transition(db_session, late, PeriodTransition(status="closed"))
+    blocked = await client.delete(f"/api/v1/payroll/entries/{stuck_id}", headers=auth_headers)
+    assert blocked.status_code == 409, blocked.text

--- a/docs/technical/payroll/overview.md
+++ b/docs/technical/payroll/overview.md
@@ -76,8 +76,11 @@ are invisible (404, never 403).
 ## Constraints
 
 Own Alembic branch (`payroll`); `manifest.depends = []`. No agent
-tools. No hard deletes — profiles deactivate, periods/entries are
-immutable records.
+tools. No hard deletes except draft corrections (issue #390):
+`DELETE /entries/{id}` and `DELETE /periods/{id}` (both 204,
+`payroll.write`) work only while the period is `draft` — 409 once
+closed/paid, 409 for a period that still has entries. Profiles
+deactivate; closed/paid records stay immutable.
 
 See [`./permissions.md`](./permissions.md) and [`./events.md`](./events.md)
 for full detail.

--- a/docs/technical/payroll/overview.md
+++ b/docs/technical/payroll/overview.md
@@ -1,6 +1,6 @@
 ---
 module: payroll
-last_verified_commit: 0f333000
+last_verified_commit: 14ec616c
 ---
 
 # payroll — overview
@@ -29,10 +29,12 @@ Routes:
 - `POST /api/v1/payroll/periods` — open a draft period (201)
 - `GET /api/v1/payroll/periods/{id}` — one period
 - `POST /api/v1/payroll/periods/{id}/status` — draft → closed → paid
+- `DELETE /api/v1/payroll/periods/{id}` — delete an empty draft period (204)
 - `GET /api/v1/payroll/periods/{id}/entries` — entries of a period
 - `POST /api/v1/payroll/entries` — raw entry (201, draft only)
 - `GET /api/v1/payroll/entries/{id}` — one entry
 - `PATCH /api/v1/payroll/entries/{id}` — edit a draft entry
+- `DELETE /api/v1/payroll/entries/{id}` — delete a draft entry (204)
 - `GET /api/v1/payroll/reports/monthly?month=` — period rollup
 - `GET /api/v1/payroll/reports/annual?year=` — year rollup
 

--- a/docs/technical/payroll/permissions.md
+++ b/docs/technical/payroll/permissions.md
@@ -1,6 +1,6 @@
 ---
 module: payroll
-last_verified_commit: 0f333000
+last_verified_commit: 14ec616c
 ---
 
 # payroll — permissions

--- a/docs/technical/payroll/permissions.md
+++ b/docs/technical/payroll/permissions.md
@@ -11,7 +11,7 @@ Returned by `PayrollModule.get_permissions()`
 | Permission | Allows | Required by |
 |------------|--------|-------------|
 | `payroll.read` | List and view profiles, periods, entries | `GET /api/v1/payroll/profiles`, `GET /api/v1/payroll/profiles/{id}`, `GET /api/v1/payroll/periods`, `GET /api/v1/payroll/periods/{id}`, `GET /api/v1/payroll/periods/{id}/entries`, `GET /api/v1/payroll/entries/{id}` |
-| `payroll.write` | Create/edit profiles, periods, entries; transitions | `POST /api/v1/payroll/profiles`, `PATCH /api/v1/payroll/profiles/{id}`, `POST /api/v1/payroll/periods`, `POST /api/v1/payroll/periods/{id}/status`, `POST /api/v1/payroll/entries`, `PATCH /api/v1/payroll/entries/{id}` |
+| `payroll.write` | Create/edit/delete-draft profiles, periods, entries; transitions | `POST /api/v1/payroll/profiles`, `PATCH /api/v1/payroll/profiles/{id}`, `POST /api/v1/payroll/periods`, `POST /api/v1/payroll/periods/{id}/status`, `DELETE /api/v1/payroll/periods/{id}` (empty draft only, 409 otherwise), `POST /api/v1/payroll/entries`, `PATCH /api/v1/payroll/entries/{id}`, `DELETE /api/v1/payroll/entries/{id}` (draft only, 409 otherwise) |
 | `payroll.reports.read` | Read monthly/annual rollups | `GET /api/v1/payroll/reports/monthly`, `GET /api/v1/payroll/reports/annual` |
 
 ## Role assignment


### PR DESCRIPTION
## Overview

- Follow-up to #383 (payroll v1): the "no hard deletes" rule made draft
  corrections impossible ,an entry added to the wrong user, or a period
  opened for the wrong month, could never be removed.
- This adds draft-only deletes: `DELETE /entries/{id}` and
  `DELETE /periods/{id}` (both 204, `payroll.write`). Entries delete
  while their period is `draft` (409 after close, reusing
  `EntryService._assert_draft_period`); periods delete while `draft`
  AND empty (409 otherwise). Closed/paid records stay immutable, no
  events (drafts are pre-formal), no schema change.

## Tasks done

- `feat(payroll): delete empty draft periods and draft entries` ,
  service guards + both DELETE routes (204) + 3 tests (2 service +
  1 HTTP) + docs (`overview`, `permissions`, module CLAUDE.md +
  CHANGELOG `## Unreleased`)
- `fix(payroll): reviewer follow-ups` — routes index entries,
  `last_verified_commit` stamps, HTTP entry-409 assertion

## Modules touched

- `payroll` only (`manifest.depends = []`, no cross-module touch).

## Checklist

- [x] PR title follows Conventional Commits
- [x] `scripts/dev-verify.sh --with-pytest --module payroll` green
  (12/12 incl. 3 new + alembic roundtrip; lint/manifest/catalog/
  coverage/typecheck PASS; remaining FAILs are documented local
  toolchain flakes on a backend-only branch — nprogress/jsdom teardown,
  MSYS `modules-json`, VitePress `?`-path — CI-authoritative)
- [x] Reviewer pass: 0 blocks (2 shoulds + 1 nit, all fixed and the
  battery re-run green)

## Test plan

- Open a draft period, add an entry to the wrong user, `DELETE` it
  (204), delete the empty period (204). Close a period and confirm
  both deletes 409; unknown ids 404.

## Closes

- Closes #390 (follow-up to #383, roadmap #229).

## Review

`@martinezsalmeron` for review/merge when convenient.
