### PR TITLE
feat(i18n): extract plural rules + pin Arabic mapping (issue #389)

### DIFF
--- a/frontend/i18n/i18n.config.ts
+++ b/frontend/i18n/i18n.config.ts
@@ -5,29 +5,7 @@
 // to English until their translations land — never to `some.dotted.key`
 // on a clinician's screen (the drift #126 documents).
 //
-function plPluralRule(choice: number, choicesLength: number): number {
-  if (choice === 1) return 0
-  const teen = choice % 100 >= 12 && choice % 100 <= 14
-  const few = choice % 10 >= 2 && choice % 10 <= 4 && !teen
-  if (choicesLength === 2) return 1
-  return few ? 1 : 2
-}
-
-// Arabic pluralization (vue-i18n `choice`): CLDR gives Arabic six
-// categories. The rule maps a count to the index vue-i18n uses to pick
-// the pipe segment: 0 → zero, 1 → one, 2 → two, 3-10 → few,
-// 11-99 → many, everything else → other (index 5).
-function arPluralRule(choice: number, choicesLength: number): number {
-  const max = choicesLength - 1
-  if (choicesLength === 2) return choice === 1 ? 0 : Math.min(1, max)
-  const mod100 = Math.abs(choice) % 100
-  if (choice === 0) return Math.min(0, max)
-  if (choice === 1) return Math.min(1, max)
-  if (choice === 2) return Math.min(2, max)
-  if (mod100 >= 3 && mod100 <= 10) return Math.min(3, max)
-  if (mod100 >= 11 && mod100 <= 99) return Math.min(4, max)
-  return Math.min(5, max)
-}
+import { arPluralRule, plPluralRule } from './pluralRules'
 
 export default defineI18nConfig(() => ({
   fallbackLocale: 'en',

--- a/frontend/i18n/i18n.config.ts
+++ b/frontend/i18n/i18n.config.ts
@@ -1,12 +1,11 @@
+import { arPluralRule, plPluralRule } from './pluralRules'
+
 // Message-level fallback: a key missing from the active locale renders
 // its English text instead of the raw dotted key. Module layers add
 // their locale files independently of the host (#131, #144), so a
 // language can ship core-first and the optional modules' UI degrades
 // to English until their translations land — never to `some.dotted.key`
 // on a clinician's screen (the drift #126 documents).
-//
-import { arPluralRule, plPluralRule } from './pluralRules'
-
 export default defineI18nConfig(() => ({
   fallbackLocale: 'en',
   missingWarn: false,

--- a/frontend/i18n/pluralRules.ts
+++ b/frontend/i18n/pluralRules.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared vue-i18n plural rules (pure, framework-free so tests can import
+ * them without a Nuxt context).
+ */
+
+export function plPluralRule(choice: number, choicesLength: number): number {
+  if (choice === 1) return 0
+  const teen = choice % 100 >= 12 && choice % 100 <= 14
+  const few = choice % 10 >= 2 && choice % 10 <= 4 && !teen
+  if (choicesLength === 2) return 1
+  return few ? 1 : 2
+}
+
+// Arabic pluralization (vue-i18n `choice`): CLDR gives Arabic six
+// categories. The rule maps a count to the index vue-i18n uses to pick
+// the pipe segment: 0 → zero, 1 → one, 2 → two, 3-10 → few,
+// 11-99 → many, everything else → other (index 5).
+// NOTE (#389): every ar.json message today carries exactly two segments,
+// so only the `choicesLength === 2` shortcut runs. The six-way tail stays
+// deliberately — it is clamped to `choicesLength - 1`, so a future
+// three-plus-form message resolves correctly instead of silently picking
+// the wrong segment. Pinned by tests/i18n/plural-rules.test.ts.
+export function arPluralRule(choice: number, choicesLength: number): number {
+  const max = choicesLength - 1
+  if (choicesLength === 2) return choice === 1 ? 0 : Math.min(1, max)
+  const mod100 = Math.abs(choice) % 100
+  if (choice === 0) return Math.min(0, max)
+  if (choice === 1) return Math.min(1, max)
+  if (choice === 2) return Math.min(2, max)
+  if (mod100 >= 3 && mod100 <= 10) return Math.min(3, max)
+  if (mod100 >= 11 && mod100 <= 99) return Math.min(4, max)
+  return Math.min(5, max)
+}

--- a/frontend/tests/i18n/plural-rules.test.ts
+++ b/frontend/tests/i18n/plural-rules.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { arPluralRule } from '../../i18n/pluralRules'
+
+/**
+ * Pins the Arabic plural rule (#389 tail). Every `ar.json` message today
+ * carries exactly two pipe segments, so only the two-way shortcut runs —
+ * these tests lock that mapping and the six-way clamp that protects a
+ * future three-plus-form message from silently resolving wrong.
+ *
+ * Pure functions, plain Node: no Nuxt context required.
+ */
+describe('arPluralRule', () => {
+  it('maps two-segment messages one/other', () => {
+    expect(arPluralRule(1, 2)).toBe(0)
+    for (const n of [0, 2, 3, 11, 100]) expect(arPluralRule(n, 2)).toBe(1)
+  })
+
+  it('maps six-segment messages onto CLDR categories', () => {
+    expect(arPluralRule(0, 6)).toBe(0)
+    expect(arPluralRule(1, 6)).toBe(1)
+    expect(arPluralRule(2, 6)).toBe(2)
+    for (const n of [3, 5, 10]) expect(arPluralRule(n, 6)).toBe(3)
+    for (const n of [11, 50, 99]) expect(arPluralRule(n, 6)).toBe(4)
+    for (const n of [100, 1000]) expect(arPluralRule(n, 6)).toBe(5)
+  })
+
+  it('clamps short variant lists instead of overrunning', () => {
+    expect(arPluralRule(100, 3)).toBeLessThanOrEqual(2)
+    expect(arPluralRule(2, 2)).toBe(1)
+  })
+})

--- a/frontend/tests/i18n/plural-rules.test.ts
+++ b/frontend/tests/i18n/plural-rules.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from 'vitest'
-import { arPluralRule } from '../../i18n/pluralRules'
+import { arPluralRule, plPluralRule } from '../../i18n/pluralRules'
 
 /**
  * Pins the Arabic plural rule (#389 tail). Every `ar.json` message today
@@ -26,7 +26,23 @@ describe('arPluralRule', () => {
   })
 
   it('clamps short variant lists instead of overrunning', () => {
-    expect(arPluralRule(100, 3)).toBeLessThanOrEqual(2)
+    // Three segments (zero | one | other): the six-way tail collapses
+    // onto the last available index instead of running past the list.
+    const threeWay: Array<[number, number]> = [[0, 0], [1, 1], [2, 2], [5, 2], [50, 2], [100, 2]]
+    for (const [n, idx] of threeWay) expect(arPluralRule(n, 3)).toBe(idx)
     expect(arPluralRule(2, 2)).toBe(1)
+  })
+})
+
+describe('plPluralRule', () => {
+  it('maps counts onto one / few / many', () => {
+    expect(plPluralRule(1, 3)).toBe(0)
+    for (const n of [2, 3, 4, 22]) expect(plPluralRule(n, 3)).toBe(1)
+    for (const n of [5, 12, 13, 14, 25]) expect(plPluralRule(n, 3)).toBe(2)
+  })
+
+  it('collapses two-segment messages onto one / other', () => {
+    expect(plPluralRule(1, 2)).toBe(0)
+    for (const n of [2, 5, 22]) expect(plPluralRule(n, 2)).toBe(1)
   })
 })


### PR DESCRIPTION
## Overview

- Closes the last open item of #389: the README already reads
  Ten-Language on main, so this finishes the carried-over nit on
  `arPluralRule` (all eight `ar.json` pipe messages are two-segment).
- Verdict: keep the six-way CLDR tail (clamped, future-proof) instead
  of dropping it, and pin the behavior with tests.

## Tasks done

- `feat(i18n)`: plural rules extracted to `i18n/pluralRules.ts`
  (framework-free, importable without Nuxt); `arPluralRule` nit
  answered in a code comment; `tests/i18n/plural-rules.test.ts`
  pins the two-way mapping, the six-way categories, and the clamp

## Modules touched

- Host frontend i18n only. No locales, permissions, endpoints, or
  generated files changed.

## Checklist

- [x] PR title follows Conventional Commits
- [x] `vitest` 6/6 on the i18n suite (new + parity), `eslint` clean
- [x] No behavior change: rule bodies byte-identical, import rewired

## Test plan

- `npx vitest run tests/i18n/` green; Arabic screens render exactly
  as before (rule logic untouched, only moved).

## Refs

- Part of #389 (PR1 #375, PR2 #397, PR3 #398, ar-gap #414 all
  merged; rebased onto post-merge main).

## Review

`@martinezsalmeron`: ready for review/merge when convenient.
