### PR TITLE
feat(operations): module manager upgrade/installable signals + UI + docs (issue #47)

### DIFF
--- a/backend/app/core/plugins/processor.py
+++ b/backend/app/core/plugins/processor.py
@@ -225,7 +225,7 @@ class PendingProcessor:
         if module is None:
             raise RuntimeError(f"Cannot upgrade {record.name}: not in in-memory registry")
 
-        previous_version = record.manifest_snapshot.get("version", record.version)
+        previous_version = record.version or (record.manifest_snapshot or {}).get("version")
 
         migrate_log = await self._op_log.started(
             module_name=record.name, operation="upgrade", step="migrate"
@@ -261,6 +261,7 @@ class PendingProcessor:
                 raise RuntimeError(f"Record {record.name} vanished mid-upgrade")
             db_record.state = ModuleState.INSTALLED.value
             db_record.applied_revision = applied_revision
+            db_record.version = module.get_manifest().version
             db_record.last_state_change = datetime.now(UTC)
             db_record.error_message = None
             db_record.error_at = None

--- a/backend/app/core/plugins/service.py
+++ b/backend/app/core/plugins/service.py
@@ -40,6 +40,7 @@ class ModuleInfo:
 
     name: str
     version: str
+    installed_version: str | None
     state: ModuleState
     category: ModuleCategory
     removable: bool
@@ -60,6 +61,7 @@ class ModuleInfo:
         return {
             "name": self.name,
             "version": self.version,
+            "installed_version": self.installed_version,
             "state": self.state.value,
             "category": self.category.value,
             "removable": self.removable,
@@ -288,6 +290,7 @@ class ModuleService:
                 ModuleInfo(
                     name=name,
                     version=version,
+                    installed_version=record.version if record else None,
                     state=state,
                     category=category,
                     removable=record.removable if record else True,
@@ -564,8 +567,11 @@ class ModuleService:
         if record.version == manifest.version:
             return False
 
+        # NOTE: record.version intentionally keeps the last-APPLIED
+        # version here. Only the upgrade finalize advances it, so a
+        # failed upgrade still reports upgrade_available and
+        # post_upgrade receives the true previous version.
         record.state = ModuleState.TO_UPGRADE.value
-        record.version = manifest.version
         record.manifest_snapshot = manifest.to_snapshot()
         record.last_state_change = datetime.now(UTC)
         record.error_message = None

--- a/backend/app/core/plugins/service.py
+++ b/backend/app/core/plugins/service.py
@@ -53,6 +53,8 @@ class ModuleInfo:
     summary: str
     depends: list[str]
     in_disk: bool
+    installable: bool
+    upgrade_available: bool
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -71,6 +73,8 @@ class ModuleInfo:
             "summary": self.summary,
             "depends": self.depends,
             "in_disk": self.in_disk,
+            "installable": self.installable,
+            "upgrade_available": self.upgrade_available,
         }
 
 
@@ -201,12 +205,14 @@ class ModuleService:
 
             if record.version != manifest.version:
                 logger.info(
-                    "Reconciled: %s version %s -> %s",
+                    "Reconciled: %s installed version %s drifts from disk %s (awaiting upgrade)",
                     manifest.name,
                     record.version,
                     manifest.version,
                 )
-                record.version = manifest.version
+                # NOTE: record.version intentionally keeps the last-applied
+                # version — it is the upgrade signal (see `upgrade()` and
+                # `upgrade_available`). Only the upgrade finalize advances it.
 
             # Always refresh the snapshot so DB stays in sync with disk.
             record.manifest_snapshot = manifest.to_snapshot()
@@ -295,6 +301,21 @@ class ModuleService:
                     summary=summary,
                     depends=depends,
                     in_disk=module is not None,
+                    installable=(
+                        manifest.installable
+                        if manifest is not None
+                        else (
+                            (record.manifest_snapshot or {}).get("installable", True)
+                            if record
+                            else True
+                        )
+                    ),
+                    upgrade_available=(
+                        record is not None
+                        and state == ModuleState.INSTALLED
+                        and manifest is not None
+                        and manifest.version != record.version
+                    ),
                 )
             )
 

--- a/backend/tests/test_module_install_flow.py
+++ b/backend/tests/test_module_install_flow.py
@@ -152,7 +152,7 @@ async def test_upgrade_marks_to_upgrade_when_version_diverges(
         await db_session.execute(select(ModuleRecord).where(ModuleRecord.name == "billing"))
     ).scalar_one()
     assert refreshed.state == ModuleState.TO_UPGRADE.value
-    assert refreshed.version != "0.0.0"  # bumped to manifest version
+    assert refreshed.version == "0.0.0"  # version advances only on finalize
 
 
 @pytest.mark.asyncio
@@ -198,9 +198,12 @@ async def test_list_signals_upgrade_available_on_drift(
     assert info is not None
     assert info.upgrade_available is True
     assert info.installable is True
+    assert info.installed_version == "0.0.0"
+    assert info.version != "0.0.0"
     payload = info.to_dict()
     assert payload["upgrade_available"] is True
     assert payload["installable"] is True
+    assert payload["installed_version"] == "0.0.0"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_module_install_flow.py
+++ b/backend/tests/test_module_install_flow.py
@@ -153,3 +153,63 @@ async def test_upgrade_marks_to_upgrade_when_version_diverges(
     ).scalar_one()
     assert refreshed.state == ModuleState.TO_UPGRADE.value
     assert refreshed.version != "0.0.0"  # bumped to manifest version
+
+
+@pytest.mark.asyncio
+async def test_reconcile_keeps_installed_version_on_drift(
+    db_session: AsyncSession,
+) -> None:
+    """Reconcile must NOT absorb a disk version bump into ``record.version``.
+
+    The stored version is the last-applied version — the upgrade signal.
+    A second reconcile with drift keeps the old version and the installed
+    state, so the upgrade path stays reachable (issue #47)."""
+    await _reconcile(db_session)
+
+    billing = (
+        await db_session.execute(select(ModuleRecord).where(ModuleRecord.name == "billing"))
+    ).scalar_one()
+    billing.version = "0.0.0"
+    await db_session.commit()
+
+    await _reconcile(db_session)
+
+    refreshed = (
+        await db_session.execute(select(ModuleRecord).where(ModuleRecord.name == "billing"))
+    ).scalar_one()
+    assert refreshed.version == "0.0.0"
+    assert refreshed.state == ModuleState.INSTALLED.value
+
+
+@pytest.mark.asyncio
+async def test_list_signals_upgrade_available_on_drift(
+    db_session: AsyncSession,
+) -> None:
+    await _reconcile(db_session)
+
+    billing = (
+        await db_session.execute(select(ModuleRecord).where(ModuleRecord.name == "billing"))
+    ).scalar_one()
+    billing.version = "0.0.0"
+    await db_session.commit()
+
+    svc = ModuleService(db_session)
+    info = await svc.get_info("billing")
+    assert info is not None
+    assert info.upgrade_available is True
+    assert info.installable is True
+    payload = info.to_dict()
+    assert payload["upgrade_available"] is True
+    assert payload["installable"] is True
+
+
+@pytest.mark.asyncio
+async def test_no_upgrade_signal_when_in_sync(
+    db_session: AsyncSession,
+) -> None:
+    await _reconcile(db_session)
+
+    svc = ModuleService(db_session)
+    info = await svc.get_info("billing")
+    assert info is not None
+    assert info.upgrade_available is False

--- a/backend/tests/test_module_service.py
+++ b/backend/tests/test_module_service.py
@@ -45,7 +45,12 @@ async def test_reconcile_empty_db_inserts_all_modules(db_session: AsyncSession) 
 
 
 @pytest.mark.asyncio
-async def test_reconcile_updates_version_change(db_session: AsyncSession) -> None:
+async def test_reconcile_keeps_installed_version_on_drift(db_session: AsyncSession) -> None:
+    """A disk version bump is an upgrade signal, not a silent absorb.
+
+    Reconcile keeps the last-applied ``record.version`` (and the installed
+    state) so ``upgrade()`` and ``upgrade_available`` stay reachable —
+    only the upgrade finalize advances the stored version."""
     svc = ModuleService(db_session)
     await svc.reconcile_with_db()
 
@@ -60,7 +65,8 @@ async def test_reconcile_updates_version_change(db_session: AsyncSession) -> Non
     refreshed = (
         await db_session.execute(select(ModuleRecord).where(ModuleRecord.name == "patients"))
     ).scalar_one()
-    assert refreshed.version != "0.0.1-old"
+    assert refreshed.version == "0.0.1-old"
+    assert refreshed.state == ModuleState.INSTALLED.value
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_module_service.py
+++ b/backend/tests/test_module_service.py
@@ -45,31 +45,6 @@ async def test_reconcile_empty_db_inserts_all_modules(db_session: AsyncSession) 
 
 
 @pytest.mark.asyncio
-async def test_reconcile_keeps_installed_version_on_drift(db_session: AsyncSession) -> None:
-    """A disk version bump is an upgrade signal, not a silent absorb.
-
-    Reconcile keeps the last-applied ``record.version`` (and the installed
-    state) so ``upgrade()`` and ``upgrade_available`` stay reachable —
-    only the upgrade finalize advances the stored version."""
-    svc = ModuleService(db_session)
-    await svc.reconcile_with_db()
-
-    # Tamper with a version to simulate an out-of-date row.
-    record = (
-        await db_session.execute(select(ModuleRecord).where(ModuleRecord.name == "patients"))
-    ).scalar_one()
-    record.version = "0.0.1-old"
-    await db_session.commit()
-
-    await svc.reconcile_with_db()
-    refreshed = (
-        await db_session.execute(select(ModuleRecord).where(ModuleRecord.name == "patients"))
-    ).scalar_one()
-    assert refreshed.version == "0.0.1-old"
-    assert refreshed.state == ModuleState.INSTALLED.value
-
-
-@pytest.mark.asyncio
 async def test_list_modules_combines_disk_and_db(db_session: AsyncSession) -> None:
     svc = ModuleService(db_session)
     await svc.reconcile_with_db()

--- a/docs/user-manual/en/operations.md
+++ b/docs/user-manual/en/operations.md
@@ -343,3 +343,40 @@ docker compose logs backend --tail 100
 
 For security reports contact the maintainers privately rather than
 opening a public issue.
+
+---
+
+## 13. Module manager UI (`/settings/modules`)
+
+Everything in §§2–6 is also available as an admin web page — no shell
+access needed. Open **Settings → Modules** (`/settings/modules`).
+
+- **Gating:** viewing the page needs `admin.clinic.read`; the
+  Install / Uninstall / Upgrade / Apply buttons need
+  `admin.clinic.write`. Other roles see an "access denied" message.
+- **Module list:** every discovered module with its state
+  (`installed`, `uninstalled`, `to_install`, `to_upgrade`,
+  `to_remove`, `disabled`, `error`), version, category badge
+  (official/community), dependencies and summary.
+- **Install:** offered for uninstalled, installable modules present on
+  disk. The confirmation modal previews the transitive dependency
+  chain that will be scheduled.
+- **Upgrade:** offered for installed modules whose on-disk manifest
+  version is newer than the installed version. The confirmation modal
+  schedules the upgrade; like installs, it needs an Apply + restart
+  (below) to run.
+- **Uninstall:** offered for installed, removable modules. The modal
+  warns about the automatic `pg_dump` backup (§8). When reverse
+  dependencies block the removal, the error renders inline with an
+  option to retry with force.
+- **Apply changes:** scheduled operations wait as pending until you
+  press **Apply**. The backend restarts, the page polls
+  `GET /-/status` until `pending=[]`, then refreshes the list and the
+  sidebar. A banner at the top always shows pending modules.
+- **Doctor banner:** when `GET /-/doctor` reports orphans, missing
+  dependencies, manifest errors or errored modules, a banner
+  summarises them at the top of the page.
+- **Detail drawer:** per module, key facts (state, category, install
+  date, revisions), the error message if any, the recent operation log
+  (migrate → seed → lifecycle → finalize per operation) and the raw
+  manifest snapshot.

--- a/docs/user-manual/en/operations.md
+++ b/docs/user-manual/en/operations.md
@@ -362,9 +362,11 @@ access needed. Open **Settings → Modules** (`/settings/modules`).
   disk. The confirmation modal previews the transitive dependency
   chain that will be scheduled.
 - **Upgrade:** offered for installed modules whose on-disk manifest
-  version is newer than the installed version. The confirmation modal
-  schedules the upgrade; like installs, it needs an Apply + restart
-  (below) to run.
+  version differs from the installed version (shown as
+  "installed → on-disk"). The confirmation modal schedules the
+  upgrade; like installs, it needs an Apply + restart
+  (below) to run. Dependency reachability is enforced by Install,
+  not by this signal.
 - **Uninstall:** offered for installed, removable modules. The modal
   warns about the automatic `pg_dump` backup (§8). When reverse
   dependencies block the removal, the error renders inline with an

--- a/docs/user-manual/es/operations.md
+++ b/docs/user-manual/es/operations.md
@@ -355,3 +355,41 @@ docker compose logs backend --tail 100
 
 Para reportes de seguridad contacta con los mantenedores en privado en
 lugar de abrir un issue público.
+
+---
+
+## 13. Interfaz de gestión de módulos (`/settings/modules`)
+
+Todo lo descrito en §§2–6 también está disponible como página web de
+administración — sin necesidad de acceso a la terminal. Abre
+**Ajustes → Módulos** (`/settings/modules`).
+
+- **Permisos:** ver la página requiere `admin.clinic.read`; los botones
+  Instalar / Desinstalar / Actualizar / Aplicar requieren
+  `admin.clinic.write`. Otros roles ven un mensaje de acceso denegado.
+- **Lista de módulos:** todos los módulos descubiertos con su estado
+  (`installed`, `uninstalled`, `to_install`, `to_upgrade`,
+  `to_remove`, `disabled`, `error`), versión, insignia de categoría
+  (oficial/comunitario), dependencias y resumen.
+- **Instalar:** disponible para módulos desinstalados e instalables
+  presentes en disco. El modal de confirmación muestra la cadena
+  transitiva de dependencias que se programará.
+- **Actualizar:** disponible para módulos instalados cuyo manifiesto en
+  disco es más nuevo que la versión instalada. El modal programa la
+  actualización; como las instalaciones, necesita Aplicar + reinicio
+  (abajo) para ejecutarse.
+- **Desinstalar:** disponible para módulos instalados y removibles. El
+  modal avisa de la copia de seguridad `pg_dump` automática (§8).
+  Cuando dependencias inversas bloquean la eliminación, el error se
+  muestra en el propio modal con opción de reintentar forzando.
+- **Aplicar cambios:** las operaciones programadas quedan pendientes
+  hasta pulsar **Aplicar**. El backend se reinicia, la página consulta
+  `GET /-/status` hasta que `pending=[]` y refresca la lista y la barra
+  lateral. Un aviso superior muestra siempre los módulos pendientes.
+- **Aviso de diagnóstico:** cuando `GET /-/doctor` reporta huérfanos,
+  dependencias faltantes, errores de manifiesto o módulos en error, un
+  aviso los resume al inicio de la página.
+- **Panel de detalle:** por módulo, datos clave (estado, categoría,
+  fecha de instalación, revisiones), el mensaje de error si lo hay, el
+  registro reciente de operaciones (migrate → seed → lifecycle →
+  finalize por operación) y el manifiesto en bruto.

--- a/docs/user-manual/es/operations.md
+++ b/docs/user-manual/es/operations.md
@@ -375,9 +375,11 @@ administración — sin necesidad de acceso a la terminal. Abre
   presentes en disco. El modal de confirmación muestra la cadena
   transitiva de dependencias que se programará.
 - **Actualizar:** disponible para módulos instalados cuyo manifiesto en
-  disco es más nuevo que la versión instalada. El modal programa la
-  actualización; como las instalaciones, necesita Aplicar + reinicio
-  (abajo) para ejecutarse.
+  disco difiere de la versión instalada (se muestra como
+  "instalada → en disco"). El modal programa la actualización; como
+  las instalaciones, necesita Aplicar + reinicio (abajo) para
+  ejecutarse. La alcanzabilidad de dependencias la impone Instalar,
+  no esta señal.
 - **Desinstalar:** disponible para módulos instalados y removibles. El
   modal avisa de la copia de seguridad `pg_dump` automática (§8).
   Cuando dependencias inversas bloquean la eliminación, el error se

--- a/frontend/app/components/settings/modules/ModuleCard.vue
+++ b/frontend/app/components/settings/modules/ModuleCard.vue
@@ -5,7 +5,6 @@ import { MODULE_STATE_ROLE } from '~/config/severity'
 
 interface Props {
   module: ModuleInfo
-  upgradeAvailable?: boolean
   canWrite: boolean
 }
 
@@ -27,7 +26,7 @@ function camelState(state: string): string {
 }
 
 const canInstall = computed(
-  () => props.module.state === 'uninstalled' && props.module.in_disk
+  () => props.module.state === 'uninstalled' && props.module.in_disk && props.module.installable
 )
 // Show uninstall for any installed, removable module. The backend still
 // enforces reverse-dep checks and Alembic safety, surfacing a 400 with a
@@ -36,7 +35,7 @@ const canUninstall = computed(
   () => props.module.state === 'installed' && props.module.removable
 )
 const canUpgrade = computed(
-  () => props.module.state === 'installed' && props.upgradeAvailable
+  () => props.module.state === 'installed' && props.module.upgrade_available
 )
 const pending = computed(() =>
   ['to_install', 'to_upgrade', 'to_remove'].includes(props.module.state)

--- a/frontend/app/components/settings/modules/ModuleCard.vue
+++ b/frontend/app/components/settings/modules/ModuleCard.vue
@@ -62,6 +62,10 @@ const categoryColor = computed<UiColor>(() =>
             {{ categoryLabel }}
           </UBadge>
           <span class="text-caption text-subtle">v{{ module.version }}</span>
+          <span
+            v-if="module.upgrade_available && module.installed_version"
+            class="text-caption text-subtle"
+          >({{ module.installed_version }} → {{ module.version }})</span>
         </div>
 
         <p

--- a/frontend/app/components/settings/modules/ModuleDetailModal.vue
+++ b/frontend/app/components/settings/modules/ModuleDetailModal.vue
@@ -21,6 +21,12 @@ const logError = ref<string | null>(null)
 
 const manifestJson = computed(() => JSON.stringify(props.module, null, 2))
 
+const stateLabel = computed(() => {
+  const state = props.module?.state ?? ''
+  const camel = state.replace(/_(.)/g, (_, c: string) => c.toUpperCase())
+  return t(`settings.modules.state.${camel}`)
+})
+
 async function fetchLog() {
   if (!props.module) {
     return
@@ -110,7 +116,7 @@ function statusColor(status: string): UiColor {
                 {{ t('settings.modules.detail.state') }}
               </p>
               <p class="text-default">
-                {{ module.state }}
+                {{ stateLabel }}
               </p>
             </div>
             <div>

--- a/frontend/app/types/module.ts
+++ b/frontend/app/types/module.ts
@@ -36,6 +36,7 @@ export type ModuleCategory = 'official' | 'community'
 export interface ModuleInfo {
   name: string
   version: string
+  installed_version: string | null
   state: ModuleState
   category: ModuleCategory
   removable: boolean

--- a/frontend/app/types/module.ts
+++ b/frontend/app/types/module.ts
@@ -49,6 +49,8 @@ export interface ModuleInfo {
   summary: string
   depends: string[]
   in_disk: boolean
+  installable: boolean
+  upgrade_available: boolean
 }
 
 export interface ModuleStatus {

--- a/frontend/i18n/i18n.config.ts
+++ b/frontend/i18n/i18n.config.ts
@@ -33,5 +33,20 @@ export default defineI18nConfig(() => ({
   fallbackLocale: 'en',
   missingWarn: false,
   fallbackWarn: false,
-  pluralRules: { pl: plPluralRule, ar: arPluralRule }
+  pluralRules: { pl: plPluralRule, ar: arPluralRule },
+  // Named date format used by the module detail modal (`d(value, 'short')`).
+  // Registered for every shipped locale so no locale falls back with a
+  // console warning (L18 parity applies to config-level formats too).
+  datetimeFormats: {
+    es: { short: { dateStyle: 'short', timeStyle: 'short' } },
+    en: { short: { dateStyle: 'short', timeStyle: 'short' } },
+    de: { short: { dateStyle: 'short', timeStyle: 'short' } },
+    fr: { short: { dateStyle: 'short', timeStyle: 'short' } },
+    hu: { short: { dateStyle: 'short', timeStyle: 'short' } },
+    it: { short: { dateStyle: 'short', timeStyle: 'short' } },
+    pl: { short: { dateStyle: 'short', timeStyle: 'short' } },
+    pt: { short: { dateStyle: 'short', timeStyle: 'short' } },
+    ta: { short: { dateStyle: 'short', timeStyle: 'short' } },
+    ar: { short: { dateStyle: 'short', timeStyle: 'short' } }
+  }
 }))


### PR DESCRIPTION
## Overview

- Follow-up to #54 (which delivered the `/settings/modules` page): the
  backend now exposes per-module `installable` + `upgrade_available`
  signals plus `installed_version`, the UI wires them (Upgrade button
  with "installed → on-disk" version, translated states, short
  dates in the detail modal), and the operations manual documents the
  module manager screens in English and Spanish. `installable` is a
  manifest passthrough; dependency reachability is enforced by
  Install, not by this signal.
- Rebuilt M5-clean off current main from the `pr/47-module-manager-phase1`
  commits; the i18n conflict was resolved by keeping main's shared
  plural rules and adding the named date format for all 10 locales
  (including Arabic).

## Tasks done

- `fix(core)`: keep installed version on reconcile; expose
  `upgrade_available` + `installable` + `installed_version` on
  `ModuleInfo`; only the upgrade finalize advances the stored
  version (issue #47)
- `feat(frontend)`: wire signals into ModuleCard/DetailModal, translated
  states, `d(value, 'short')` format (issue #47)
- `docs(operations)`: module manager UI section en+es (issue #47)

## Modules touched

- Core only (`core/plugins` + host frontend + operations manual). No
  manifest, migration, permission, or event changes.

## Checklist

- [x] PR title follows Conventional Commits
- [x] `eslint` clean on touched frontend files
- [x] Container pytest: `test_module_install_flow.py` +
  `test_module_service.py` 20/20 green
- [x] docs-layout OK, catalog check clean, no generated-file dirt
- [x] Reviewer pass: 0 blockers
- [x] M5-clean: merge-base is current `upstream/main`, only #47 files

## Test plan

- Open `/settings/modules` as admin: installable modules show install,
  outdated ones show an Upgrade button with "installed → on-disk",
  detail modal shows short dates
  with no console warnings in any of the 10 locales.
- `upgrade_available` is true only for installed modules whose manifest
  version differs from the last-applied record version.

## Refs

- Refs #47 (phase-1 follow-up; does not close the marketplace roadmap).

## Review

`@martinezsalmeron`: ready for review/merge when convenient.
