### PR TITLE
docs(strategy): booking UX, triage spike, license sweep, compliance posture

### DIFF
--- a/docs/features/booking-ux-design.md
+++ b/docs/features/booking-ux-design.md
@@ -1,7 +1,7 @@
 # Booking UX build-similar — design record (Stream 3, design-first)
 
 > Local-only design. No code copied from any Group D repo (most are
-> unlicensed; MIT ones usable only with notice — see `external-repos-sweep.md`).
+> unlicensed; MIT ones usable only with notice — see `../technical/external-repos-sweep.md`).
 > Everything below is reimplemented ideas mapped onto existing DentalPin
 > modules. Requires maintainer product decision before code.
 
@@ -16,10 +16,10 @@
 
 ## Mapping onto our modules (no new module)
 
-- Slot grid + hold tokens → `schedules` (new endpoints, own migration branch).
+- Slot grid + hold tokens → `agenda` (new endpoints, own migration branch).
 - Reminder cascade → `recall_reminders` + `notifications` events (no new tables).
-- Triage queue → `schedules` status extension (`pending_online`).
-- Permissions: `schedules.appointments.write` reuse; public grid is
+- Triage queue → `agenda` status extension (`pending_online`).
+- Permissions: `agenda.appointments.write` reuse; public grid is
   unauthenticated-by-design like the budget public link (signed token, TTL).
 
 ## Non-goals
@@ -29,7 +29,7 @@ datepicker components copied in.
 
 ## Ship shape (later)
 
-Tight `schedules`/`recalls` gap-close PR on its own branch, en/es screen
+Tight `agenda`/`recalls` gap-close PR on its own branch, en/es screen
 docs, e2e smoke on the hold→confirm flow.
 
 ## Code mining result (2026-09-03) — no code gap, S3 stays design-only

--- a/docs/features/booking-ux-design.md
+++ b/docs/features/booking-ux-design.md
@@ -1,0 +1,49 @@
+# Booking UX build-similar — design record (Stream 3, design-first)
+
+> Local-only design. No code copied from any Group D repo (most are
+> unlicensed; MIT ones usable only with notice — see `external-repos-sweep.md`).
+> Everything below is reimplemented ideas mapped onto existing DentalPin
+> modules. Requires maintainer product decision before code.
+
+## Patterns mined (ideas only)
+
+1. **Public slot grid** (Denpointment/Nacre-style): week view of bookable
+   chairs, hold-and-confirm (10-min hold token) → confirm via link.
+2. **Reminder cascade** (dentrx-style): T-48h + T-2h nudges through the
+   existing notifications gateway (no new vendor).
+3. **Front-desk triage queue**: unconfirmed online requests land in a manual
+   review list (mirrors the approval pattern in `app/core/agents`).
+
+## Mapping onto our modules (no new module)
+
+- Slot grid + hold tokens → `schedules` (new endpoints, own migration branch).
+- Reminder cascade → `recall_reminders` + `notifications` events (no new tables).
+- Triage queue → `schedules` status extension (`pending_online`).
+- Permissions: `schedules.appointments.write` reuse; public grid is
+  unauthenticated-by-design like the budget public link (signed token, TTL).
+
+## Non-goals
+
+No patient portal accounts, no online payments for booking, no vendor
+datepicker components copied in.
+
+## Ship shape (later)
+
+Tight `schedules`/`recalls` gap-close PR on its own branch, en/es screen
+docs, e2e smoke on the hold→confirm flow.
+
+## Code mining result (2026-09-03) — no code gap, S3 stays design-only
+
+Mined `acevedo-daniel/dms-demo` (MIT) at code level: overlap exclusion
+(GiST), transition map, confirm button, status badge. Verdict per pattern:
+
+- Overlap guard: **ours is stronger** — partial unique slot index
+  (`ag_0004`, active-status-only) + app-level detection + IntegrityError→409.
+  Replacing it with GiST EXCLUDE is migration risk for zero user-visible gain.
+- Status machine: ours has `transition` + VALID_TRANSITIONS + agent
+  self-correction; theirs is a static map. Covered.
+- Confirm button / status badge: trivial PATCH-status components; our agent
+  tools + slots cover the flows. Nothing to port.
+- Only unbuilt piece is the **public hold-and-confirm link** (signed token +
+  TTL, budget public-link precedent) — a product decision, not a mining
+  task. S3 ships if/when the maintainer wants online booking.

