### PR TITLE
chore(license): set Wikiparty Labs S.L. as Licensor

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
 Business Source License 1.1
 
-Licensor: Ramón Martínez Salmerón
+Licensor: Wikiparty Labs S.L. (NIF B25884396)
 Licensed Work: DentalPin
-The Licensed Work is (c) 2026 Ramón Martínez Salmerón and contributors
+The Licensed Work is (c) 2026 Wikiparty Labs S.L. and contributors
 
 Additional Use Grant: You may make production use of the Licensed Work,
 provided that you do not use it to provide a commercial Software-as-a-Service


### PR DESCRIPTION
## What

`Licensor` and the copyright line in `LICENSE` now name Wikiparty Labs S.L. (NIF B25884396), the maintainer's holding company, instead of the maintainer personally. Follow-up to #417.

## Why

Alternative licensing arrangements should be granted by a legal entity, not an individual.

## What does NOT change

Same Additional Use Grant, Change Date and Change License. Contributors keep copyright on their work ("and contributors").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBgNLJAVSkrjikEuGGL9NU
