### PR TITLE
docs(adr): 0027/0028 — connector route to certified invoicing (PT) and homologated FSE engine (FR); fr_ccam as the French prerequisite (#411)

### DIFF
--- a/docs/adr/0027-portugal-at-certification-and-billing-position.md
+++ b/docs/adr/0027-portugal-at-certification-and-billing-position.md
@@ -94,8 +94,10 @@ obstacle; **self-hosting is**, for two independent reasons:
    cover; the certificate number printed on its invoices would be
    false.
 
-Both objections disappear under one model, and only that one: a
-**certified edition** in which (a) the signing step, and therefore
+Both objections disappear when the certified program is not the one
+the practice runs: the simplest form is a certified invoicing service
+driven through its API (the Decision); the other is a **certified
+edition** in which (a) the signing step, and therefore
 the private key, lives in a service operated by the producer (a
 DentalPin-operated signing endpoint or a partner's), (b) the
 installation sends the five signature fields and receives the
@@ -146,20 +148,37 @@ Everything else in the issue is ordinary work once that model exists:
    may modify, cannot be an AT-certified invoicing program.** The
    blocker is art. 3 b)/d) of Portaria 363/2010 (producer-exclusive
    private key, unalterable program), not the licence.
-2. **DentalPin's position in Portugal is "clinical record and
-   schedule; invoice with a certified program"** until a certified
-   edition exists. The website's Portuguese pages and the country
-   readiness matrix say so plainly; a `PT` clinic sees `billing`'s
-   invoice issuing disabled with that explanation (budgets, treatment
-   plans and payments stay).
-3. The only viable path to invoicing is a **certified edition**:
-   producer-held key behind a remote signing service, a frozen billing
-   code path, ATCUD series webservice, QR code and SAF-T (PT) export,
-   filed for certification by an entity with a Portuguese NIF. This
-   ADR records the shape so the door stays open; it does not commit
-   anyone to building it.
-4. No `pt_at` module is started until a producer decides to run the
-   signing service and file the certification.
+2. **Invoices for a Portuguese practice are issued by a certified
+   invoicing service through its API**, not by DentalPin. Certified
+   SaaS invoicing programs with public REST APIs are the norm for
+   small businesses in Portugal (InvoiceXpress, Moloni, Vendus,
+   TOConline, KeyInvoice, among others); they hold the private key,
+   assign the ATCUD, print the QR and communicate the invoice to AT.
+   DentalPin sends the recipient and the lines, and stores what comes
+   back: the provider's number, ATCUD, signature characters and PDF.
+   The provider's document is the legal invoice; DentalPin's invoice
+   number is an internal reference.
+3. This is a **`PT`-gated connector module (`pt_invoicing`)** in the
+   `verifactu` shape, registered through `BillingHookRegistry`: one
+   provider driver first, others behind the same interface if demand
+   appears. Numbering, ATCUD and PDF come from the provider via the
+   hook, so `billing` learns nothing about Portugal.
+4. **Until the connector exists, DentalPin's position in Portugal is
+   "clinical record and schedule; invoice with a certified program"**:
+   the website's Portuguese pages and the country readiness matrix
+   say so, and a `PT` clinic sees `billing`'s invoice issuing disabled
+   with that explanation (budgets, treatment plans and payments stay).
+5. One question is asked of AT before the connector ships, in
+   writing: whether a program that only feeds a certified program
+   through its API needs a certificate of its own. The market reading
+   is that it does not, because the certified program issues the
+   invoice; the answer is recorded here when it arrives — **open**.
+6. The certified-edition route (producer-held key behind a signing
+   service, frozen billing path, own ATCUD/QR/SAF-T, filed with a
+   Portuguese NIF) stays documented in the Context as the only way
+   for DentalPin itself to be the certified program. It is not
+   pursued: the connector delivers the same outcome for the practice
+   at a subscription instead of a certification programme.
 
 ## Consequences
 
@@ -167,19 +186,32 @@ Everything else in the issue is ordinary work once that model exists:
 
 - The website stops implying something the law forbids, which is the
   outcome the issue asked for in the "no" case.
-- The certified-edition shape is written down with its legal anchors,
-  so a future producer (DentalPin the company, or a Portuguese
-  partner) can cost it instead of re-reading the Portaria.
+- The practice invoices legally from inside DentalPin once the
+  connector exists, with no DentalPin-operated service and no
+  certification filing.
+- The connector pattern (a third party issues, DentalPin mirrors) is
+  the same one France needs for FSE (ADR 0028); the hook interface is
+  shared.
 
 ### Bad / accepted trade-offs
 