--- a/docs/technical/compliance-posture.md
+++ b/docs/technical/compliance-posture.md
@@ -28,7 +28,7 @@
 > before any cloud call, and tools flagged `exposes_free_text` are
 > excluded from the cloud path entirely. Tool calls re-check the
 > caller's role permissions at the chokepoint; WRITE/DESTRUCTIVE tools
-> need inline user confirmation. The posture above (§4) governs
+> need inline user confirmation. The posture below (§4) governs
 > *planned imaging AI*; this paragraph governs the shipped copilot.
 
 ## 2. Tenancy and access control (the primary safeguard)
@@ -46,8 +46,7 @@
 
 ## 3. DICOM metadata and the RVG import path (planned modules)
 
-> Binding rules, proposed as ADR 0030 (staged — lands once #415's
-> 0029 merges; numbering must stay gapless per the layout gate).
+> Binding rules, candidate for an ADR (decision pending).
 > The `imaging_viewer` / `imaging_ai` branches are not merged yet. These
 > rules bind the day they land; nothing below describes shipped behavior.
 
@@ -66,11 +65,11 @@
 
 ## 4. AI processing boundaries (planned modules)
 
-> Binding rules, proposed as ADR 0030 (staged — lands once #415's
-> 0029 merges). Same status as §3: binding on the `imaging_ai`
-> rebuild, not shipped.
+> Binding rules, candidate for an ADR (decision pending). Same
+> status as §3: binding on the `imaging_ai` rebuild, not shipped.
 
-- AI runs as **operator-provided sidecars** (nnU-Net, pano, OCR, transcription
+- AI runs as **operator-provided sidecars** for imaging AI (nnU-Net,
+  pano, OCR, transcription
   runners) behind the `imaging_ai` `Runner` protocol — never as in-process
   cloud calls from the backend. No patient data leaves the clinic network
   unless the operator configures a cloud backend.

--- a/docs/technical/compliance-posture.md
+++ b/docs/technical/compliance-posture.md
@@ -20,6 +20,16 @@
 | Consents, DSRs, erasure audit, breach register | `gdpr` module tables | The accountability layer (§5) |
 | AI job inputs/outputs (frames, overlays, transcripts) | planned `imaging_ai` job records + sidecar hosts (branch, not yet merged) | Never auto-finalized into records (§4) |
 | Auth + access traces | core auth, `activity_journal` | Who touched what, when |
+| Copilot prompts + tool results (today) | `copilot` module: redaction-gated cloud LLM path | See below — redaction gate, not a ban |
+
+> **Copilot today (shipped, not planned).** The assistant backend runs
+> through a redaction gate (`copilot/CLAUDE.md`, `copilot_settings.
+> redaction_enabled`, default on): PII fields tokenize deterministically
+> before any cloud call, and tools flagged `exposes_free_text` are
+> excluded from the cloud path entirely. Tool calls re-check the
+> caller's role permissions at the chokepoint; WRITE/DESTRUCTIVE tools
+> need inline user confirmation. The posture above (§4) governs
+> *planned imaging AI*; this paragraph governs the shipped copilot.
 
 ## 2. Tenancy and access control (the primary safeguard)
 
@@ -36,6 +46,8 @@
 
 ## 3. DICOM metadata and the RVG import path (planned modules)
 
+> Binding rules, proposed as ADR 0030 (staged — lands once #415's
+> 0029 merges; numbering must stay gapless per the layout gate).
 > The `imaging_viewer` / `imaging_ai` branches are not merged yet. These
 > rules bind the day they land; nothing below describes shipped behavior.
 
@@ -54,7 +66,9 @@
 
 ## 4. AI processing boundaries (planned modules)
 
-> Same status as §3: binding on the `imaging_ai` rebuild, not shipped.
+> Binding rules, proposed as ADR 0030 (staged — lands once #415's
+> 0029 merges). Same status as §3: binding on the `imaging_ai`
+> rebuild, not shipped.
 
 - AI runs as **operator-provided sidecars** (nnU-Net, pano, OCR, transcription
   runners) behind the `imaging_ai` `Runner` protocol — never as in-process

--- a/docs/technical/compliance-posture.md
+++ b/docs/technical/compliance-posture.md
@@ -1,0 +1,96 @@
+# Compliance posture — patient data, DICOM metadata, AI processing
+
+> Cross-cutting posture statement for operators and reviewers. It describes
+> how DentalPin handles regulated data **today** and what an operator must do
+> to stay compliant. It is not legal advice and not a certification.
+> Sections marked *planned* bind future modules (§§3–4); everything else
+> describes shipped behavior.
+>
+> Normative references: EU 2016/679 (GDPR) via the `gdpr` module (PR #374);
+> HIPAA-style safeguards where they map to our controls. No HIPAA
+> certification is claimed.
+
+## 1. Data map (what regulated data exists and where)
+
+| Category | Lives in | Notes |
+|---|---|---|
+| Patient identity + contact (name, phone, email, DNI) | `patients`, `contacts` | Core PII; every query scoped by `clinic_id` |
+| Clinical records (charts, notes, plans, images) | `patients_clinical`, `clinical_notes`, `odontogram`, `treatment_plan`, `media`, `documents` | Health data (GDPR Art. 9 special category) |
+| DICOM metadata (PatientID, PatientName, StudyInstanceUID, …) | planned `imaging_viewer.dicom_metadata` JSONB + raw bytes in `media`/`documents` (branch, not yet merged) | Identity leaks hide in tags — see §3 |
+| Consents, DSRs, erasure audit, breach register | `gdpr` module tables | The accountability layer (§5) |
+| AI job inputs/outputs (frames, overlays, transcripts) | planned `imaging_ai` job records + sidecar hosts (branch, not yet merged) | Never auto-finalized into records (§4) |
+| Auth + access traces | core auth, `activity_journal` | Who touched what, when |
+
+## 2. Tenancy and access control (the primary safeguard)
+
+- **Every query filters by `clinic_id`** from `get_clinic_context` — including
+  inside agent tool handlers. An id-only lookup is treated as a security bug
+  (CI reviewer bar, L1).
+- Endpoints require `require_permission("module.resource.action")`;
+  permissions are module-prefixed and merged from manifests at runtime.
+  Frontend references `PERMISSIONS.*` via `usePermissions()` — never raw strings.
+- Cross-clinic ids resolve to 404, never an oracle (no existence disclosure).
+- Patient data is **soft-deleted, never hard-deleted**; erasure means
+  retention-gated blanking (Art. 17(3) — billing, legal claims), executed
+  through the `gdpr` module so it is audited.
+
+## 3. DICOM metadata and the RVG import path (planned modules)
+
+> The `imaging_viewer` / `imaging_ai` branches are not merged yet. These
+> rules bind the day they land; nothing below describes shipped behavior.
+
+- DICOM tags routinely embed direct identifiers (PatientName, PatientID,
+  birth dates). Treat extracted `dicom_metadata` as PII with the same
+  protections as the patient row: `clinic_id` scoping, RBAC-gated proxy,
+  no logging of tag values.
+- The RVG watch-folder importer (T1) must: fingerprint files by content hash
+  (dedup, no silent re-import), keep failed files discoverable with retry,
+  suggest patient matches for human approval (never auto-link an
+  unlinked identity on first sight), and store the DICOM-PatientID link
+  explicitly so future files auto-import **only** through an approved link.
+- De-identification for any secondary use (demos, exports, AI training data)
+  is a deliberate operator action, not a default — tag-level blanking must
+  cover PatientID/PatientName/other IDs, and the action is recorded.
+
+## 4. AI processing boundaries (planned modules)
+
+> Same status as §3: binding on the `imaging_ai` rebuild, not shipped.
+
+- AI runs as **operator-provided sidecars** (nnU-Net, pano, OCR, transcription
+  runners) behind the `imaging_ai` `Runner` protocol — never as in-process
+  cloud calls from the backend. No patient data leaves the clinic network
+  unless the operator configures a cloud backend.
+- Cloud AI backends require a **recorded patient consent** (`gdpr` consents,
+  purpose-scoped) before first use, plus a data-processing agreement with the
+  provider. Defaults are on-prem; cloud is opt-in per clinic.
+- AI outputs are **drafts**: overlays, OCR lines, transcripts attach as
+  unconfirmed data for clinician review and are never auto-finalized into
+  clinical records. Research-grade model output is never presented as
+  diagnosis (Slicer-license §4 pattern).
+
+## 5. Accountability layer (`gdpr` module)
+
+- Data-subject requests (access, rectification, erasure, portability,
+  restriction) with a 30-day SLA tracker; consent grant/withdraw with audit
+  continuity; retention policies gating erasure eligibility; immutable
+  erasure audit log; breach register (Art. 33–34: assess, record, notify
+  authority within 72h where required, communicate to subjects where required).
+- Portability export (`GET /gdpr/export/{patient_id}`) is the answering
+  mechanism for access/portability DSRs and for CSV-style data-portability
+  requests — machine-readable, clinic-scoped, permission-gated.
+
+## 6. Operator duties (what the software cannot do for you)
+
+1. Host hardening, encrypted backups, and access to the deployment itself.
+2. Signing DPAs with any cloud AI provider before enabling cloud backends.
+3. Training staff on the approval queue (RVG matching), consent capture, and
+   breach reporting within 72 hours.
+4. Reviewing retention policies yearly; keeping `legal_hold_until` current.
+5. Re-verifying this posture after every imaging/AI track ships (T1–T6).
+
+## 7. Explicitly not claimed
+
+HIPAA certification; automatic anonymization; cross-border transfer
+mechanisms beyond what the operator configures; legal review of
+retention periods (those are jurisdictional and the operator's counsel
+sets them).

--- a/docs/technical/external-repos-sweep.md
+++ b/docs/technical/external-repos-sweep.md
@@ -10,8 +10,8 @@
 > endpoint (or Zenodo API for weights) on 2026-09-03. Re-verify before any
 > push — licenses can change.
 >
-> Rule (non-negotiable, proposed as ADR 0030 — staged until #415's
-> 0029 merges): no license file = all rights reserved = **no code
+> Rule (non-negotiable, candidate for an ADR — decision pending):
+> no license file = all rights reserved = **no code
 > copied, build-similar only**. MIT/Apache-2.0 = usable **with the copyright
 > notice preserved**. GPL/NC/custom-restricted = **no code**.
 

--- a/docs/technical/external-repos-sweep.md
+++ b/docs/technical/external-repos-sweep.md
@@ -1,0 +1,79 @@
+# External repos sweep — Groups C/D/E + AI weights (verified 2026-09-03)
+
+> Companion to `external-repos-reference.md` (§B1a/B1b, on the imaging
+> branches). Every row below was verified live via the GitHub API `license`
+> endpoint (or Zenodo API for weights) on 2026-09-03. Re-verify before any
+> push — licenses can change.
+>
+> Rule (non-negotiable): no license file = all rights reserved = **no code
+> copied, build-similar only**. MIT/Apache-2.0 = usable **with the copyright
+> notice preserved**. GPL/NC/custom-restricted = **no code**.
+
+## Weights — B1b (Stream 1 input)
+
+| Artifact | License (verified) | Verdict |
+|---|---|---|
+| Zenodo `Dataset112_DentalSegmentator_v100.zip` (DOI `10.5281/zenodo.10829675`, 230 MB) | **CC-BY-4.0** (open, attribution via paper citation) | ✅ Usable as operator-downloaded weights. Cite Dot et al. 2024 + Isensee nnU-Net 2021. **V1 unblocked with real weights.** |
+
+## Group C — orthodontic apps (reference only, feeds #270 design)
+
+| Repo | License | Verdict |
+|---|---|---|
+| `lopo12123/Orthodontic-platform` | none | build-similar only |
+| `donovanhiland/OrthodonticApp` | none | build-similar only |
+| `rahul1947/Orthodontist-Expert-System` | **MIT** (© 2019 Rahul Nalawade) | usable with notice; still treat as design reference (student-grade) |
+| `Kruthikas27/AI-Based-Validation-System-for-Orthodontic-Braces-Placement` | none | build-similar only |
+| `davidegironi/dentned` | none | build-similar only |
+
+## Group D — PMS / ERP / booking (booking-UX patterns for Stream 3)
+
+| Repo | License | Verdict |
+|---|---|---|
+| `alexcorvi/apexo` | **MIT** (© 2019 Alex Corvi) | parity study only (separate PMS, never embedded) |
+| `alselawi/apexo-flutter` | **GPL-3.0** | excluded, no code |
+| `odonto-facil/odontofacil-dental-erp` | none | build-similar only |
+| `acevedo-daniel/dms-demo` | **MIT** (© 2026 Daniel Acevedo) | usable with notice |
+| `muhammedmaahir68-droid/dental-clinic-management-system` | none | build-similar only |
+| `Hezarani/dentrx` | **MIT-text** + clinical disclaimer (API: NOASSERTION, file governs) | usable with notice; keep the not-medical-advice disclaimer posture |
+| `Raju53/Nacre-Dentals-Online-Appointment-Booking-Application` | none | build-similar only |
+| `Tzesh/Denpointment` | none | build-similar only |
+| `hbapte/dentrw-alx` | **MIT** (© 2024) | usable with notice |
+
+## Group E — marketing site templates (portal styling inspiration only)
+
+MIT (usable with notice): `themixlyweb/nextjs-dental-website-template`,
+`harshitdev-wq/dentist-clinic-website`, `lat0s/FlossophyUI` (Apache-2.0).
+Custom/restricted — no code: `vin-jex/dent-clack` (Dent-Clack License v1.0:
+public distribution non-commercial only → build-similar only).
+No license — no code: `AshisChetia/DentaPremium`, `alaeddineazri/Dentist-Project`,
+`Bharadwaja-sahoo/Dental-site`, `Omareeo/dentist-website-with-PHP-Laravel`,
+`uttamsdev/dentist-application`, `ahmed-ali-codes/smilecraft-dental-site`,
+`tnaomi/dentist`, `ganraj21/Dental_Clinic`, `sohelrana1831/AYSHA-DENTAL-CARE`,
+`codewithsadee/dentelo`.
+
+## Tier-1 pano backends (adjudicated 2026-09-03 — feeds the pano Runner)
+
+| Candidate | Code | Weights / data | Verdict |
+|---|---|---|---|
+| `stmharry/dental-pano-ai` | **MIT** ✅ | S3 tarball, no stated terms; Docker image published; CPU-only | **PICK.** CLI wrap, weights operator-provided. Cite Wang et al. arXiv:2502.10277. |
+| `ibrahimethemhamamci/HierarchicalDet` | **MIT** ✅ | DENTEX data **CC BY-SA 4.0** (open, share-alike) | Runner-up. Cite Hamamci MICCAI 2023. |
+| `NoahOksuz/DentalXrayAI` | **Apache-2.0** ✅ | `best.pt` personal link, no terms; **ultralytics is AGPL** | Feasible with CLI-boundary containment; deferred. |
+| `IvisionLab/deep-dental-image` | **MIT** ✅ | weights unknown | Deferred; operator-provided gate. |
+| `clemkoa/tooth-detection` | **MIT** ✅ | dataset + model **explicitly NOT shared** | No backend possible; pipeline idea only. |
+| `ibrahimethemhamamci/DENTEX` | **none** (ledger "MIT code" corrected) | data CC BY-SA 4.0 | Build-similar + benchmark reference only. |
+| `limhoyeon/ToothGroupNetwork`, `LucasKre/dilated_tooth_seg_net`, `IvisionLab/dental-image`, `Loki-Silvres/Dental-Disease-Detection`, `sdmadhav/CBCT_Dental`, `prince0310/Smart-CBCT…`, `ErdanC/…bone…`, `Maxlo24/ALI_CBCT`, `Ash2617/DICOM_VIEWER` | none | — | Build-similar only. |
+| `AImageLab-zip/ToothFairy2-Benchmark` | none | — | Benchmark reference only. |
+| `coolleafly/VDING` | **GPL-3.0** ❌ (newly verified) | — | Excluded (ledger B4). |
+
+Full per-repo notes: `docs/technical/pano-backends.md` (ships with the
+`imaging_ai` rebuild, not yet on main).
+
+## Scoreboard
+
+- 40 swept: 13 permissive (MIT/Apache, usable with notice) · 1 custom-restricted ·
+  3 excluded (GPL) · 23 unlicensed-or-NC (build-similar/ideas only).
+- Net code-grade inputs: OHIF (B1a), nnU-Net CLI + CC-BY weights (B1b),
+  dental-pano-ai (pano Runner), HierarchicalDet/DentalXrayAI/deep-dental-image
+  (standby backends), apexo (parity study), dms-demo/dentrx/dentrw-alx +
+  rahul1947 expert system + 3 templates (available with notice). Everything
+  else is ideas-only.

--- a/docs/technical/external-repos-sweep.md
+++ b/docs/technical/external-repos-sweep.md
@@ -1,11 +1,17 @@
 # External repos sweep — Groups C/D/E + AI weights (verified 2026-09-03)
 
-> Companion to `external-repos-reference.md` (§B1a/B1b, on the imaging
-> branches). Every row below was verified live via the GitHub API `license`
+> Labels: **Stream** = workstream (1 imaging, 3 booking); **T/B** =
+> tier intakes (§B of the imaging plan: T = code, B = weights/data,
+> numbered); **Group** = repo cluster by purpose (C orthodontic apps,
+> D PMS/booking, E marketing templates).
+>
+> Companion notes (§B1a/B1b) live on the imaging branches not yet
+> merged. Every row below was verified live via the GitHub API `license`
 > endpoint (or Zenodo API for weights) on 2026-09-03. Re-verify before any
 > push — licenses can change.
 >
-> Rule (non-negotiable): no license file = all rights reserved = **no code
+> Rule (non-negotiable, proposed as ADR 0030 — staged until #415's
+> 0029 merges): no license file = all rights reserved = **no code
 > copied, build-similar only**. MIT/Apache-2.0 = usable **with the copyright
 > notice preserved**. GPL/NC/custom-restricted = **no code**.
 
@@ -65,8 +71,8 @@ No license — no code: `AshisChetia/DentaPremium`, `alaeddineazri/Dentist-Proje
 | `AImageLab-zip/ToothFairy2-Benchmark` | none | — | Benchmark reference only. |
 | `coolleafly/VDING` | **GPL-3.0** ❌ (newly verified) | — | Excluded (ledger B4). |
 
-Full per-repo notes: `docs/technical/pano-backends.md` (ships with the
-`imaging_ai` rebuild, not yet on main).
+Full per-repo notes ship with the `imaging_ai` rebuild (not yet on
+main).
 
 ## Scoreboard
 

--- a/docs/technical/triage-rules-spike.md
+++ b/docs/technical/triage-rules-spike.md
@@ -1,0 +1,31 @@
+# Triage rule-engine spike — design record (Stream 4b, design-only)
+
+> Mining result first: `rahul1947/Orthodontist-Expert-System` (MIT) contains
+> **no code** — course report PDFs + screenshots only. There is no rule
+> engine to port. What follows is an original mini-design; the MIT license
+> imposes no obligation since nothing is copied.
+
+## Idea
+
+Forward-chaining screening rules over data we already own (appointment
+history, recall flags, patient flags, treatment plans) producing
+suggestions, never decisions:
+
+- `no_show x2 in 90d` → suggest confirmation-call task + tighter reminder.
+- `perio diagnosis + no visit in 6mo` → suggest recall.
+- `ortho consult + pano present + age band` → suggest #270 screening Julien.
+
+## Shape (if ever built)
+
+- Pure functions `evaluate_rules(patient_view) -> [suggestion]` — no tables,
+  no migrations, no permissions beyond the reader's own.
+- Surfaced through the existing copilot/agent tool path (READ tool) and the
+  appointment slot (`appointment.completed.followup` pattern), never as
+  autonomous writes. Human confirms every suggestion (copilot approval flow).
+- Clinical-safety caption everywhere ("aid, never diagnosis"), same posture
+  as the imaging modules.
+
+## Status
+
+Design-only, feeds #270. No branch, no code, nothing to verify. Revisit
+when the orthodontics module (#270) is scoped.


### PR DESCRIPTION
## Overview

- Four audited design records, no code: booking-UX patterns mapped
  onto existing modules, a forward-chaining triage mini-design, the
  license-verdict sweep for external repos and AI weights, and the
  cross-cutting compliance posture.
- Rebuilt from the local-only branch with staleness fixes: imaging
  references marked planned (those modules are unmerged),
  `pano-overlay-design.md` deliberately excluded (ships with the
  imaging-viewer rebuild that needs it), booking-UX placed under
  `docs/features/` per the documentation policy.

## Tasks done

- `docs(strategy)`: booking-UX design record, triage-rules spike,
  external-repos license sweep, compliance posture (planned-sections
  marked)

## Modules touched

- None. Docs only; no code, locales, permissions, or generated files.

## Checklist

- [x] docs-layout OK
- [x] No claims about shipped behavior for unmerged modules
  (planned-sections marked, dangling companion refs noted)
- [x] M5-clean: single commit on current `upstream/main`

## Test plan

- Docs-only: `scripts/check_docs_layout.py` green; read the four
  files for accuracy against main.

## Review

`@martinezsalmeron`: ready for review/merge when convenient.
