### PR TITLE
fix(sdi_it): bollo outside the document total, recipient edit after a scarto, persist regenerated compliance_data

### DIFF
--- a/backend/app/modules/billing/CHANGELOG.md
+++ b/backend/app/modules/billing/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: `regenerate_after_party_change` results are persisted — `compliance_data` is reassigned instead of updated in place (plain JSONB does not track mutation), so the regenerated record shows on the invoice after a billing-party edit.
+
 - fix: the discount-type select in the invoice item modals crashed on open — reka-ui rejects `''` as an item value; the 'no discount' option now uses `null`.
 
 - fix(#326): the invoice-series onboarding rule carries `permission: 'billing.read'` — it no longer renders or fires its load for a clinic where billing isn't active.

--- a/backend/app/modules/billing/workflow.py
+++ b/backend/app/modules/billing/workflow.py
@@ -376,8 +376,9 @@ class InvoiceWorkflowService:
             if hook is not None:
                 regenerated = await hook.regenerate_after_party_change(invoice, db)
                 if regenerated:
-                    invoice.compliance_data = invoice.compliance_data or {}
-                    invoice.compliance_data.update(regenerated)
+                    # New dict, not an in-place update: plain JSONB only
+                    # persists on reassignment.
+                    invoice.compliance_data = {**(invoice.compliance_data or {}), **regenerated}
 
         return invoice
 

--- a/backend/app/modules/sdi_it/CHANGELOG.md
+++ b/backend/app/modules/sdi_it/CHANGELOG.md
@@ -8,5 +8,7 @@
   valid partita IVA become SDI records; patient invoices are marked
   `not_applicable` (art. 10-bis DL 119/2018, ADR 0025).
 - Manual transport: XML download, mark exported, receipt import (RC/NS/MC),
-  requeue after a scarto with the same number and date.
+  requeue after a scarto with the same number and date; billing's
+  edit-billing-party flow is allowed while the latest record is `rejected`
+  and queues the corrected file.
 - Tables `sdi_it_settings`, `sdi_it_records` on the `sdi_it` Alembic branch.

--- a/backend/app/modules/sdi_it/CLAUDE.md
+++ b/backend/app/modules/sdi_it/CLAUDE.md
@@ -8,8 +8,12 @@
 - **No columns in `billing`.** Everything lives in `sdi_it_*`; the hook
   returns its data through `Invoice.compliance_data["IT"]`.
 - **XML is built at issue time** (`hook.build_record`) and stored verbatim;
-  receipts are stored verbatim too. Regeneration only through `requeue`
-  after a scarto, with the same number and date and a new progressivo.
+  receipts are stored verbatim too. Regeneration only after a scarto
+  (`requeue` endpoint, or billing's edit-billing-party flow through
+  `can_edit_billing_party` / `regenerate_after_party_change`), with the
+  same number and date and a new progressivo.
+- **Bollo is the issuer's cost.** `DatiBollo` is declared but never added
+  to `ImportoTotaleDocumento`: the XML total must equal the invoice total.
 - **Schema fidelity.** `tests/modules/sdi_it/test_xml_builder.py` validates
   every generated file against the vendored official XSD; keep that test
   green before touching element order in `services/xml_builder.py`.

--- a/backend/app/modules/sdi_it/hook.py
+++ b/backend/app/modules/sdi_it/hook.py
@@ -15,20 +15,18 @@ to the admin, the PEC transport (later) sends it.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth.models import Clinic
 from app.modules.billing.hooks import BillingComplianceHook
+from app.modules.billing.models import Invoice
 
 from .models import SdiItRecord, SdiItSettings
 from .services.tax_ids import PartitaIva, is_business_recipient
 from .services.xml_builder import Party, SdiBuildError, build_fattura, progressivo_invio
-
-if TYPE_CHECKING:
-    from app.modules.billing.models import Invoice
 
 NOT_APPLICABLE_REASON = "b2c_healthcare_art_10bis"
 
@@ -105,6 +103,57 @@ async def build_record(
     return record
 
 
+async def requeue(
+    db: AsyncSession,
+    rejected: SdiItRecord,
+    invoice: Invoice,
+    settings: SdiItSettings,
+    *,
+    original: Invoice | None,
+) -> SdiItRecord:
+    """After a scarto: new file (same number and date, new progressivo);
+    the rejected record stays as history."""
+    new = await build_record(db, invoice, settings, original=original)
+    new.attempts = rejected.attempts
+    rejected.finished_at = rejected.finished_at or datetime.now(UTC)
+    return new
+
+
+async def latest_record(db: AsyncSession, invoice: Invoice) -> SdiItRecord | None:
+    return (
+        await db.execute(
+            select(SdiItRecord)
+            .where(SdiItRecord.invoice_id == invoice.id, SdiItRecord.clinic_id == invoice.clinic_id)
+            .order_by(SdiItRecord.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+
+async def original_invoice(db: AsyncSession, invoice: Invoice) -> Invoice | None:
+    if invoice.credit_note_for_id is None:
+        return None
+    return (
+        await db.execute(
+            select(Invoice).where(
+                Invoice.id == invoice.credit_note_for_id, Invoice.clinic_id == invoice.clinic_id
+            )
+        )
+    ).scalar_one_or_none()
+
+
+def _queued(record: SdiItRecord) -> dict[str, Any]:
+    return {
+        "IT": {
+            "sdi": "queued",
+            "record_id": str(record.id),
+            "tipo_documento": record.tipo_documento,
+            "file_name": record.file_name,
+            "state": record.state,
+        }
+    }
+
+
 class SdiItHook(BillingComplianceHook):
     @property
     def country_code(self) -> str:
@@ -152,12 +201,28 @@ class SdiItHook(BillingComplianceHook):
         except SdiBuildError as exc:
             settings.last_error = str(exc)[:500]
             return {"IT": {"sdi": "error", "error": str(exc)}}
-        return {
-            "IT": {
-                "sdi": "queued",
-                "record_id": str(record.id),
-                "tipo_documento": record.tipo_documento,
-                "file_name": record.file_name,
-                "state": record.state,
-            }
-        }
+        return _queued(record)
+
+    async def can_edit_billing_party(self, invoice, db) -> tuple[bool, str | None]:
+        """Only after a scarto: the SDI never accepted the file, so the
+        corrected recipient goes out with the same number and date (ADR 0025 §4)."""
+        record = await latest_record(db, invoice)
+        if record is not None and record.state == "rejected":
+            return True, None
+        return False, "Il destinatario si può correggere solo dopo uno scarto dell'SDI."
+
+    async def regenerate_after_party_change(self, invoice, db) -> dict[str, Any]:
+        record = await latest_record(db, invoice)
+        settings = await get_settings(db, invoice.clinic_id)
+        if record is None or record.state != "rejected" or settings is None or not settings.enabled:
+            return {}
+        if not is_business_recipient(invoice.billing_tax_id):
+            return {"IT": {"sdi": "not_applicable", "reason": NOT_APPLICABLE_REASON}}
+        await db.refresh(invoice, attribute_names=["items"])
+        original = await original_invoice(db, invoice) if record.tipo_documento == "TD04" else None
+        try:
+            new = await requeue(db, record, invoice, settings, original=original)
+        except SdiBuildError as exc:
+            settings.last_error = str(exc)[:500]
+            return {"IT": {"sdi": "error", "error": str(exc)}}
+        return _queued(new)

--- a/backend/app/modules/sdi_it/router.py
+++ b/backend/app/modules/sdi_it/router.py
@@ -22,7 +22,7 @@ from app.core.schemas import ApiResponse, PaginatedApiResponse
 from app.database import get_db
 from app.modules.billing.models import Invoice
 
-from .hook import build_record, get_settings
+from .hook import get_settings, requeue
 from .models import SdiItRecord, SdiItSettings
 from .schemas import (
     ReceiptImport,
@@ -193,16 +193,15 @@ async def requeue_record(
     if invoice is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Fattura non trovata")
     try:
-        new = await build_record(
+        new = await requeue(
             db,
+            row,
             invoice,
             settings,
             original=invoice.credit_note_for if row.tipo_documento == "TD04" else None,
         )
     except SdiBuildError as exc:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
-    new.attempts = row.attempts
-    row.finished_at = row.finished_at or datetime.now(UTC)
     await db.commit()
     await db.refresh(new)
     return ApiResponse(data=SdiRecordResponse.model_validate(new))

--- a/backend/app/modules/sdi_it/services/xml_builder.py
+++ b/backend/app/modules/sdi_it/services/xml_builder.py
@@ -240,9 +240,10 @@ def build_fattura(
         groups[(ln.aliquota, ln.natura)] = (base, tax)
     exempt_total = sum((b for (_, n), (b, _) in groups.items() if n), Decimal(0))
     bollo = bool(bollo_virtuale and exempt_total > BOLLO_THRESHOLD)
-    total = sum((b + t for b, t in groups.values()), Decimal(0)) + (
-        BOLLO_AMOUNT if bollo else Decimal(0)
-    )
+    # The stamp is the issuer's cost: billing has no bollo line, so the
+    # document total stays what the client owes (re-charging it would need
+    # an explicit N1 line in the invoice).
+    total = sum((b + t for b, t in groups.values()), Decimal(0))
 
     address = invoice.billing_address or {}
     codice_dest = str(address.get("sdi_code") or "").strip().upper()

--- a/backend/tests/modules/sdi_it/test_hook.py
+++ b/backend/tests/modules/sdi_it/test_hook.py
@@ -93,8 +93,11 @@ async def test_b2b_invoice_is_queued_with_valid_file(db_session):
     assert out["IT"]["sdi"] == "queued" and out["IT"]["tipo_documento"] == "TD01"
     rec = (await db_session.execute(select(SdiItRecord))).scalar_one()
     assert rec.state == "pending" and rec.file_name == "IT01234567897_00001.xml"
-    assert rec.codice_destinatario == "0000000" and rec.gross_amount == Decimal("152.00")  # + bollo
-    assert "<Natura>N4</Natura>" in rec.xml_payload
+    assert rec.codice_destinatario == "0000000" and rec.gross_amount == Decimal("150.00")
+    assert (
+        "<Natura>N4</Natura>" in rec.xml_payload
+        and "<ImportoBollo>2.00</ImportoBollo>" in rec.xml_payload
+    )
     settings = (await db_session.execute(select(SdiItSettings))).scalar_one()
     assert settings.progressivo_invio == 1
 
@@ -169,3 +172,28 @@ async def test_credit_note_is_td04_referencing_the_original(db_session):
         await db_session.execute(select(SdiItRecord).where(SdiItRecord.invoice_id == note.id))
     ).scalar_one()
     assert "<IdDocumento>E/2026/0001</IdDocumento>" in rec.xml_payload
+
+
+@pytest.mark.asyncio
+async def test_recipient_edit_is_allowed_only_after_a_scarto_and_requeues(db_session):
+    clinic, invoice = await _setup(db_session)
+    hook = SdiItHook()
+    await hook.on_invoice_issued(invoice, db_session)
+    rec = (await db_session.execute(select(SdiItRecord))).scalar_one()
+    assert (await hook.can_edit_billing_party(invoice, db_session))[0] is False
+    assert await hook.regenerate_after_party_change(invoice, db_session) == {}
+
+    rec.state = "rejected"
+    await db_session.flush()
+    assert await hook.can_edit_billing_party(invoice, db_session) == (True, None)
+    invoice.billing_tax_id = "IT01234567897"  # corrected partita IVA
+    out = await hook.regenerate_after_party_change(invoice, db_session)
+    assert out["IT"]["sdi"] == "queued" and out["IT"]["file_name"] == "IT01234567897_00002.xml"
+    records = (
+        (await db_session.execute(select(SdiItRecord).order_by(SdiItRecord.created_at)))
+        .scalars()
+        .all()
+    )
+    assert [r.state for r in records] == ["rejected", "pending"]
+    assert records[0].finished_at is not None
+    assert "<IdCodice>01234567897</IdCodice>" in records[1].xml_payload

--- a/backend/tests/modules/sdi_it/test_xml_builder.py
+++ b/backend/tests/modules/sdi_it/test_xml_builder.py
@@ -83,10 +83,14 @@ def test_exempt_invoice_validates_with_natura_n4_and_bollo():
     riepilogo = doc.find(body + "DatiBeniServizi/DatiRiepilogo")
     assert riepilogo.find("Natura").text == "N4"
     assert "art. 10 n. 18" in riepilogo.find("RiferimentoNormativo").text
-    # 180.00 exempt > 77.47 → virtual €2 stamp, added to the document total
+    # 180.00 exempt > 77.47 → virtual €2 stamp; the issuer bears it, the
+    # document total stays the invoice total
     assert _text(doc, body + "DatiGenerali/DatiGeneraliDocumento/DatiBollo/ImportoBollo") == "2.00"
-    assert res.gross_amount == Decimal("182.00")
-    assert _text(doc, body + "DatiPagamento/DettaglioPagamento/ImportoPagamento") == "182.00"
+    assert res.gross_amount == Decimal("180.00")
+    assert (
+        _text(doc, body + "DatiGenerali/DatiGeneraliDocumento/ImportoTotaleDocumento") == "180.00"
+    )
+    assert _text(doc, body + "DatiPagamento/DettaglioPagamento/ImportoPagamento") == "180.00"
     assert res.file_name == "IT01234567897_00001.xml"
     assert res.codice_destinatario == "0000000"
     header = "FatturaElettronicaHeader/"

--- a/docs/modules/sdi_it.md
+++ b/docs/modules/sdi_it.md
@@ -16,7 +16,7 @@ SDI returns:
 |---|---|---|
 | `RC` ricevuta di consegna | `delivered` | nothing |
 | `MC` impossibilità di recapito | `undeliverable` | tell the recipient the invoice is in their area riservata |
-| `NS` notifica di scarto | `rejected` | fix the invoice data, **Requeue** (same number and date, new progressivo) within 5 days |
+| `NS` notifica di scarto | `rejected` | fix the data and resend within 5 days: editing the recipient on the invoice (billing's *edit billing party*, allowed only while the latest record is `rejected`) queues a new file automatically; after fixing clinic data use **Requeue**. Same number and date, new progressivo |
 
 Invoices to natural persons never produce a record: healthcare invoices to
 persone fisiche may not be electronic (art. 10-bis DL 119/2018). They are

--- a/docs/technical/sdi_it/events.md
+++ b/docs/technical/sdi_it/events.md
@@ -1,0 +1,10 @@
+---
+module: sdi_it
+last_verified_commit: 0000000
+---
+
+# sdi_it — events
+
+This module neither publishes nor subscribes to bus events in phase 1.
+It is driven by the billing compliance hook (`on_invoice_issued` /
+`on_credit_note_issued` / `regenerate_after_party_change`).


### PR DESCRIPTION
Follow-up to #410 (review fixes; the push to the contributor branch was rejected because the PR had just been merged).

**What**

1. **Bollo out of the document total.** `ImportoTotaleDocumento` / `ImportoPagamento` added the €2 bollo virtuale (a 330.00 invoice produced a 332.00 file). Billing has no bollo line and the client owes the invoice total, so the XML total now equals it; `DatiBollo` stays declared. Re-charging the stamp would need an explicit N1 line.
2. **Recipient edit after a scarto.** Issued invoices are immutable unless the country hook overrides `can_edit_billing_party`; `sdi_it` did not, so an NS on recipient data (wrong partita IVA, CodiceDestinatario) could only be requeued with the same wrong data. The hook now allows billing's edit-billing-party flow only while the latest record is `rejected`, and `regenerate_after_party_change` queues the corrected file (same number and date, new progressivo, old record kept). `requeue` and the hook share one helper.
3. **billing workflow: persist the regenerated record.** `compliance_data` is a plain JSONB column; the in-place `.update()` after `regenerate_after_party_change` was never flushed, so the invoice kept pointing at the rejected record. Reassignment now. Verifactu's regenerate already reassigned internally, which is why it never showed there.
4. `docs/technical/sdi_it/events.md` for checklist parity with `nav_online`.

**Verified locally**: `tests/modules/sdi_it` (23), `verifactu` and `nav_online` suites green (114 passed); full HTTP flow on the dev stack — B2B invoice → `pending` record, NS import → `rejected`, `PATCH /billing/invoices/{id}/billing-party` → new `pending` file with the corrected `CessionarioCommittente`, persisted on the invoice, XSD-valid; edit refused before the scarto and while the new record is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3SEhNDZKAob9n6oP9Sf28