-- A Portuguese practice cannot invoice from DentalPin today; the
-  product is weaker in Portugal than the UI translation suggests.
-- The certified edition is a hosted dependency inside a self-hosted
-  product; some users will reject that on principle.
+- A Portuguese practice cannot invoice from DentalPin until the
+  connector ships; the product is weaker in Portugal than the UI
+  translation suggests.
+- The practice pays a second subscription and depends on a commercial
+  provider's API and uptime; DentalPin holds a mirror, not the legal
+  document.
+- The provider's PDF replaces DentalPin's invoice template in
+  Portugal; per-clinic invoice branding is whatever the provider
+  offers.
 
 ## Alternatives considered
 
+- **Certified edition operated by DentalPin.** — Legally sound (the
+  key stays with the producer) but it means a signing service, a
+  frozen billing path, ATCUD/QR/SAF-T and a certification filing by
+  an entity with a Portuguese NIF, for the same practical result the
+  connector gives. Kept in the Context in case a producer wants it.
 - **Certify the self-hosted build and ship the private key with it.**
   — Violates art. 3 b) as read by AT (FAQ R32); the signatures would
   be invalid and the certificate revocable.
@@ -189,17 +221,20 @@ Everything else in the issue is ordinary work once that model exists:
 - **Ignore certification for small practices.** — DL 28/2019 art. 4
   n.º 1 b) applies to anyone using an invoicing program; no volume
   exemption survives (FAQ 4307 for ATCUD).
-- **Build ATCUD/QR/SAF-T now and certify later.** — Wasted until the
-  key/hosting question is decided; the ADR keeps the design instead.
+- **Build ATCUD/QR/SAF-T in DentalPin now and certify later.** —
+  Wasted; in the connector model all three belong to the provider.
 
 ## How to verify the rule still holds
 
-- `docs/technical/country-readiness.md` lists PT billing as "not
-  available: AT certification"; the Portuguese landing page repeats
-  it.
-- Backend test: a clinic with country `PT` gets `409` from the issue
-  endpoint of `billing` with the certification message (once the gate
-  is implemented).
+- `docs/technical/country-readiness.md` lists PT billing as "through
+  a certified invoicing service (connector)"; the Portuguese landing
+  page repeats it.
+- Backend test: a clinic with country `PT` and no connector installed
+  gets `409` from the issue endpoint of `billing` with the
+  certification message (once the gate is implemented).
+- `pt_invoicing` never generates an invoice number, ATCUD, signature
+  or QR locally; every one of them comes from the provider's
+  response.
 
 ## References
 

--- a/docs/adr/0028-france-sesam-vitale-homologation-and-billing-position.md
+++ b/docs/adr/0028-france-sesam-vitale-homologation-and-billing-position.md
@@ -75,7 +75,8 @@ SESAM-Vitale*** from a specialised vendor (several exist; the GIE
 lists them among éditeurs), where the engine vendor holds the
 homologation and DentalPin is the LGC feeding it. Whether the LGC
 still needs its own CNDA attestation when it drives such an engine is
-**open** and is the first question to put to the CNDA.
+**open** on the CNDA pages; the engine vendors' editor programmes
+settle it contractually (Decision 2).
 
 ### 3. Beyond FSE: HDS and Ségur
 
@@ -101,22 +102,48 @@ still needs its own CNDA attestation when it drives such an engine is
    self-hosted open-source product.** The gates are per publisher and
    per version, rest on proprietary workstation components, and would
    not survive a practice modifying its own build.
