### PR TITLE
fix(ui): discount-type and state-filter selects crashed on open (empty-string item value)

### DIFF
--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: the discount-type select in the invoice item modals crashed on open — reka-ui rejects `''` as an item value; the 'no discount' option now uses `null`.
+
 - fix(#326): the invoice-series onboarding rule carries `permission: 'billing.read'` — it no longer renders or fires its load for a clinic where billing isn't active.
 
 - refactor(#126): invoice-line descriptions resolve catalog names through the shared `app.core.i18n_names.catalog_name` helper (same chain, one source of truth).

--- a/backend/app/modules/billing/frontend/components/billing/InvoiceItemModal.vue
+++ b/backend/app/modules/billing/frontend/components/billing/InvoiceItemModal.vue
@@ -349,7 +349,7 @@ watch(open, async (isOpen) => {
                 <USelectMenu
                   v-model="form.discount_type"
                   :items="[
-                    { label: '-', value: '' },
+                    { label: '-', value: null },
                     { label: t('budget.percentage'), value: 'percentage' },
                     { label: t('budget.absolute'), value: 'absolute' }
                   ]"

--- a/backend/app/modules/billing/frontend/components/billing/NewInvoiceItemModal.vue
+++ b/backend/app/modules/billing/frontend/components/billing/NewInvoiceItemModal.vue
@@ -271,7 +271,7 @@ watch(() => props.open, async (isOpen) => {
                 <USelectMenu
                   v-model="form.discount_type"
                   :items="[
-                    { label: '-', value: '' },
+                    { label: '-', value: null },
                     { label: t('budget.percentage'), value: 'percentage' },
                     { label: t('budget.absolute'), value: 'absolute' }
                   ]"

--- a/backend/app/modules/budget/CHANGELOG.md
+++ b/backend/app/modules/budget/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: the discount-type selects (item modal and global discount in the budget detail page) crashed on open — reka-ui rejects `''` as an item value (`A <ComboboxItem /> must have a value prop that is not an empty string`), which left the modal half-unmounted (`Cannot read properties of null (reading 'parentNode')`). The 'no discount' option now uses `null`.
+
 - feat(i18n): the frontend layer's directional spacing, borders, text alignment and inset positioning now resolve against the document direction (physical→logical CSS utilities, Arabic RTL support).
 
 - fix(#101): the module's frontend adopts the useApi error contract — 400/409/422 failures the UI used to swallow now toast the backend's message; calls whose surrounding code already presents the error pass `errorToast: false` (single toast), and hand-built error reads use the shared `errorMessage`/`errorDetail` helpers.

--- a/backend/app/modules/budget/frontend/components/budget/BudgetItemModal.vue
+++ b/backend/app/modules/budget/frontend/components/budget/BudgetItemModal.vue
@@ -214,7 +214,7 @@ watch(() => props.open, (isOpen) => {
               <USelectMenu
                 v-model="form.discount_type"
                 :items="[
-                  { label: '-', value: '' },
+                  { label: '-', value: null },
                   { label: t('budget.percentage'), value: 'percentage' },
                   { label: t('budget.absolute'), value: 'absolute' }
                 ]"

--- a/backend/app/modules/budget/frontend/pages/budgets/[id].vue
+++ b/backend/app/modules/budget/frontend/pages/budgets/[id].vue
@@ -152,7 +152,7 @@ const isEditing = ref(false)
 const editForm = reactive({
   valid_from: '',
   valid_until: '',
-  global_discount_type: '',
+  global_discount_type: null as string | null,
   global_discount_value: '',
   internal_notes: '',
   patient_notes: ''
@@ -162,7 +162,7 @@ function startEditing() {
   if (!currentBudget.value) return
   editForm.valid_from = currentBudget.value.valid_from
   editForm.valid_until = currentBudget.value.valid_until || ''
-  editForm.global_discount_type = currentBudget.value.global_discount_type || ''
+  editForm.global_discount_type = currentBudget.value.global_discount_type || null
   editForm.global_discount_value = currentBudget.value.global_discount_value?.toString() || ''
   editForm.internal_notes = currentBudget.value.internal_notes || ''
   editForm.patient_notes = currentBudget.value.patient_notes || ''
@@ -735,7 +735,7 @@ function getItemName(item: DeepReadonly<BudgetItem>): string {
                   <USelect
                     v-model="editForm.global_discount_type"
                     :items="[
-                      { label: '-', value: '' },
+                      { label: '-', value: null },
                       { label: t('budget.percentage'), value: 'percentage' },
                       { label: t('budget.absolute'), value: 'absolute' }
                     ]"

--- a/backend/app/modules/nav_online/CHANGELOG.md
+++ b/backend/app/modules/nav_online/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: the records-page state filter's 'all states' option used `''` as its value, which reka-ui rejects in `<SelectItem />`; it now uses `null`.
+
 - feat(#341): initial release — phase 1 of NAV Online Számla reporting:
   `BillingComplianceHook` for HU snapshotting issued invoices / credit
   notes as Online Számla 3.0 `InvoiceData` XML (TAM exemption + 27 %

--- a/backend/app/modules/nav_online/frontend/components/NavOnlineRecordsPage.vue
+++ b/backend/app/modules/nav_online/frontend/components/NavOnlineRecordsPage.vue
@@ -12,10 +12,10 @@ const total = ref(0)
 const page = ref(1)
 const pageSize = 20
 const loading = ref(true)
-const stateFilter = ref('')
+const stateFilter = ref<string | null>(null)
 
 const stateOptions = computed(() => [
-  { value: '', label: t('nav_online.records.allStates') },
+  { value: null, label: t('nav_online.records.allStates') },
   ...['pending', 'sending', 'sent', 'done', 'rejected', 'failed', 'aborted'].map(s => ({
     value: s,
     label: t(`nav_online.state.${s}`)


### PR DESCRIPTION
## Bug

Reported on Telegram: clicking "Tipo de descuento" in `BudgetItemModal` does nothing and the console shows `Cannot read properties of null (reading 'parentNode')`.

Root cause: reka-ui throws in `<ComboboxItem />` / `<SelectItem />` setup when an item's `value` is `''` (*"must have a value prop that is not an empty string"*). The throw leaves the modal half-unmounted, which is where the `parentNode` error comes from.

## Fix

The "no value" option (`{ label: '-', value: '' }` and the nav_online "all states" filter) now uses `null`. Submit paths already coerce falsy discount types to `undefined`, so the API payload is unchanged.

Same pattern fixed in all 5 places it existed:

- budget: `BudgetItemModal`, global discount in `budgets/[id].vue`
- billing: `InvoiceItemModal`, `NewInvoiceItemModal`
- nav_online: `NavOnlineRecordsPage` state filter

## Verification

- Browser: dropdown opens, "Porcentaje" shows the value field, "-" hides it, no console errors. Global discount select in edit mode also checked.
- `npm run lint`: 0 errors.
- `npm run typecheck:layers`: exit 0.

Not touched: both discount selects render very narrow (no `w-full`); cosmetic, separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBgNLJAVSkrjikEuGGL9NU
