### PR TITLE
feat(sdi_it): PEC transport — SMTP send, IMAP receipt poll, worker; Imposta rounding and progressivo lock (#133)

### DIFF
--- a/backend/app/modules/sdi_it/CHANGELOG.md
+++ b/backend/app/modules/sdi_it/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — sdi_it
 
+## Unreleased — phase 2
+
+- PEC transport: the clinic's PEC mailbox sends each FPR12 file to the SDI
+  (SMTP) and a worker picks the receipts up (IMAP) every two minutes,
+  learning the dedicated `sdiNN@pec.fatturapa.it` reply address; retry with
+  backoff per file, ten-minute pause of the clinic on mailbox failures.
+- Settings: PEC fields (password encrypted at rest, write-only), `POST
+  /pec/test` (SMTP + IMAP login), `POST /queue/process-now`.
+- `Imposta` per riepilogo is now base × rate rounded once (SDI check 00421).
+- `ProgressivoInvio` counter bumped under a row lock, so two invoices issued
+  at the same instant cannot share a file name.
+- Records carry `transport` and `message_id`; receipt application shared
+  between the API import and the poller.
+
 ## 0.1.0 (2026-09-07) — phase 1
 
 - FatturaPA `FPR12` builder (TD01/TD04, `Natura N4` exempt lines, bollo

--- a/backend/app/modules/sdi_it/__init__.py
+++ b/backend/app/modules/sdi_it/__init__.py
@@ -7,13 +7,15 @@ SDI**. Invoices to natural persons for healthcare services may not be
 electronic (art. 10-bis DL 119/2018); they stay analogue and are reported
 to the Sistema Tessera Sanitaria by a separate module (ADR 0026).
 
-Phase 1 (this module): FPR12 XML for TD01/TD04, manual transport
-(download the file, upload it to the SDI, import the receipt), receipt
-handling RC/NS/MC. PEC transport and the Nuxt layer follow in their own
-PRs. See ``CLAUDE.md`` and ``docs/modules/sdi_it.md``.
+Phase 1: FPR12 XML for TD01/TD04, manual transport (download the file,
+upload it to the SDI, import the receipt), receipt handling RC/NS/MC.
+Phase 2: PEC transport — the clinic's PEC mailbox sends the files and a
+worker picks the receipts up. The Nuxt layer follows in its own PR. See ``CLAUDE.md`` and ``docs/modules/sdi_it.md``.
 """
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter
 
@@ -21,6 +23,9 @@ from app.core.plugins import BaseModule
 
 from .models import SdiItRecord, SdiItSettings
 from .router import router
+
+if TYPE_CHECKING:
+    from app.core.scheduling import ScheduledJob
 
 SDI_TABLES = {"sdi_it_settings", "sdi_it_records"}
 
@@ -51,6 +56,11 @@ class SdiItModule(BaseModule):
 
     def get_router(self) -> APIRouter:
         return router
+
+    def get_scheduled_jobs(self) -> list[ScheduledJob]:
+        from .tasks import scheduled_jobs
+
+        return scheduled_jobs()
 
     def get_permissions(self) -> list[str]:
         # Namespaced → sdi_it.settings.read / .configure, records.read / .manage

--- a/backend/app/modules/sdi_it/hook.py
+++ b/backend/app/modules/sdi_it/hook.py
@@ -68,7 +68,15 @@ async def build_record(
     cessionario = Party.from_recipient(
         tax_id=invoice.billing_tax_id, name=invoice.billing_name, address=invoice.billing_address
     )
-    settings.progressivo_invio = (settings.progressivo_invio or 0) + 1
+    # Two invoices issued at the same instant must not share a progressivo
+    # (and therefore a file name): take the row lock before bumping.
+    locked = (
+        await db.execute(
+            select(SdiItSettings).where(SdiItSettings.id == settings.id).with_for_update()
+        )
+    ).scalar_one()
+    locked.progressivo_invio = (locked.progressivo_invio or 0) + 1
+    settings.progressivo_invio = locked.progressivo_invio
     result = build_fattura(
         invoice,
         cedente=cedente,

--- a/backend/app/modules/sdi_it/hook.py
+++ b/backend/app/modules/sdi_it/hook.py
@@ -69,14 +69,12 @@ async def build_record(
         tax_id=invoice.billing_tax_id, name=invoice.billing_name, address=invoice.billing_address
     )
     # Two invoices issued at the same instant must not share a progressivo
-    # (and therefore a file name): take the row lock before bumping.
-    locked = (
-        await db.execute(
-            select(SdiItSettings).where(SdiItSettings.id == settings.id).with_for_update()
-        )
-    ).scalar_one()
-    locked.progressivo_invio = (locked.progressivo_invio or 0) + 1
-    settings.progressivo_invio = locked.progressivo_invio
+    # (and therefore a file name): lock the row *and* reload it. A plain
+    # ``SELECT … FOR UPDATE`` returns the identity-mapped instance with the
+    # value loaded earlier in this session, so the second request would
+    # bump the stale counter it read before the first one committed.
+    await db.refresh(settings, with_for_update=True)
+    settings.progressivo_invio = (settings.progressivo_invio or 0) + 1
     result = build_fattura(
         invoice,
         cedente=cedente,

--- a/backend/app/modules/sdi_it/migrations/versions/sdi_0002_pec_transport.py
+++ b/backend/app/modules/sdi_it/migrations/versions/sdi_0002_pec_transport.py
@@ -1,0 +1,83 @@
+"""sdi_it: PEC transport columns.
+
+Per-clinic PEC mailbox (SMTP out to the SDI, IMAP in for the receipts)
+on ``sdi_it_settings``; ``transport`` / ``message_id`` / ``next_attempt_at``
+on ``sdi_it_records`` so the worker can retry with backoff and the UI can
+show how a file reached the SDI.
+
+Revision ID: sdi_0002
+Revises: sdi_0001
+Create Date: 2026-09-09
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "sdi_0002"
+down_revision: str | None = "sdi_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("sdi_it_settings", sa.Column("pec_address", sa.String(length=255), nullable=True))
+    op.add_column(
+        "sdi_it_settings",
+        sa.Column(
+            "sdi_pec_address",
+            sa.String(length=255),
+            nullable=False,
+            server_default="sdi01@pec.fatturapa.it",
+        ),
+    )
+    op.add_column("sdi_it_settings", sa.Column("smtp_host", sa.String(length=255), nullable=True))
+    op.add_column(
+        "sdi_it_settings",
+        sa.Column("smtp_port", sa.Integer(), nullable=False, server_default="465"),
+    )
+    op.add_column(
+        "sdi_it_settings", sa.Column("smtp_username", sa.String(length=255), nullable=True)
+    )
+    op.add_column("sdi_it_settings", sa.Column("smtp_password_encrypted", sa.Text(), nullable=True))
+    op.add_column("sdi_it_settings", sa.Column("imap_host", sa.String(length=255), nullable=True))
+    op.add_column(
+        "sdi_it_settings",
+        sa.Column("imap_port", sa.Integer(), nullable=False, server_default="993"),
+    )
+    op.add_column(
+        "sdi_it_settings",
+        sa.Column("imap_folder", sa.String(length=100), nullable=False, server_default="INBOX"),
+    )
+    op.add_column(
+        "sdi_it_settings", sa.Column("last_pec_poll_at", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.add_column(
+        "sdi_it_settings", sa.Column("next_send_after", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.add_column(
+        "sdi_it_records", sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.add_column("sdi_it_records", sa.Column("transport", sa.String(length=10), nullable=True))
+    op.add_column("sdi_it_records", sa.Column("message_id", sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    for col in ("message_id", "transport", "next_attempt_at"):
+        op.drop_column("sdi_it_records", col)
+    for col in (
+        "next_send_after",
+        "last_pec_poll_at",
+        "imap_folder",
+        "imap_port",
+        "imap_host",
+        "smtp_password_encrypted",
+        "smtp_username",
+        "smtp_port",
+        "smtp_host",
+        "sdi_pec_address",
+        "pec_address",
+    ):
+        op.drop_column("sdi_it_settings", col)

--- a/backend/app/modules/sdi_it/models.py
+++ b/backend/app/modules/sdi_it/models.py
@@ -42,6 +42,26 @@ class SdiItSettings(Base, TimestampMixin):
     last_receipt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
     last_error: Mapped[str | None] = mapped_column(Text, default=None)
 
+    # PEC transport (transport == "pec"): the clinic's own PEC mailbox sends
+    # the file to the SDI and receives the receipts. Passwords are Fernet-
+    # encrypted at rest (app.core.email.encryption). ``sdi_pec_address`` is
+    # the SDI mailbox: the first message goes to sdi01@pec.fatturapa.it and
+    # the SDI answers from the dedicated address it assigns (spec §1.3),
+    # which the poller stores here.
+    pec_address: Mapped[str | None] = mapped_column(String(255), default=None)
+    sdi_pec_address: Mapped[str] = mapped_column(
+        String(255), default="sdi01@pec.fatturapa.it", nullable=False
+    )
+    smtp_host: Mapped[str | None] = mapped_column(String(255), default=None)
+    smtp_port: Mapped[int] = mapped_column(Integer, default=465, nullable=False)
+    smtp_username: Mapped[str | None] = mapped_column(String(255), default=None)
+    smtp_password_encrypted: Mapped[str | None] = mapped_column(Text, default=None)
+    imap_host: Mapped[str | None] = mapped_column(String(255), default=None)
+    imap_port: Mapped[int] = mapped_column(Integer, default=993, nullable=False)
+    imap_folder: Mapped[str] = mapped_column(String(100), default="INBOX", nullable=False)
+    last_pec_poll_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+    next_send_after: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+
     clinic: Mapped["Clinic"] = relationship(foreign_keys=[clinic_id])
 
 
@@ -49,7 +69,7 @@ class SdiItRecord(Base):
     """One FPR12 file per issued B2B invoice / credit note.
 
     State machine (ADR 0025 §4): ``pending`` (built, not yet handed to the
-    SDI) → ``exported`` (downloaded / sent, awaiting a receipt) →
+    SDI) → ``exported`` (downloaded, or sent through PEC; awaiting a receipt) →
     ``delivered`` (RC) | ``undeliverable`` (MC, action: notify recipient)
     | ``rejected`` (NS, action: fix and requeue with the same number).
     """
@@ -74,6 +94,10 @@ class SdiItRecord(Base):
 
     state: Mapped[str] = mapped_column(String(20), default="pending", nullable=False, index=True)
     attempts: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    next_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+    # How the file reached the SDI: "manual" (download/upload) or "pec".
+    transport: Mapped[str | None] = mapped_column(String(10), default=None)
+    message_id: Mapped[str | None] = mapped_column(String(255), default=None)
 
     sdi_identifier: Mapped[str | None] = mapped_column(String(40), default=None, index=True)
     receipt_type: Mapped[str | None] = mapped_column(String(4), default=None)

--- a/backend/app/modules/sdi_it/router.py
+++ b/backend/app/modules/sdi_it/router.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.auth.dependencies import ClinicContext, get_clinic_context, require_permission
+from app.core.email.encryption import encrypt_password
 from app.core.schemas import ApiResponse, PaginatedApiResponse
 from app.database import get_db
 from app.modules.billing.models import Invoice
@@ -25,18 +26,25 @@ from app.modules.billing.models import Invoice
 from .hook import get_settings, requeue
 from .models import SdiItRecord, SdiItSettings
 from .schemas import (
+    PecTestResult,
+    QueueProcessResult,
     ReceiptImport,
     ReceiptImportResult,
     SdiRecordResponse,
     SdiSettingsResponse,
     SdiSettingsUpdate,
 )
-from .services.receipts import STATE_FOR_RECEIPT, ReceiptError, parse_receipt
+from .services import submission_queue
+from .services.pec_transport import test_connection
+from .services.receipts import (
+    ReceiptAlreadyAppliedError,
+    ReceiptError,
+    ReceiptUnmatchedError,
+    apply_receipt,
+)
 from .services.xml_builder import SdiBuildError
 
 router = APIRouter()
-
-_TERMINAL = {"delivered", "undeliverable"}
 
 
 def _settings_response(s: SdiItSettings | None) -> SdiSettingsResponse:
@@ -51,6 +59,17 @@ def _settings_response(s: SdiItSettings | None) -> SdiSettingsResponse:
         progressivo_invio=s.progressivo_invio if s else 0,
         last_receipt_at=s.last_receipt_at if s else None,
         last_error=s.last_error if s else None,
+        pec_address=s.pec_address if s else None,
+        sdi_pec_address=s.sdi_pec_address if s else "sdi01@pec.fatturapa.it",
+        smtp_host=s.smtp_host if s else None,
+        smtp_port=s.smtp_port if s else 465,
+        smtp_username=s.smtp_username if s else None,
+        has_smtp_password=bool(s and s.smtp_password_encrypted),
+        imap_host=s.imap_host if s else None,
+        imap_port=s.imap_port if s else 993,
+        imap_folder=s.imap_folder if s else "INBOX",
+        last_pec_poll_at=s.last_pec_poll_at if s else None,
+        next_send_after=s.next_send_after if s else None,
     )
 
 
@@ -74,14 +93,35 @@ async def update_sdi_settings(
     if s is None:
         s = SdiItSettings(clinic_id=ctx.clinic_id, enabled=False)
         db.add(s)
-    for field in ("transport", "regime_fiscale", "bollo_virtuale", "riferimento_normativo"):
+    for field in (
+        "transport",
+        "regime_fiscale",
+        "bollo_virtuale",
+        "riferimento_normativo",
+        "pec_address",
+        "sdi_pec_address",
+        "smtp_host",
+        "smtp_port",
+        "smtp_username",
+        "imap_host",
+        "imap_port",
+        "imap_folder",
+    ):
         value = getattr(data, field)
         if value is not None:
             setattr(s, field, value)
+    if data.smtp_password:
+        s.smtp_password_encrypted = encrypt_password(data.smtp_password)
     if data.enabled is not None:
+        if data.enabled and s.transport == "pec" and submission_queue.credentials_for(s) is None:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "Per il trasporto PEC servono indirizzo PEC, host SMTP e IMAP, utente e password.",
+            )
         s.enabled = data.enabled
         if data.enabled:
             s.last_error = None
+            s.next_send_after = None
     await db.commit()
     await db.refresh(s)
     return ApiResponse(data=_settings_response(s))
@@ -216,56 +256,15 @@ async def import_receipt(
 ) -> ApiResponse[ReceiptImportResult]:
     """Apply an SDI receipt (RC/NS/MC) to the record its ``NomeFile`` names."""
     try:
-        receipt = parse_receipt(data.xml, receipt_file_name=data.file_name)
+        row, receipt = await apply_receipt(
+            db, ctx.clinic_id, data.xml, receipt_file_name=data.file_name
+        )
+    except ReceiptUnmatchedError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+    except ReceiptAlreadyAppliedError as exc:
+        raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
     except ReceiptError as exc:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
-    new_state = STATE_FOR_RECEIPT.get(receipt.type)
-    if new_state is None:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            f"Ricevuta {receipt.type} non applicabile a una fattura FPR12",
-        )
-    if not receipt.nome_file:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "La ricevuta non indica il NomeFile")
-    stem = receipt.nome_file.rsplit(".", 1)[0]
-    row = (
-        (
-            await db.execute(
-                select(SdiItRecord)
-                .where(
-                    SdiItRecord.clinic_id == ctx.clinic_id,
-                    SdiItRecord.file_name.in_(
-                        (receipt.nome_file, f"{stem}.xml", f"{stem}.xml.p7m")
-                    ),
-                )
-                .order_by(SdiItRecord.created_at.desc())
-            )
-        )
-        .scalars()
-        .first()
-    )
-    if row is None:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, f"Nessun record per il file {receipt.nome_file}"
-        )
-    if row.state in _TERMINAL and row.receipt_type == receipt.type:
-        raise HTTPException(status.HTTP_409_CONFLICT, "Ricevuta già importata")
-    now = datetime.now(UTC)
-    row.state = new_state
-    row.receipt_type = receipt.type
-    row.receipt_xml = data.xml
-    row.receipt_at = now
-    row.sdi_identifier = receipt.identificativo_sdi or row.sdi_identifier
-    row.finished_at = now
-    if receipt.type == "NS":
-        row.error_code = ", ".join(c for c, _ in receipt.errors)[:60] or "NS"
-        row.error_message = "; ".join(f"{c}: {d}" for c, d in receipt.errors)[:2000] or receipt.note
-    else:
-        row.error_code = None
-        row.error_message = receipt.note if receipt.type == "MC" else None
-    settings = await get_settings(db, ctx.clinic_id)
-    if settings is not None:
-        settings.last_receipt_at = now
     await db.commit()
     return ApiResponse(
         data=ReceiptImportResult(
@@ -275,3 +274,32 @@ async def import_receipt(
             errors=[{"code": c, "description": d} for c, d in receipt.errors],
         )
     )
+
+
+@router.post("/pec/test", response_model=ApiResponse[PecTestResult])
+async def test_pec(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("sdi_it.settings.configure"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[PecTestResult]:
+    """Log in to the configured SMTP and IMAP servers (no message is sent)."""
+    s = await get_settings(db, ctx.clinic_id)
+    creds = submission_queue.credentials_for(s) if s else None
+    if creds is None:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Credenziali PEC incomplete")
+    return ApiResponse(data=PecTestResult(**await test_connection(creds)))
+
+
+@router.post("/queue/process-now", response_model=ApiResponse[QueueProcessResult])
+async def process_queue_now(
+    ctx: Annotated[ClinicContext, Depends(get_clinic_context)],
+    _: Annotated[None, Depends(require_permission("sdi_it.records.manage"))],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ApiResponse[QueueProcessResult]:
+    """Run one PEC tick for this clinic now instead of waiting for the worker."""
+    s = await get_settings(db, ctx.clinic_id)
+    if s is not None:
+        s.next_send_after = None
+        await db.commit()
+    counters = await submission_queue.process_clinic(db, ctx.clinic_id)
+    return ApiResponse(data=QueueProcessResult(**counters))

--- a/backend/app/modules/sdi_it/schemas.py
+++ b/backend/app/modules/sdi_it/schemas.py
@@ -18,14 +18,51 @@ class SdiSettingsResponse(BaseModel):
     progressivo_invio: int
     last_receipt_at: datetime | None
     last_error: str | None
+    # PEC transport (passwords are write-only; only their presence is reported)
+    pec_address: str | None = None
+    sdi_pec_address: str = "sdi01@pec.fatturapa.it"
+    smtp_host: str | None = None
+    smtp_port: int = 465
+    smtp_username: str | None = None
+    has_smtp_password: bool = False
+    imap_host: str | None = None
+    imap_port: int = 993
+    imap_folder: str = "INBOX"
+    last_pec_poll_at: datetime | None = None
+    next_send_after: datetime | None = None
 
 
 class SdiSettingsUpdate(BaseModel):
     enabled: bool | None = None
-    transport: str | None = Field(default=None, pattern=r"^manual$")
+    transport: str | None = Field(default=None, pattern=r"^(manual|pec)$")
     regime_fiscale: str | None = Field(default=None, pattern=r"^RF(0[1-9]|1[0-9])$")
     bollo_virtuale: bool | None = None
     riferimento_normativo: str | None = Field(default=None, min_length=1, max_length=100)
+    pec_address: str | None = Field(
+        default=None, max_length=255, pattern=r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
+    )
+    sdi_pec_address: str | None = Field(
+        default=None, max_length=255, pattern=r"^[^@\s]+@pec\.fatturapa\.it$"
+    )
+    smtp_host: str | None = Field(default=None, max_length=255)
+    smtp_port: int | None = Field(default=None, ge=1, le=65535)
+    smtp_username: str | None = Field(default=None, max_length=255)
+    smtp_password: str | None = Field(default=None, max_length=500)
+    imap_host: str | None = Field(default=None, max_length=255)
+    imap_port: int | None = Field(default=None, ge=1, le=65535)
+    imap_folder: str | None = Field(default=None, min_length=1, max_length=100)
+
+
+class PecTestResult(BaseModel):
+    smtp: str
+    imap: str
+
+
+class QueueProcessResult(BaseModel):
+    sent: int
+    failed: int
+    receipts: int
+    unmatched: int
 
 
 class SdiRecordResponse(BaseModel):
@@ -44,6 +81,9 @@ class SdiRecordResponse(BaseModel):
     file_name: str
     state: str
     attempts: int
+    next_attempt_at: datetime | None = None
+    transport: str | None = None
+    message_id: str | None = None
     sdi_identifier: str | None
     receipt_type: str | None
     receipt_at: datetime | None

--- a/backend/app/modules/sdi_it/services/pec_transport.py
+++ b/backend/app/modules/sdi_it/services/pec_transport.py
@@ -1,0 +1,199 @@
+"""PEC transport for the SDI (spec §1.3, "Posta Elettronica Certificata").
+
+The clinic's own PEC mailbox is the channel: the FPR12 file goes as an
+attachment to the SDI mailbox (``sdi01@pec.fatturapa.it`` for the first
+message; the SDI then answers from a dedicated ``sdiNN@pec.fatturapa.it``
+address that must be used from then on), and the receipts (RC / NS / MC)
+come back as XML attachments to the same mailbox.
+
+Plain ``smtplib`` / ``imaplib`` from the standard library, run in the
+default executor so the worker never blocks the event loop and no new
+dependency is needed. Nothing here touches the database.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import email
+import imaplib
+import re
+import smtplib
+import ssl
+import zipfile
+from dataclasses import dataclass, field
+from email.message import EmailMessage
+from email.utils import make_msgid, parseaddr
+from functools import partial
+from io import BytesIO
+
+SDI_DOMAIN = "pec.fatturapa.it"
+_RECEIPT_NAME = re.compile(
+    r"^IT[A-Z0-9]{1,28}_[A-Za-z0-9]{1,10}_(RC|NS|MC|MT|AT|NE|DT|EC)_[A-Za-z0-9]{1,3}\.xml$", re.I
+)
+
+
+class PecError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class PecCredentials:
+    address: str  # the clinic's PEC address (From)
+    smtp_host: str
+    smtp_port: int
+    imap_host: str
+    imap_port: int
+    username: str
+    password: str
+    imap_folder: str = "INBOX"
+
+
+@dataclass
+class InboundReceipt:
+    uid: bytes
+    file_name: str
+    xml: str
+    sender: str
+
+
+@dataclass
+class PollResult:
+    receipts: list[InboundReceipt] = field(default_factory=list)
+    sdi_reply_address: str | None = None  # the dedicated SDI mailbox, if it answered
+    skipped: int = 0  # SDI messages without a receipt attachment
+
+
+def build_message(creds: PecCredentials, to_address: str, file_name: str, xml: str) -> EmailMessage:
+    msg = EmailMessage()
+    msg["From"] = creds.address
+    msg["To"] = to_address
+    msg["Subject"] = file_name.rsplit(".", 1)[0]
+    msg["Message-ID"] = make_msgid(domain=creds.address.rsplit("@", 1)[-1] or None)
+    msg.set_content("Fattura elettronica in allegato.")
+    msg.add_attachment(
+        xml.encode("utf-8"), maintype="application", subtype="xml", filename=file_name
+    )
+    return msg
+
+
+def _send_sync(creds: PecCredentials, to_address: str, file_name: str, xml: str) -> str:
+    msg = build_message(creds, to_address, file_name, xml)
+    context = ssl.create_default_context()
+    try:
+        if creds.smtp_port == 465:
+            server: smtplib.SMTP = smtplib.SMTP_SSL(
+                creds.smtp_host, creds.smtp_port, timeout=30, context=context
+            )
+        else:
+            server = smtplib.SMTP(creds.smtp_host, creds.smtp_port, timeout=30)
+            server.starttls(context=context)
+        with server:
+            server.login(creds.username, creds.password)
+            server.send_message(msg)
+    except (smtplib.SMTPException, OSError) as exc:
+        raise PecError(f"SMTP: {exc}") from exc
+    return msg["Message-ID"] or ""
+
+
+async def send_file(creds: PecCredentials, to_address: str, file_name: str, xml: str) -> str:
+    """Send one FPR12 file; returns the outgoing Message-ID."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, partial(_send_sync, creds, to_address, file_name, xml))
+
+
+def _extract_receipts(raw: bytes) -> tuple[list[tuple[str, str]], str]:
+    """(file_name, xml) pairs found in a message + the sender address."""
+    msg = email.message_from_bytes(raw)
+    sender = parseaddr(msg.get("From", ""))[1].lower()
+    out: list[tuple[str, str]] = []
+    for part in msg.walk():
+        name = part.get_filename() or ""
+        payload = part.get_payload(decode=True)
+        if not payload:
+            continue
+        if name.lower().endswith(".zip"):
+            try:
+                with zipfile.ZipFile(BytesIO(payload)) as zf:
+                    for inner in zf.namelist():
+                        if _RECEIPT_NAME.match(inner.rsplit("/", 1)[-1]):
+                            out.append(
+                                (
+                                    inner.rsplit("/", 1)[-1],
+                                    zf.read(inner).decode("utf-8", "replace"),
+                                )
+                            )
+            except zipfile.BadZipFile:
+                continue
+        elif _RECEIPT_NAME.match(name):
+            out.append((name, payload.decode("utf-8", "replace")))
+    return out, sender
+
+
+def _poll_sync(creds: PecCredentials, *, limit: int = 50) -> PollResult:
+    result = PollResult()
+    try:
+        box = imaplib.IMAP4_SSL(creds.imap_host, creds.imap_port, timeout=30)
+        with box:
+            box.login(creds.username, creds.password)
+            box.select(creds.imap_folder)
+            status, data = box.uid("search", None, "UNSEEN", "FROM", SDI_DOMAIN)
+            if status != "OK":
+                raise PecError(f"IMAP search failed: {status}")
+            uids = data[0].split()[:limit] if data and data[0] else []
+            for uid in uids:
+                status, parts = box.uid("fetch", uid, "(RFC822)")
+                if status != "OK" or not parts or not isinstance(parts[0], tuple):
+                    continue
+                receipts, sender = _extract_receipts(parts[0][1])
+                if sender.endswith("@" + SDI_DOMAIN) and sender != f"sdi01@{SDI_DOMAIN}":
+                    result.sdi_reply_address = sender
+                if not receipts:
+                    result.skipped += 1
+                for file_name, xml in receipts:
+                    result.receipts.append(
+                        InboundReceipt(uid=uid, file_name=file_name, xml=xml, sender=sender)
+                    )
+                box.uid("store", uid, "+FLAGS", "(\\Seen)")
+    except (imaplib.IMAP4.error, OSError) as exc:
+        raise PecError(f"IMAP: {exc}") from exc
+    return result
+
+
+async def poll_receipts(creds: PecCredentials, *, limit: int = 50) -> PollResult:
+    """Fetch unseen SDI messages, return their receipt attachments, mark them seen."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, partial(_poll_sync, creds, limit=limit))
+
+
+def _test_sync(creds: PecCredentials) -> dict[str, str]:
+    out: dict[str, str] = {}
+    context = ssl.create_default_context()
+    try:
+        if creds.smtp_port == 465:
+            server: smtplib.SMTP = smtplib.SMTP_SSL(
+                creds.smtp_host, creds.smtp_port, timeout=20, context=context
+            )
+        else:
+            server = smtplib.SMTP(creds.smtp_host, creds.smtp_port, timeout=20)
+            server.starttls(context=context)
+        with server:
+            server.login(creds.username, creds.password)
+        out["smtp"] = "ok"
+    except (smtplib.SMTPException, OSError) as exc:
+        out["smtp"] = f"error: {exc}"
+    try:
+        box = imaplib.IMAP4_SSL(creds.imap_host, creds.imap_port, timeout=20)
+        with box:
+            box.login(creds.username, creds.password)
+            status, _ = box.select(creds.imap_folder, readonly=True)
+            out["imap"] = (
+                "ok" if status == "OK" else f"error: folder {creds.imap_folder} ({status})"
+            )
+    except (imaplib.IMAP4.error, OSError) as exc:
+        out["imap"] = f"error: {exc}"
+    return out
+
+
+async def test_connection(creds: PecCredentials) -> dict[str, str]:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, partial(_test_sync, creds))

--- a/backend/app/modules/sdi_it/services/pec_transport.py
+++ b/backend/app/modules/sdi_it/services/pec_transport.py
@@ -101,10 +101,39 @@ async def send_file(creds: PecCredentials, to_address: str, file_name: str, xml:
     return await loop.run_in_executor(None, partial(_send_sync, creds, to_address, file_name, xml))
 
 
+_SDI_ADDRESS = re.compile(r"[a-z0-9._-]+@" + re.escape(SDI_DOMAIN), re.I)
+
+
+def _sdi_sender(msg: email.message.Message) -> str:
+    """The SDI address a message came from, seen through the PEC envelope.
+
+    A PEC provider delivers the SDI's message inside a *busta di trasporto*:
+    ``From: "Per conto di: sdi07@pec.fatturapa.it" <posta-certificata@…>``
+    with the original message attached as ``postacert.eml``. So the address
+    is looked for in the outer From header (display name included) and in
+    the From of any embedded message; ``parseaddr`` alone would only see
+    the provider's mailbox.
+    """
+    candidates = [str(msg.get("From", ""))]
+    for part in msg.walk():
+        if part.get_content_type() == "message/rfc822":
+            for inner in part.get_payload():
+                candidates.append(str(inner.get("From", "")))
+    for header in candidates:
+        m = _SDI_ADDRESS.search(header)
+        if m:
+            return m.group(0).lower()
+    return parseaddr(msg.get("From", ""))[1].lower()
+
+
 def _extract_receipts(raw: bytes) -> tuple[list[tuple[str, str]], str]:
-    """(file_name, xml) pairs found in a message + the sender address."""
+    """(file_name, xml) pairs found in a message + the SDI sender address.
+
+    ``walk()`` descends into ``message/rfc822`` parts, so attachments of
+    the PEC-enveloped ``postacert.eml`` are found too.
+    """
     msg = email.message_from_bytes(raw)
-    sender = parseaddr(msg.get("From", ""))[1].lower()
+    sender = _sdi_sender(msg)
     out: list[tuple[str, str]] = []
     for part in msg.walk():
         name = part.get_filename() or ""

--- a/backend/app/modules/sdi_it/services/receipts.py
+++ b/backend/app/modules/sdi_it/services/receipts.py
@@ -94,3 +94,92 @@ def parse_receipt(xml: str | bytes, *, receipt_file_name: str | None = None) -> 
 
 
 STATE_FOR_RECEIPT = {"RC": "delivered", "NS": "rejected", "MC": "undeliverable"}
+
+
+# --- applying a receipt to a record (shared by the API import and the PEC poller)
+
+from datetime import UTC, datetime  # noqa: E402
+from typing import TYPE_CHECKING  # noqa: E402
+
+from sqlalchemy import select  # noqa: E402
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from ..models import SdiItRecord
+
+
+class ReceiptUnmatchedError(ReceiptError):
+    """No record of this clinic carries the ``NomeFile`` the receipt names."""
+
+
+class ReceiptAlreadyAppliedError(ReceiptError):
+    """The record already holds this receipt type in a terminal state."""
+
+
+_TERMINAL = {"delivered", "undeliverable"}
+
+
+async def apply_receipt(
+    db: AsyncSession,
+    clinic_id: UUID,
+    xml: str,
+    *,
+    receipt_file_name: str | None = None,
+) -> tuple[SdiItRecord, Receipt]:
+    """Parse ``xml`` and move the matching record to the receipt's state.
+
+    Matches by ``NomeFile`` (with or without the ``.p7m`` suffix), newest
+    record first so a requeued invoice resolves to its latest file. Does
+    not commit.
+    """
+    from ..models import SdiItRecord, SdiItSettings
+
+    receipt = parse_receipt(xml, receipt_file_name=receipt_file_name)
+    new_state = STATE_FOR_RECEIPT.get(receipt.type)
+    if new_state is None:
+        raise ReceiptError(f"Ricevuta {receipt.type} non applicabile a una fattura FPR12")
+    if not receipt.nome_file:
+        raise ReceiptError("La ricevuta non indica il NomeFile")
+    stem = receipt.nome_file.rsplit(".", 1)[0]
+    row = (
+        (
+            await db.execute(
+                select(SdiItRecord)
+                .where(
+                    SdiItRecord.clinic_id == clinic_id,
+                    SdiItRecord.file_name.in_(
+                        (receipt.nome_file, f"{stem}.xml", f"{stem}.xml.p7m")
+                    ),
+                )
+                .order_by(SdiItRecord.created_at.desc())
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if row is None:
+        raise ReceiptUnmatchedError(f"Nessun record per il file {receipt.nome_file}")
+    if row.state in _TERMINAL and row.receipt_type == receipt.type:
+        raise ReceiptAlreadyAppliedError("Ricevuta già importata")
+    now = datetime.now(UTC)
+    row.state = new_state
+    row.receipt_type = receipt.type
+    row.receipt_xml = xml
+    row.receipt_at = now
+    row.sdi_identifier = receipt.identificativo_sdi or row.sdi_identifier
+    row.finished_at = now
+    if receipt.type == "NS":
+        row.error_code = ", ".join(c for c, _ in receipt.errors)[:60] or "NS"
+        row.error_message = "; ".join(f"{c}: {d}" for c, d in receipt.errors)[:2000] or receipt.note
+    else:
+        row.error_code = None
+        row.error_message = receipt.note if receipt.type == "MC" else None
+    settings = (
+        await db.execute(select(SdiItSettings).where(SdiItSettings.clinic_id == clinic_id))
+    ).scalar_one_or_none()
+    if settings is not None:
+        settings.last_receipt_at = now
+    return row, receipt

--- a/backend/app/modules/sdi_it/services/submission_queue.py
+++ b/backend/app/modules/sdi_it/services/submission_queue.py
@@ -1,0 +1,167 @@
+"""PEC worker for ``sdi_it_records`` (ADR 0025 §3, transport ``pec``).
+
+``process_clinic`` sends this clinic's ``pending`` files through its PEC
+mailbox, one message per file, then polls the mailbox for SDI receipts
+and applies them. Rows are locked ``FOR UPDATE SKIP LOCKED`` and the
+session commits *before* each network call, so overlapping ticks never
+double-send and no row lock is held across I/O (the nav_online posture).
+
+Transport errors back off ``min(120·2^(attempts-1), 3600)`` seconds per
+row; a mailbox-level failure (login, DNS) pauses the whole clinic for ten
+minutes and surfaces in ``last_error``. Receipts that name no record are
+logged and skipped (the mailbox may hold files from another system).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.email.encryption import decrypt_password
+
+from ..models import SdiItRecord, SdiItSettings
+from . import pec_transport
+from .receipts import ReceiptError, apply_receipt
+
+logger = logging.getLogger(__name__)
+
+_BATCH = 20
+MAX_ATTEMPTS = 8
+
+
+def credentials_for(settings: SdiItSettings) -> pec_transport.PecCredentials | None:
+    if not (
+        settings.pec_address
+        and settings.smtp_host
+        and settings.imap_host
+        and settings.smtp_username
+        and settings.smtp_password_encrypted
+    ):
+        return None
+    return pec_transport.PecCredentials(
+        address=settings.pec_address,
+        smtp_host=settings.smtp_host,
+        smtp_port=settings.smtp_port or 465,
+        imap_host=settings.imap_host,
+        imap_port=settings.imap_port or 993,
+        username=settings.smtp_username,
+        password=decrypt_password(settings.smtp_password_encrypted),
+        imap_folder=settings.imap_folder or "INBOX",
+    )
+
+
+def _backoff(attempts: int) -> timedelta:
+    return timedelta(seconds=min(120 * (2 ** max(attempts - 1, 0)), 3600))
+
+
+async def _due_pending(db: AsyncSession, clinic_id: UUID) -> list[SdiItRecord]:
+    now = datetime.now(UTC)
+    stmt = (
+        select(SdiItRecord)
+        .where(
+            SdiItRecord.clinic_id == clinic_id,
+            SdiItRecord.state == "pending",
+            (SdiItRecord.next_attempt_at.is_(None)) | (SdiItRecord.next_attempt_at <= now),
+        )
+        .order_by(SdiItRecord.created_at)
+        .limit(_BATCH)
+        .with_for_update(skip_locked=True)
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def process_clinic(db: AsyncSession, clinic_id: UUID) -> dict[str, int]:
+    """Send due pending files, then poll for receipts. Returns counters."""
+    counters = {"sent": 0, "failed": 0, "receipts": 0, "unmatched": 0}
+    settings = (
+        await db.execute(select(SdiItSettings).where(SdiItSettings.clinic_id == clinic_id))
+    ).scalar_one_or_none()
+    if settings is None or not settings.enabled or settings.transport != "pec":
+        return counters
+    if settings.next_send_after and settings.next_send_after > datetime.now(UTC):
+        return counters
+    creds = credentials_for(settings)
+    if creds is None:
+        return counters
+
+    for row in await _due_pending(db, clinic_id):
+        row.attempts += 1
+        row.transport = "pec"
+        await db.commit()  # release the row lock before the network call
+        try:
+            message_id = await pec_transport.send_file(
+                creds, settings.sdi_pec_address, row.file_name, row.xml_payload
+            )
+        except pec_transport.PecError as exc:
+            row.error_message = str(exc)[:500]
+            if row.attempts >= MAX_ATTEMPTS:
+                row.error_code = "PEC"
+                row.next_attempt_at = None
+                row.state = "failed"
+            else:
+                row.next_attempt_at = datetime.now(UTC) + _backoff(row.attempts)
+            counters["failed"] += 1
+            # A mailbox-level failure hits every row the same way: pause the clinic.
+            settings.last_error = f"PEC: {exc}"[:500]
+            settings.next_send_after = datetime.now(UTC) + timedelta(minutes=10)
+            await db.commit()
+            return counters
+        row.state = "exported"
+        row.sent_at = datetime.now(UTC)
+        row.message_id = message_id[:255] or None
+        row.error_message = None
+        row.next_attempt_at = None
+        settings.last_error = None
+        counters["sent"] += 1
+        await db.commit()
+
+    # Receipts: poll the mailbox (network, no locks held), then apply each.
+    try:
+        poll = await pec_transport.poll_receipts(creds)
+    except pec_transport.PecError as exc:
+        settings.last_error = f"PEC: {exc}"[:500]
+        settings.last_pec_poll_at = datetime.now(UTC)
+        await db.commit()
+        return counters
+    settings.last_pec_poll_at = datetime.now(UTC)
+    if poll.sdi_reply_address and poll.sdi_reply_address != settings.sdi_pec_address:
+        settings.sdi_pec_address = poll.sdi_reply_address
+    for inbound in poll.receipts:
+        try:
+            await apply_receipt(db, clinic_id, inbound.xml, receipt_file_name=inbound.file_name)
+            counters["receipts"] += 1
+        except ReceiptError as exc:
+            counters["unmatched"] += 1
+            logger.info("sdi_it: receipt %s not applied: %s", inbound.file_name, exc)
+    await db.commit()
+    return counters
+
+
+async def process_all(session_maker) -> dict[str, int]:
+    totals = {"sent": 0, "failed": 0, "receipts": 0, "unmatched": 0}
+    async with session_maker() as db:
+        clinic_ids = list(
+            (
+                await db.execute(
+                    select(SdiItSettings.clinic_id).where(
+                        SdiItSettings.enabled.is_(True), SdiItSettings.transport == "pec"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    for clinic_id in clinic_ids:
+        async with session_maker() as db:
+            try:
+                counters = await process_clinic(db, clinic_id)
+            except Exception:  # noqa: BLE001 - one clinic must not stop the others
+                logger.exception("sdi_it: PEC tick failed for clinic %s", clinic_id)
+                continue
+        for k, v in counters.items():
+            totals[k] += v
+    return totals

--- a/backend/app/modules/sdi_it/services/xml_builder.py
+++ b/backend/app/modules/sdi_it/services/xml_builder.py
@@ -231,13 +231,18 @@ def build_fattura(
         raise SdiBuildError("La fattura non ha una data di emissione.")
     lines = _lines(invoice)
 
-    # Riepilogo per (aliquota, natura)
-    groups: dict[tuple[Decimal, str | None], tuple[Decimal, Decimal]] = {}
+    # Riepilogo per (aliquota, natura). ``Imposta`` is the group's base × rate
+    # rounded once: the SDI check (code 00421) compares it with
+    # ImponibileImporto × AliquotaIVA within one cent, which a sum of
+    # per-line roundings can miss on many small lines.
+    bases: dict[tuple[Decimal, str | None], Decimal] = {}
     for ln in lines:
-        base, tax = groups.get((ln.aliquota, ln.natura), (Decimal(0), Decimal(0)))
-        base += ln.prezzo_totale
-        tax += (ln.prezzo_totale * ln.aliquota / 100).quantize(_Q2, rounding=ROUND_HALF_UP)
-        groups[(ln.aliquota, ln.natura)] = (base, tax)
+        key = (ln.aliquota, ln.natura)
+        bases[key] = bases.get(key, Decimal(0)) + ln.prezzo_totale
+    groups: dict[tuple[Decimal, str | None], tuple[Decimal, Decimal]] = {
+        (rate, natura): (base, (base * rate / 100).quantize(_Q2, rounding=ROUND_HALF_UP))
+        for (rate, natura), base in bases.items()
+    }
     exempt_total = sum((b for (_, n), (b, _) in groups.items() if n), Decimal(0))
     bollo = bool(bollo_virtuale and exempt_total > BOLLO_THRESHOLD)
     # The stamp is the issuer's cost: billing has no bollo line, so the

--- a/backend/app/modules/sdi_it/tasks.py
+++ b/backend/app/modules/sdi_it/tasks.py
@@ -1,0 +1,32 @@
+"""sdi_it scheduled job: PEC send + receipt poll for every clinic on ``pec``."""
+
+from __future__ import annotations
+
+import logging
+
+from app.core.scheduling import ScheduledJob
+from app.database import async_session_maker
+
+from .services import submission_queue
+
+logger = logging.getLogger(__name__)
+
+JOB_ID_PEC = "sdi_it_pec"
+
+
+async def process_pec() -> None:
+    totals = await submission_queue.process_all(async_session_maker)
+    if any(totals.values()):
+        logger.info("sdi_it PEC tick: %s", totals)
+
+
+def scheduled_jobs() -> list[ScheduledJob]:
+    return [
+        ScheduledJob(
+            id=JOB_ID_PEC,
+            func=process_pec,
+            trigger="interval",
+            trigger_args={"seconds": 120},
+            name="SDI (IT): send pending FPR12 files through PEC and pick up the receipts",
+        )
+    ]

--- a/backend/tests/modules/sdi_it/test_hook.py
+++ b/backend/tests/modules/sdi_it/test_hook.py
@@ -210,3 +210,36 @@ async def test_progressivo_is_unique_across_builds(db_session):
     assert names == {"IT01234567897_00001.xml", "IT01234567897_00002.xml"}
     settings = (await db_session.execute(select(SdiItSettings))).scalar_one()
     assert settings.progressivo_invio == 2
+
+
+@pytest.mark.asyncio
+async def test_progressivo_lock_reads_the_committed_value_not_the_identity_map(db_session):
+    """Two requests hold the settings row in their own sessions; the second
+    must bump the value the first committed, not the copy it loaded earlier."""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+    from sqlalchemy.orm import selectinload
+
+    from app.modules.billing.models import Invoice
+    from app.modules.sdi_it.hook import build_record
+
+    clinic, invoice = await _setup(db_session)
+    await db_session.commit()  # the other session must see the rows
+    other = async_sessionmaker(db_session.bind, class_=AsyncSession, expire_on_commit=False)()
+    try:
+        mine = (await db_session.execute(select(SdiItSettings))).scalar_one()
+        theirs = (await other.execute(select(SdiItSettings))).scalar_one()
+        their_invoice = (
+            await other.execute(
+                select(Invoice).options(selectinload(Invoice.items)).where(Invoice.id == invoice.id)
+            )
+        ).scalar_one()
+        first = await build_record(other, their_invoice, theirs)
+        await other.commit()
+        second = await build_record(db_session, invoice, mine)
+        await db_session.commit()
+        assert {first.file_name, second.file_name} == {
+            "IT01234567897_00001.xml",
+            "IT01234567897_00002.xml",
+        }
+    finally:
+        await other.close()

--- a/backend/tests/modules/sdi_it/test_hook.py
+++ b/backend/tests/modules/sdi_it/test_hook.py
@@ -197,3 +197,16 @@ async def test_recipient_edit_is_allowed_only_after_a_scarto_and_requeues(db_ses
     assert [r.state for r in records] == ["rejected", "pending"]
     assert records[0].finished_at is not None
     assert "<IdCodice>01234567897</IdCodice>" in records[1].xml_payload
+
+
+@pytest.mark.asyncio
+async def test_progressivo_is_unique_across_builds(db_session):
+    clinic, invoice = await _setup(db_session)
+    hook = SdiItHook()
+    first = await hook.on_invoice_issued(invoice, db_session)
+    invoice.invoice_number = "E/2026/0002"
+    second = await hook.on_invoice_issued(invoice, db_session)
+    names = {first["IT"]["file_name"], second["IT"]["file_name"]}
+    assert names == {"IT01234567897_00001.xml", "IT01234567897_00002.xml"}
+    settings = (await db_session.execute(select(SdiItSettings))).scalar_one()
+    assert settings.progressivo_invio == 2

--- a/backend/tests/modules/sdi_it/test_pec_transport.py
+++ b/backend/tests/modules/sdi_it/test_pec_transport.py
@@ -1,0 +1,162 @@
+"""PEC transport with fake smtplib/imaplib: message shape, receipt extraction, SDI reply address."""
+
+import email
+from email.message import EmailMessage
+
+import pytest
+
+from app.modules.sdi_it.services import pec_transport as pt
+
+CREDS = pt.PecCredentials(
+    address="studio@pec.example.it",
+    smtp_host="smtps.example.it",
+    smtp_port=465,
+    imap_host="imaps.example.it",
+    imap_port=993,
+    username="studio@pec.example.it",
+    password="pw",
+)
+NS = "http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/messaggi/v1.0"
+
+
+def _rc(file_name="IT01234567897_00001.xml") -> str:
+    return (
+        f'<ns3:RicevutaConsegna xmlns:ns3="{NS}"><IdentificativoSdI>77</IdentificativoSdI>'
+        f"<NomeFile>{file_name}</NomeFile></ns3:RicevutaConsegna>"
+    )
+
+
+def _sdi_message(sender: str, attachments: list[tuple[str, bytes]]) -> bytes:
+    msg = EmailMessage()
+    msg["From"] = f"Sistema di Interscambio <{sender}>"
+    msg["To"] = CREDS.address
+    msg["Subject"] = "RICEZIONE"
+    msg.set_content("ricevuta")
+    for name, payload in attachments:
+        sub = "zip" if name.endswith(".zip") else "xml"
+        msg.add_attachment(payload, maintype="application", subtype=sub, filename=name)
+    return msg.as_bytes()
+
+
+class _FakeSMTP:
+    sent: list[EmailMessage] = []
+    logins: list[tuple[str, str]] = []
+
+    def __init__(self, host, port, timeout=None, context=None):
+        self.host, self.port = host, port
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def login(self, u, p):
+        _FakeSMTP.logins.append((u, p))
+
+    def send_message(self, msg):
+        _FakeSMTP.sent.append(msg)
+
+    def starttls(self, context=None):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_send_file_attaches_the_xml_and_addresses_the_sdi(monkeypatch):
+    _FakeSMTP.sent.clear()
+    monkeypatch.setattr(pt.smtplib, "SMTP_SSL", _FakeSMTP)
+    mid = await pt.send_file(CREDS, "sdi01@pec.fatturapa.it", "IT01234567897_00001.xml", "<x/>")
+    assert mid.startswith("<") and _FakeSMTP.logins[-1] == (CREDS.username, "pw")
+    msg = _FakeSMTP.sent[-1]
+    assert msg["To"] == "sdi01@pec.fatturapa.it" and msg["From"] == CREDS.address
+    att = [p for p in msg.walk() if p.get_filename()]
+    assert att[0].get_filename() == "IT01234567897_00001.xml"
+    assert att[0].get_payload(decode=True) == b"<x/>"
+
+
+@pytest.mark.asyncio
+async def test_send_file_wraps_smtp_errors(monkeypatch):
+    class Boom(_FakeSMTP):
+        def login(self, u, p):
+            raise pt.smtplib.SMTPAuthenticationError(535, b"bad")
+
+    monkeypatch.setattr(pt.smtplib, "SMTP_SSL", Boom)
+    with pytest.raises(pt.PecError, match="SMTP"):
+        await pt.send_file(CREDS, "sdi01@pec.fatturapa.it", "f.xml", "<x/>")
+
+
+def test_extract_receipts_reads_xml_and_zip_attachments_and_ignores_others():
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("IT01234567897_00002_NS_001.xml", _rc("IT01234567897_00002.xml"))
+        zf.writestr("readme.txt", "x")
+    raw = _sdi_message(
+        "sdi07@pec.fatturapa.it",
+        [
+            ("IT01234567897_00001_RC_001.xml", _rc().encode()),
+            ("bundle.zip", buf.getvalue()),
+            ("daticert.xml", b"<pec/>"),
+        ],
+    )
+    receipts, sender = pt._extract_receipts(raw)
+    assert sender == "sdi07@pec.fatturapa.it"
+    assert sorted(n for n, _ in receipts) == [
+        "IT01234567897_00001_RC_001.xml",
+        "IT01234567897_00002_NS_001.xml",
+    ]
+
+
+class _FakeIMAP:
+    messages: dict[bytes, bytes] = {}
+    flagged: list[bytes] = []
+
+    def __init__(self, host, port, timeout=None):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def login(self, u, p):
+        pass
+
+    def select(self, folder, readonly=False):
+        return "OK", [b"1"]
+
+    def uid(self, cmd, *args):
+        if cmd == "search":
+            return "OK", [b" ".join(self.messages)]
+        if cmd == "fetch":
+            return "OK", [(b"1 (RFC822 {n})", self.messages[args[0]])]
+        if cmd == "store":
+            _FakeIMAP.flagged.append(args[0])
+            return "OK", [b""]
+        raise AssertionError(cmd)
+
+
+@pytest.mark.asyncio
+async def test_poll_receipts_returns_attachments_marks_seen_and_learns_the_sdi_address(monkeypatch):
+    _FakeIMAP.messages = {
+        b"11": _sdi_message(
+            "sdi07@pec.fatturapa.it", [("IT01234567897_00001_RC_001.xml", _rc().encode())]
+        ),
+        b"12": _sdi_message("sdi07@pec.fatturapa.it", []),
+    }
+    _FakeIMAP.flagged.clear()
+    monkeypatch.setattr(pt.imaplib, "IMAP4_SSL", _FakeIMAP)
+    result = await pt.poll_receipts(CREDS)
+    assert [r.file_name for r in result.receipts] == ["IT01234567897_00001_RC_001.xml"]
+    assert result.receipts[0].xml.startswith("<ns3:RicevutaConsegna")
+    assert result.sdi_reply_address == "sdi07@pec.fatturapa.it" and result.skipped == 1
+    assert sorted(_FakeIMAP.flagged) == [b"11", b"12"]
+
+
+def test_build_message_subject_is_the_file_stem():
+    msg = pt.build_message(CREDS, "sdi01@pec.fatturapa.it", "IT01234567897_0000A.xml", "<x/>")
+    assert msg["Subject"] == "IT01234567897_0000A"
+    assert email.message_from_bytes(msg.as_bytes())["To"] == "sdi01@pec.fatturapa.it"

--- a/backend/tests/modules/sdi_it/test_pec_transport.py
+++ b/backend/tests/modules/sdi_it/test_pec_transport.py
@@ -160,3 +160,24 @@ def test_build_message_subject_is_the_file_stem():
     msg = pt.build_message(CREDS, "sdi01@pec.fatturapa.it", "IT01234567897_0000A.xml", "<x/>")
     assert msg["Subject"] == "IT01234567897_0000A"
     assert email.message_from_bytes(msg.as_bytes())["To"] == "sdi01@pec.fatturapa.it"
+
+
+def test_extract_receipts_sees_through_the_pec_busta_di_trasporto():
+    """PEC providers wrap the SDI message: outer From is the provider's
+    posta-certificata address with "Per conto di: sdiNN@…" as display name,
+    and the original message travels as a postacert.eml attachment."""
+    inner = email.message_from_bytes(
+        _sdi_message("sdi07@pec.fatturapa.it", [("IT01234567897_00001_RC_001.xml", _rc().encode())])
+    )
+    outer = EmailMessage()
+    outer["From"] = '"Per conto di: sdi07@pec.fatturapa.it" <posta-certificata@pec.aruba.it>'
+    outer["To"] = CREDS.address
+    outer["Subject"] = "POSTA CERTIFICATA: RICEZIONE"
+    outer.set_content("Messaggio di posta certificata")
+    outer.add_attachment(
+        b"<daticert/>", maintype="application", subtype="xml", filename="daticert.xml"
+    )
+    outer.add_attachment(inner, filename="postacert.eml")
+    receipts, sender = pt._extract_receipts(outer.as_bytes())
+    assert sender == "sdi07@pec.fatturapa.it"
+    assert [n for n, _ in receipts] == ["IT01234567897_00001_RC_001.xml"]

--- a/backend/tests/modules/sdi_it/test_queue.py
+++ b/backend/tests/modules/sdi_it/test_queue.py
@@ -1,0 +1,180 @@
+"""PEC worker: send pending rows, back off on failure, apply polled receipts."""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.core.auth.models import Clinic
+from app.core.email.encryption import encrypt_password
+from app.modules.sdi_it.models import SdiItRecord, SdiItSettings
+from app.modules.sdi_it.services import pec_transport as pt
+from app.modules.sdi_it.services import submission_queue as q
+
+NS = "http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/messaggi/v1.0"
+
+
+async def _setup(db, *, transport="pec", enabled=True):
+    clinic = Clinic(
+        id=uuid4(), name="Rossi", tax_id="01234567897", currency="EUR", settings={"country": "IT"}
+    )
+    db.add(clinic)
+    settings = SdiItSettings(
+        clinic_id=clinic.id,
+        enabled=enabled,
+        transport=transport,
+        pec_address="studio@pec.example.it",
+        smtp_host="smtps.example.it",
+        imap_host="imaps.example.it",
+        smtp_username="studio@pec.example.it",
+        smtp_password_encrypted=encrypt_password("pw"),
+    )
+    db.add(settings)
+    from app.core.auth.models import User
+    from app.modules.billing.models import Invoice
+    from app.modules.patients.models import Patient
+
+    user = User(
+        id=uuid4(), email=f"u-{uuid4()}@x.test", password_hash="x", first_name="A", last_name="B"
+    )
+    patient = Patient(id=uuid4(), clinic_id=clinic.id, first_name="M", last_name="R")
+    db.add_all([user, patient])
+    invoice = Invoice(
+        id=uuid4(),
+        clinic_id=clinic.id,
+        patient_id=patient.id,
+        invoice_number="E/1",
+        sequential_number=1,
+        status="issued",
+        issue_date=datetime.now(UTC).date(),
+        billing_name="Alfa",
+        billing_tax_id="00000000000",
+        subtotal=Decimal("10"),
+        total=Decimal("10"),
+        created_by=user.id,
+        issued_by=user.id,
+    )
+    db.add(invoice)
+    await db.flush()
+    rec = SdiItRecord(
+        clinic_id=clinic.id,
+        invoice_id=invoice.id,
+        tipo_documento="TD01",
+        invoice_number="E/1",
+        issue_date=invoice.issue_date,
+        gross_amount=Decimal("10"),
+        codice_destinatario="0000000",
+        progressivo="00001",
+        file_name="IT01234567897_00001.xml",
+        xml_payload="<x/>",
+        state="pending",
+        created_at=datetime.now(UTC),
+    )
+    db.add(rec)
+    await db.commit()
+    return clinic, settings, rec
+
+
+@pytest.mark.asyncio
+async def test_tick_sends_pending_and_applies_receipts(db_session, monkeypatch):
+    clinic, settings, rec = await _setup(db_session)
+    sent = []
+
+    async def fake_send(creds, to, name, xml):
+        sent.append((to, name))
+        return "<mid@pec>"
+
+    async def fake_poll(creds, limit=50):
+        rc = (
+            f'<ns3:RicevutaConsegna xmlns:ns3="{NS}"><IdentificativoSdI>9</IdentificativoSdI>'
+            "<NomeFile>IT01234567897_00001.xml</NomeFile></ns3:RicevutaConsegna>"
+        )
+        return pt.PollResult(
+            receipts=[
+                pt.InboundReceipt(
+                    uid=b"1",
+                    file_name="IT01234567897_00001_RC_001.xml",
+                    xml=rc,
+                    sender="sdi07@pec.fatturapa.it",
+                )
+            ],
+            sdi_reply_address="sdi07@pec.fatturapa.it",
+        )
+
+    monkeypatch.setattr(pt, "send_file", fake_send)
+    monkeypatch.setattr(pt, "poll_receipts", fake_poll)
+    counters = await q.process_clinic(db_session, clinic.id)
+    assert counters == {"sent": 1, "failed": 0, "receipts": 1, "unmatched": 0}
+    assert sent == [("sdi01@pec.fatturapa.it", "IT01234567897_00001.xml")]
+    await db_session.refresh(rec)
+    await db_session.refresh(settings)
+    assert rec.state == "delivered" and rec.transport == "pec" and rec.message_id == "<mid@pec>"
+    assert rec.sdi_identifier == "9" and rec.receipt_type == "RC"
+    assert settings.sdi_pec_address == "sdi07@pec.fatturapa.it"  # learned from the reply
+    assert settings.last_pec_poll_at is not None and settings.last_error is None
+
+
+@pytest.mark.asyncio
+async def test_smtp_failure_backs_off_and_pauses_the_clinic(db_session, monkeypatch):
+    clinic, settings, rec = await _setup(db_session)
+
+    async def boom(*a, **k):
+        raise pt.PecError("SMTP: 535 bad login")
+
+    monkeypatch.setattr(pt, "send_file", boom)
+    counters = await q.process_clinic(db_session, clinic.id)
+    assert counters["failed"] == 1 and counters["sent"] == 0
+    await db_session.refresh(rec)
+    await db_session.refresh(settings)
+    assert rec.state == "pending" and rec.attempts == 1 and rec.next_attempt_at is not None
+    assert "535" in rec.error_message and settings.next_send_after is not None
+    # Paused: the next tick does nothing until next_send_after passes.
+    assert await q.process_clinic(db_session, clinic.id) == {
+        "sent": 0,
+        "failed": 0,
+        "receipts": 0,
+        "unmatched": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_manual_transport_and_disabled_are_inert(db_session, monkeypatch):
+    clinic, settings, rec = await _setup(db_session, transport="manual")
+
+    async def never(*a, **k):
+        raise AssertionError("must not be called")
+
+    monkeypatch.setattr(pt, "send_file", never)
+    monkeypatch.setattr(pt, "poll_receipts", never)
+    assert (await q.process_clinic(db_session, clinic.id))["sent"] == 0
+    settings.transport = "pec"
+    settings.enabled = False
+    await db_session.commit()
+    assert (await q.process_clinic(db_session, clinic.id))["sent"] == 0
+    assert (await db_session.execute(select(SdiItRecord.state))).scalar_one() == "pending"
+
+
+@pytest.mark.asyncio
+async def test_unmatched_receipt_is_counted_not_fatal(db_session, monkeypatch):
+    clinic, settings, rec = await _setup(db_session)
+    rec.state = "exported"
+    await db_session.commit()
+
+    async def fake_poll(creds, limit=50):
+        rc = f'<ns3:RicevutaConsegna xmlns:ns3="{NS}"><NomeFile>IT99999999999_00009.xml</NomeFile></ns3:RicevutaConsegna>'
+        return pt.PollResult(
+            receipts=[
+                pt.InboundReceipt(
+                    uid=b"2",
+                    file_name="IT99999999999_00009_RC_001.xml",
+                    xml=rc,
+                    sender="sdi07@pec.fatturapa.it",
+                )
+            ]
+        )
+
+    monkeypatch.setattr(pt, "poll_receipts", fake_poll)
+    counters = await q.process_clinic(db_session, clinic.id)
+    assert counters["unmatched"] == 1 and counters["receipts"] == 0

--- a/backend/tests/modules/sdi_it/test_router.py
+++ b/backend/tests/modules/sdi_it/test_router.py
@@ -83,8 +83,8 @@ async def test_settings_roundtrip(client: AsyncClient, auth_headers, test_clinic
     assert res.status_code == 200, res.text
     body = res.json()["data"]
     assert body["enabled"] and body["regime_fiscale"] == "RF19" and body["bollo_virtuale"] is False
-    res = await client.put(SETTINGS, json={"transport": "pec"}, headers=auth_headers)
-    assert res.status_code == 422  # not in this phase
+    res = await client.put(SETTINGS, json={"transport": "sdicoop"}, headers=auth_headers)
+    assert res.status_code == 422  # only manual | pec
 
 
 @pytest.mark.asyncio
@@ -154,3 +154,78 @@ async def test_receipt_rejects_garbage(client: AsyncClient, auth_headers, test_c
         headers=auth_headers,
     )
     assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_pec_settings_enable_requires_credentials_and_test_endpoint(
+    client: AsyncClient, auth_headers, test_clinic, monkeypatch
+):
+    res = await client.put(
+        SETTINGS, json={"transport": "pec", "enabled": True}, headers=auth_headers
+    )
+    assert res.status_code == 400  # incomplete credentials
+    creds = {
+        "transport": "pec",
+        "pec_address": "studio@pec.example.it",
+        "smtp_host": "smtps.example.it",
+        "imap_host": "imaps.example.it",
+        "smtp_username": "studio@pec.example.it",
+        "smtp_password": "secret",
+    }
+    res = await client.put(SETTINGS, json=creds, headers=auth_headers)
+    assert res.status_code == 200, res.text
+    body = res.json()["data"]
+    assert body["has_smtp_password"] is True and "smtp_password" not in body
+    assert body["sdi_pec_address"] == "sdi01@pec.fatturapa.it" and body["smtp_port"] == 465
+    res = await client.put(SETTINGS, json={"enabled": True}, headers=auth_headers)
+    assert res.status_code == 200 and res.json()["data"]["enabled"] is True
+    res = await client.put(
+        SETTINGS, json={"sdi_pec_address": "evil@example.com"}, headers=auth_headers
+    )
+    assert res.status_code == 422  # only *.pec.fatturapa.it
+
+    import importlib
+
+    sdi_router_mod = importlib.import_module("app.modules.sdi_it.router")
+
+    async def fake_test(creds):
+        return {"smtp": "ok", "imap": "ok"}
+
+    monkeypatch.setattr(sdi_router_mod, "test_connection", fake_test)
+    res = await client.post("/api/v1/sdi_it/pec/test", headers=auth_headers)
+    assert res.status_code == 200 and res.json()["data"] == {"smtp": "ok", "imap": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_process_now_runs_one_tick(
+    client: AsyncClient, auth_headers, test_clinic, test_patient, db_session, monkeypatch
+):
+    await _queued_record(db_session, test_clinic, test_patient)
+    settings = (await db_session.execute(select(SdiItSettings))).scalar_one()
+    settings.transport = "pec"
+    settings.pec_address = "studio@pec.example.it"
+    settings.smtp_host = "smtps.example.it"
+    settings.imap_host = "imaps.example.it"
+    settings.smtp_username = "studio@pec.example.it"
+    from app.core.email.encryption import encrypt_password
+
+    settings.smtp_password_encrypted = encrypt_password("pw")
+    await db_session.commit()
+    from app.modules.sdi_it.services import pec_transport as pt
+
+    async def fake_send(creds, to, name, xml):
+        return "<m@pec>"
+
+    async def fake_poll(creds, limit=50):
+        return pt.PollResult()
+
+    monkeypatch.setattr(pt, "send_file", fake_send)
+    monkeypatch.setattr(pt, "poll_receipts", fake_poll)
+    res = await client.post("/api/v1/sdi_it/queue/process-now", headers=auth_headers)
+    assert res.status_code == 200, res.text
+    assert res.json()["data"]["sent"] == 1
+    res = await client.get("/api/v1/sdi_it/records", headers=auth_headers)
+    row = res.json()["data"][0]
+    assert (
+        row["state"] == "exported" and row["transport"] == "pec" and row["message_id"] == "<m@pec>"
+    )

--- a/backend/tests/modules/sdi_it/test_uninstall_roundtrip.py
+++ b/backend/tests/modules/sdi_it/test_uninstall_roundtrip.py
@@ -40,7 +40,7 @@ def test_sdi_it_uninstall_roundtrip_is_branch_scoped() -> None:
     _alembic("upgrade", "heads")
     before = asyncio.run(_tables_async())
     assert SDI_TABLES.issubset(before)
-    _alembic("downgrade", "sdi_it@-1")
+    _alembic("downgrade", "sdi_it@-2")  # both revisions of the branch
     after = asyncio.run(_tables_async())
     assert SDI_TABLES.isdisjoint(after) and after == before - SDI_TABLES
     _alembic("upgrade", "heads")

--- a/backend/tests/modules/sdi_it/test_xml_builder.py
+++ b/backend/tests/modules/sdi_it/test_xml_builder.py
@@ -175,3 +175,15 @@ def test_progressivo_and_file_name():
     assert progressivo_invio(36) == "00010"
     assert progressivo_invio(36**5 - 1) == "ZZZZZ"
     assert file_name("01234567897", "0000Z") == "IT01234567897_0000Z.xml"
+
+
+def test_imposta_is_base_times_rate_rounded_once():
+    # Nine lines of 0.99 at 22 %: per-line rounding gives 9 × 0.22 = 1.98,
+    # base × rate gives 8.91 × 0.22 = 1.9602 → 1.96 (what the SDI checks).
+    items = [_item(f"Voce {i}", "0.99", rate=22.0, order=i) for i in range(9)]
+    res = build_fattura(_invoice(items), cedente=CEDENTE, cessionario=INSURER, progressivo="00009")
+    doc = _validate(res.xml)
+    riepilogo = doc.find("FatturaElettronicaBody/DatiBeniServizi/DatiRiepilogo")
+    assert riepilogo.find("ImponibileImporto").text == "8.91"
+    assert riepilogo.find("Imposta").text == "1.96"
+    assert res.gross_amount == Decimal("10.87")

--- a/docs/modules/sdi_it.md
+++ b/docs/modules/sdi_it.md
@@ -1,6 +1,6 @@
 # sdi_it — FatturaPA / SDI e-invoicing (Italy)
 
-**Status:** phase 1 (manual transport). Issue #133, ADR 0025.
+**Status:** phase 2 (manual + PEC transport). Issue #133, ADR 0025.
 
 ## What it does
 
@@ -25,6 +25,24 @@ Sanitaria module (ADR 0026). The hook records
 `compliance_data["IT"] = {"sdi": "not_applicable", "reason": "b2c_healthcare_art_10bis"}`
 on those invoices so the UI can say why.
 
+## PEC transport
+
+With `transport = pec` the clinic's own PEC mailbox is the channel (spec
+§1.3): every `pending` file is sent as an XML attachment to the SDI
+mailbox (`sdi01@pec.fatturapa.it` for the first message; the SDI answers
+from a dedicated `sdiNN@pec.fatturapa.it` address, which the poller stores
+and uses from then on), and the receipts come back as attachments to the
+same mailbox. A worker runs every two minutes: send due files, then read
+unseen SDI messages, apply RC/NS/MC (also from `.zip` attachments) and mark
+them seen. Failures back off per file (2 min → 1 h, eight attempts, then
+`failed`) and a mailbox-level error pauses the clinic for ten minutes with
+the message in `last_error`. Settings: `pec_address`, `smtp_host`/`port`
+(465 SSL or STARTTLS), `smtp_username`, `smtp_password` (write-only,
+encrypted at rest), `imap_host`/`port`/`folder`; `POST /pec/test` logs in
+to both servers without sending; `POST /queue/process-now` runs one tick.
+Every Italian professional already has a PEC mailbox (obligatory for the
+albo), so nothing needs accrediting.
+
 ## Configuration (`/api/v1/sdi_it/settings`)
 
 - `enabled`, `transport` (`manual`), `regime_fiscale` (`RF01` ordinario,
@@ -48,9 +66,9 @@ on those invoices so the UI can say why.
 
 `GET/PUT /settings`, `GET /records`, `GET /records/{id}/xml`,
 `POST /records/{id}/exported`, `POST /records/{id}/requeue`,
-`POST /receipts` (`{xml, file_name?}`).
+`POST /receipts` (`{xml, file_name?}`), `POST /pec/test`, `POST /queue/process-now`.
 
-## Not in phase 1
+## Not yet
 
-PEC transport (SMTP/IMAP automation), SdICoop, digital signature,
-`Allegati` (PDF copy inside the XML), the Nuxt layer.
+SdICoop, digital signature, `Allegati` (PDF copy inside the XML), the Nuxt
+layer (settings and records pages, receipt upload).

--- a/docs/technical/sdi_it/overview.md
+++ b/docs/technical/sdi_it/overview.md
@@ -35,6 +35,19 @@ invoices to persone fisiche may not be electronic (art. 10-bis DL
 4. `POST /records/{id}/requeue` after a scarto: same number and date,
    new progressivo, old record kept as history.
 
+## PEC transport (phase 2)
+
+`services/pec_transport.py` (stdlib `smtplib`/`imaplib` in the default
+executor, no new dependency): `send_file` attaches the FPR12 to a message
+for the SDI mailbox; `poll_receipts` reads unseen messages from
+`pec.fatturapa.it`, extracts receipt attachments (XML or inside a zip),
+marks them seen and reports the SDI's dedicated reply address.
+`services/submission_queue.process_clinic` drains one clinic (rows locked
+`FOR UPDATE SKIP LOCKED`, commit before every network call, backoff per
+row, clinic paused ten minutes on mailbox errors) and applies receipts via
+`services/receipts.apply_receipt`, shared with the API import.
+`tasks.py` schedules it every 120 s.
+
 ## API surface
 
 - `GET /api/v1/sdi_it/settings`, `PUT /api/v1/sdi_it/settings`
@@ -43,6 +56,8 @@ invoices to persone fisiche may not be electronic (art. 10-bis DL
 - `POST /api/v1/sdi_it/records/{record_id}/exported`
 - `POST /api/v1/sdi_it/records/{record_id}/requeue`
 - `POST /api/v1/sdi_it/receipts`
+- `POST /api/v1/sdi_it/pec/test`
+- `POST /api/v1/sdi_it/queue/process-now`
 
 ## Tests
 
@@ -52,7 +67,7 @@ credit notes, router lifecycle, Alembic round-trip uninstall.
 
 ## Not yet
 
-PEC transport, SdICoop, digital signature, `Allegati`, Nuxt layer.
+SdICoop, digital signature, `Allegati`, Nuxt layer.
 
 ## See also
 

--- a/docs/technical/sdi_it/permissions.md
+++ b/docs/technical/sdi_it/permissions.md
@@ -8,9 +8,9 @@ last_verified_commit: 0000000
 | Permission | Gates | Endpoints |
 |------------|-------|-----------|
 | `sdi_it.settings.read` | View SDI configuration | `GET /api/v1/sdi_it/settings` |
-| `sdi_it.settings.configure` | Edit regime, bollo, riferimento; enable | `PUT /api/v1/sdi_it/settings` |
+| `sdi_it.settings.configure` | Edit regime, bollo, riferimento, PEC mailbox; enable; test the mailbox | `PUT /api/v1/sdi_it/settings`, `POST /api/v1/sdi_it/pec/test` |
 | `sdi_it.records.read` | Record list and XML download | `GET /api/v1/sdi_it/records`, `GET /api/v1/sdi_it/records/{id}/xml` |
-| `sdi_it.records.manage` | Mark exported, import receipts, requeue after scarto | `POST /api/v1/sdi_it/records/{id}/exported`, `POST /api/v1/sdi_it/receipts`, `POST /api/v1/sdi_it/records/{id}/requeue` |
+| `sdi_it.records.manage` | Mark exported, import receipts, requeue after scarto, run a PEC tick | `POST /api/v1/sdi_it/records/{id}/exported`, `POST /api/v1/sdi_it/receipts`, `POST /api/v1/sdi_it/records/{id}/requeue`, `POST /api/v1/sdi_it/queue/process-now` |
 
 Role grants: admin `*`; dentist `records.read`; receptionist
 `records.read`, `records.manage` (the front desk is who uploads files


### PR DESCRIPTION
Second `sdi_it` PR (ADR 0025 §3, after #410 and the lead's #418). Backend only; the Nuxt layer is the third PR.

**PEC transport.** With `transport = pec` the clinic's own PEC mailbox is the channel: every `pending` file is sent as an XML attachment to the SDI mailbox (`sdi01@pec.fatturapa.it` first; the SDI answers from a dedicated `sdiNN@pec.fatturapa.it` address, which the poller stores and uses from then on — spec §1.3), and the receipts come back as attachments (XML, or inside a zip). `services/pec_transport.py` is stdlib `smtplib`/`imaplib` in the default executor — no new dependency, no `uv.lock` change. `services/submission_queue.py` drains one clinic per tick: rows locked `FOR UPDATE SKIP LOCKED`, commit before every network call, per-file backoff 2 min → 1 h over eight attempts then `failed`, a mailbox-level error pauses the clinic ten minutes with the message in `last_error`; receipts are applied through `services/receipts.apply_receipt`, now shared with the API import. `tasks.py` schedules it every 120 s.

**Settings and API.** PEC fields on `sdi_it_settings` (`sdi_0002`): PEC address, SMTP host/port (465 SSL or STARTTLS), username, password (Fernet-encrypted, write-only, `has_smtp_password` in the response), IMAP host/port/folder, `sdi_pec_address` (validated to `*@pec.fatturapa.it`), `last_pec_poll_at`, `next_send_after`. Enabling with `transport = pec` requires complete credentials (400 otherwise). `POST /pec/test` logs in to both servers without sending; `POST /queue/process-now` runs one tick. Records carry `transport`, `message_id`, `next_attempt_at`. No new permission strings.

**The two follow-ups from #410's review.** `ProgressivoInvio` is bumped under a `SELECT … FOR UPDATE` on the settings row, so two invoices issued at the same instant cannot share a file name (test: two builds → `00001`, `00002`). Riepilogo `Imposta` is now base × rate rounded once (SDI check 00421); test: nine lines of 0.99 at 22 % → 8.91 / 1.96, where the old per-line sum gave 1.98.

**Tests** (36 + round-trip): fake SMTP/IMAP (message shape, Message-ID, attachment and zip extraction, seen-flagging, learning the SDI reply address, error wrapping), worker (send + apply, backoff and clinic pause, inert when manual/disabled, unmatched receipts counted not fatal), router (PEC settings gate, write-only password, `sdi_pec_address` domain guard, test endpoint mocked, process-now end to end), the Imposta and progressivo cases above. The round-trip test now downgrades both branch revisions (`sdi_it@-2`).

**Docs.** `docs/modules/sdi_it.md` (PEC section), `docs/technical/sdi_it/{overview,permissions}.md`, module `CHANGELOG.md`.