-2. **DentalPin's position in France is "clinical record, schedule and
-   billing outside the Assurance Maladie flow"**: invoices and paper
-   *feuilles de soins* the patient sends themselves; no FSE, no tiers
-   payant. The French pages and the country readiness matrix say so.
-3. The path to FSE, if a producer wants it, is a **connector module
-   (`FR`-gated) to a homologated billing engine** from a vendor that
-   holds the CNDA/GIE approvals, with the workstation agent supplied
-   by that vendor. The first step is the two open questions to the
-   CNDA (LGC attestation when driving an engine; component
-   distribution model), not code.
-4. **HDS**: self-hosted installations are out of scope of HDS; any
+2. **FSE and tiers payant are reached through a homologated billing
+   engine that its vendor sells as an API to LGC editors** (Stellair
+   Intégral by Olaqin, Pyxvital by Pyxistem, Juxta, among others).
+   The engine vendor holds the CNDA/GIE approvals, the SESAM-Vitale
+   components, the card reader integration and the CPS/e-CPS; the
+   *appli carte Vitale* on the patient's phone reduces the reader
+   dependency further. DentalPin sends the patient and the acts and
+   stores the returned status and NOEMIE returns. In this model the
+   LGC does not fabricate the FSE, so the CNDA attestation question
+   is the engine vendor's to answer in its editor contract; the
+   vendor's editor programme replaces the two questions previously
+   marked open for the CNDA.
+3. This is a **`FR`-gated connector module (`fr_fse`)** registered
+   through `BillingHookRegistry`, in the same shape as Portugal's
+   connector (ADR 0027). No engine is chosen here; the first step is
+   the editor programmes of the vendors above (contract, sandbox,
+   price per practitioner), which is a maintainer task, not code.
+4. **Prerequisite, and the work that starts now: the French
+   nomenclature** — CCAM dental codes and the NGAP acts dentists
+   still bill, tariffs and bases de remboursement, the three 100 %
+   Santé baskets with their honoraires limites de facturation, and
+   the *devis conventionnel*. Without it there is no legal devis and
+   no feuille de soins, paper or electronic. This is module `fr_ccam`
+   (issue #411), `FR`-gated, with no external dependency.
+5. **Until the connector exists, DentalPin's position in France is
+   "clinical record, schedule and billing outside the Assurance
+   Maladie flow"**: invoices and paper *feuilles de soins* the patient
+   sends themselves; no FSE, no tiers payant. The French pages and
+   the country readiness matrix say so. This is not a long-term
+   position: a dentist without télétransmission forfeits the
+   convention's modernisation forfait, pays the paper contribution
+   per feuille, cannot offer tiers payant to Complémentaire santé
+   solidaire beneficiaries in practice, and makes patients wait weeks
+   for reimbursement. Only purely aesthetic or non-conventionné
+   practices live there.
+6. **HDS**: self-hosted installations are out of scope of HDS; any
    hosted offer for French practices requires an HDS-certified host.
    Write this on the French pages instead of hedging.
-5. Ségur referencing (INS, DMP, MSSanté, PSC) is tracked as a separate
-   product decision; it is independent of FSE and does not change
-   points 1–3.
+7. Ségur referencing (INS, DMP, MSSanté, PSC) is tracked as a separate
+   product decision. The engines above typically expose INSi and DMP
+   too, so the connector is the natural place for it later; it does
+   not change points 1–5.
 
 ## Consequences
 
@@ -125,15 +152,21 @@ still needs its own CNDA attestation when it drives such an engine is
 - Clear French positioning; no more "coming soon" for a feature that
   needs a publisher programme we have not entered.
 - The connector route keeps FSE reachable without owning proprietary
-  components or a workstation agent.
+  components or a workstation agent, and the same hook serves
+  Portugal.
+- `fr_ccam` gives French practices a legal devis and correct tariffs
+  before any vendor contract, and is reusable by the connector.
 
 ### Bad / accepted trade-offs
 
-- No tiers payant means a French practice keeps a second tool for
-  billing the Assurance Maladie; DentalPin is a clinical/scheduling
-  product there.
-- The connector route makes FSE depend on a commercial vendor's
-  engine and licence.
+- Until the connector ships, a French practice keeps a second tool
+  for billing the Assurance Maladie; DentalPin is a clinical /
+  scheduling product there.
+- FSE depends on a commercial vendor's engine, contract and per-
+  practitioner subscription; a self-hosted user still needs that
+  vendor account.
+- The nomenclature seed must follow CCAM versions and convention
+  tariff updates; someone owns that refresh.
 
 ## Alternatives considered
 
@@ -144,16 +177,23 @@ still needs its own CNDA attestation when it drives such an engine is
 - **Read the Vitale card only (identity), skip FSE.** — Card reading
   uses the same licensed components and reader; it does not escape
   the programme, and INSi needs a CPS-authenticated call.
+- **Stay at "billing outside the Assurance Maladie flow" for good.**
+  — Leaves DentalPin usable only by a niche of French practices; the
+  connector route is cheap enough to make that the wrong stop.
 - **Ship nothing and say nothing.** — The issue exists because the
   hedging costs credibility; the honest sentence is the deliverable.
 
 ## How to verify the rule still holds
 
 - The country readiness matrix and the French landing page state
-  "billing outside the Assurance Maladie flow; no FSE/tiers payant;
+  "FSE / tiers payant through a homologated engine (connector,
+  pending); until then billing outside the Assurance Maladie flow;
   self-hosted installations outside HDS".
