### PR TITLE
fix(settings): settings rail hydration mismatch — gate by CSS, not the SSR-false media query

### DIFF
--- a/frontend/app/components/settings/SettingsLayout.vue
+++ b/frontend/app/components/settings/SettingsLayout.vue
@@ -28,8 +28,6 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const { t } = useI18n()
-const { isDesktop } = useBreakpoint()
-
 const headerTitle = computed(() => props.title ?? t('settings.title'))
 </script>
 
@@ -65,9 +63,12 @@ const headerTitle = computed(() => props.title ?? t('settings.title'))
     </header>
 
     <div class="flex gap-6">
+      <!-- Desktop rail. Gated by CSS, not by the media-query ref: useMediaQuery
+           is false during SSR, so a v-if here rendered a comment on the server
+           and an <aside> on the client (hydration mismatch on every settings page). -->
       <aside
-        v-if="!hideRail && isDesktop"
-        class="w-60 shrink-0"
+        v-if="!hideRail"
+        class="hidden lg:block w-60 shrink-0"
       >
         <SettingsCategoryNav :active-id="activeId" />
       </aside>

--- a/frontend/app/pages/settings/[category]/index.vue
+++ b/frontend/app/pages/settings/[category]/index.vue
@@ -7,7 +7,6 @@ const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
 const registry = useSettingsRegistry()
-const { isDesktop } = useBreakpoint()
 
 const categoryId = computed(() => route.params.category as SettingsCategoryId)
 const category = computed(() => registry.findCategory(categoryId.value))
@@ -66,8 +65,8 @@ const showOnboarding = computed(() => categoryId.value === (registry.firstVisibl
 
       <!-- Mobile: full-screen category nav when on first-visible category landing -->
       <div
-        v-if="!isDesktop && showOnboarding"
-        class="mb-6"
+        v-if="showOnboarding"
+        class="mb-6 lg:hidden"
       >
         <h2 class="text-h2 text-default mb-3">
           {{ t('settings.allCategories') }}


### PR DESCRIPTION
Every settings page logged "Hydration completed but contains mismatches" (found during the browser pass for #394; pre-existing on `main`). `SettingsLayout` rendered its rail with `v-if="!hideRail && isDesktop"`, and `useBreakpoint().isDesktop` is a VueUse `useMediaQuery` ref, which is `false` during SSR: the server emitted a comment where the client expected an `<aside>`. Same pattern on the mobile category nav in `settings/[category]/index.vue` (`v-if="!isDesktop && showOnboarding"`, mismatching in the other direction on desktop).

Both now render the element unconditionally and hide it with Tailwind at the same 1024 px breakpoint (`hidden lg:block` / `lg:hidden`), so server and client markup agree; the media-query refs are no longer needed in either component. Verified on the dev server: `/settings/account` loads with no hydration warning.

What remains on `/settings/billing` is a different, architectural mismatch (module settings sections registered from client-only plugins), filed as #424.

~10 lines; `frontend/app/**` so it needs the lead's review.