-- No module under `backend/app/modules/` claims SESAM-Vitale
-  capability without a CNDA attestation number in its docs.
+- No module under `backend/app/modules/` claims to produce an FSE
+  itself; `fr_fse` only drives an engine whose vendor's homologation
+  is named in its docs.
+- `fr_ccam` exists before `fr_fse`; the connector consumes its codes
+  and baskets instead of carrying its own.
 
 ## References
 

--- a/docs/technical/country-readiness.md
+++ b/docs/technical/country-readiness.md
@@ -41,8 +41,8 @@ templates are contributed.
 |---|---|---|---|---|---|
 | Spain | ✅ `es` | ✅ | ✅ `verifactu` module (AEAT) | n/a | — |
 | India | ✅ `en` + `ta` | ✅ | ✅ `india_gst` module (CGST/SGST/IGST, GSTIN checksum, FY numbering; e-invoice is applicability-tracking only) | ❓ ABDM voluntary? DPDP audit | #145 (e-invoicing GSP/IRP, DPDP, ABDM) |
-| France | ✅ `fr` | ✅ | ❌ e-invoicing reform (partner platforms, e-reporting); invoicing outside the Assurance Maladie flow only | ❌ SESAM-Vitale: no FSE / tiers payant for a self-hosted open-source product (ADR 0028); self-hosted installations are outside HDS, hosted offers need an HDS host | #141 (answered), #142 |
-| Portugal | ✅ `pt` | ✅ | ❌ AT certification is not possible for a self-hosted, modifiable program (producer-exclusive signing key, Portaria 363/2010 art. 3; ADR 0027) — invoice with a certified program; certified-edition route recorded | n/a | #140 (answered) |
+| France | ✅ `fr` | ✅ | ❌ e-invoicing reform (partner platforms, e-reporting); invoicing outside the Assurance Maladie flow until the FSE connector exists | ❌ `fr_ccam` (CCAM dentaire, tariffs, 100 % Santé baskets, devis conventionnel) then `fr_fse` connector to a homologated engine sold as API (ADR 0028); no in-house homologation; self-hosted installations are outside HDS, hosted offers need an HDS host | #411 (fr_ccam), #141 (answered), #142 |
+| Portugal | ✅ `pt` | ✅ | ❌ AT certification is not possible for a self-hosted, modifiable program (producer-exclusive signing key, Portaria 363/2010 art. 3; ADR 0027) — `pt_invoicing` connector to a certified invoicing API (InvoiceXpress, Moloni, Vendus…) pending; until then invoice with a certified program | n/a | #140 (answered) |
 | United States | ✅ `en` | ✅ | ✅ patient invoicing works as-is | ❌ CDT coding, X12 837D claims; HIPAA gap analysis | #137 |
 | Mexico | ✅ `es` | ✅ | ❌ CFDI stamping through a PAC | n/a | #138 |
 | Brazil | ✅ `pt` | ✅ | ❌ NFS-e | ❌ TISS | #139 |


### PR DESCRIPTION
Rewrites the Decision of ADR 0027 (Portugal) and ADR 0028 (France), both still *proposed*, after #408/#409.

**Portugal.** The certified edition (DentalPin-operated signing service + certification filing) is replaced as the route by a `PT`-gated connector, `pt_invoicing`, to a certified invoicing SaaS with a public API (InvoiceXpress, Moloni, Vendus, TOConline…). The provider holds the key, ATCUD, QR and the AT communication; DentalPin mirrors number, ATCUD, signature characters and PDF through `BillingHookRegistry`. One question to AT stays open (does a program that only feeds a certified program need its own certificate). The certified edition stays in Context and Alternatives.

**France.** FSE / tiers payant through a homologated engine sold as an API to LGC editors (Stellair Intégral, Pyxvital, Juxta), `fr_fse`, same hook. The engine vendor's editor programme replaces the two CNDA questions. New point: the French nomenclature (CCAM dentaire, NGAP, tariffs, 100 % Santé baskets, devis conventionnel) is the prerequisite and starts now as `fr_ccam` — issue #411. The Decision also says why "billing outside the Assurance Maladie flow" cannot be the long-term position (modernisation forfait, paper contribution, tiers payant for CSS beneficiaries, reimbursement delays).

Readiness matrix rows for FR and PT updated. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3SEhNDZKAob9n6oP9Sf28