### PR TITLE
fix(auth): warn when session cookies can never reach a split-host app (#444)

### DIFF
--- a/backend/app/core/auth/cookies.py
+++ b/backend/app/core/auth/cookies.py
@@ -63,10 +63,14 @@ def warn_if_host_only(request: Request | None) -> None:
 
     A cookie without ``Domain`` is host-only. When the app is served from
     another host than the API, the browser keeps the session cookies for
-    the API host: client-side calls still work, but a server-rendered page
-    load carries no cookie at all, so every reload lands on ``/login``.
-    Nothing fails loudly at deploy time, so say it here, once, with the
-    value to set.
+    the API host. Client-side reads still work, because the browser
+    attaches them to the API host itself, so the deployment looks healthy;
+    what breaks is everything that needs the cookies on the app's own
+    origin. A server-rendered page load carries no cookie at all and lands
+    on ``/login`` (#444), and ``dp_csrf`` - the JS-readable half of the
+    double-submit pair - is unreadable there, so every unsafe request goes
+    out without ``X-CSRF-Token`` and is refused with 403 (#448). Nothing
+    fails at deploy time, so say it here, once, with the value to set.
     """
     global _HOST_ONLY_WARNED
     if _HOST_ONLY_WARNED or _domain() or request is None:
@@ -85,8 +89,9 @@ def warn_if_host_only(request: Request | None) -> None:
     )
     logger.warning(
         "Session cookies are host-only: the app (%s) and the API (%s) are different hosts "
-        "and COOKIE_DOMAIN is empty, so the browser never sends dp_access/dp_refresh to the "
-        "app and every page reload will redirect to /login - %s.",
+        "and COOKIE_DOMAIN is empty, so the browser never sends them to the app. Every "
+        "server-rendered page load will redirect to /login (#444) and every write will fail "
+        "with 403 CSRF token missing, because the app cannot read dp_csrf either (#448) - %s.",
         app_host,
         api_host,
         fix,

--- a/backend/app/core/auth/cookies.py
+++ b/backend/app/core/auth/cookies.py
@@ -16,11 +16,15 @@ parent domain for split-host deployments.
 
 from __future__ import annotations
 
+import logging
 import secrets
+from urllib.parse import urlsplit
 
-from fastapi import Response
+from fastapi import Request, Response
 
 from app.config import settings
+
+logger = logging.getLogger(__name__)
 
 ACCESS_COOKIE = "dp_access"
 REFRESH_COOKIE = "dp_refresh"
@@ -38,13 +42,70 @@ def _domain() -> str | None:
     return settings.COOKIE_DOMAIN.strip() or None
 
 
+_HOST_ONLY_WARNED = False
+
+
+def _shared_parent(app_host: str, api_host: str) -> str | None:
+    """Longest common dotted suffix of two hosts, at least two labels:
+    ``demo.example.com`` + ``api-demo.example.com`` -> ``.example.com``."""
+    common: list[str] = []
+    for left, right in zip(reversed(app_host.split(".")), reversed(api_host.split("."))):
+        if left != right:
+            break
+        common.append(left)
+    if len(common) < 2:
+        return None
+    return "." + ".".join(reversed(common))
+
+
+def warn_if_host_only(request: Request | None) -> None:
+    """Warn once when the session cookies can never reach the app (#444).
+
+    A cookie without ``Domain`` is host-only. When the app is served from
+    another host than the API, the browser keeps the session cookies for
+    the API host: client-side calls still work, but a server-rendered page
+    load carries no cookie at all, so every reload lands on ``/login``.
+    Nothing fails loudly at deploy time, so say it here, once, with the
+    value to set.
+    """
+    global _HOST_ONLY_WARNED
+    if _HOST_ONLY_WARNED or _domain() or request is None:
+        return
+    origin = request.headers.get("origin") or request.headers.get("referer") or ""
+    app_host = (urlsplit(origin).hostname or "").lower()
+    api_host = (request.headers.get("host") or request.url.hostname or "").split(":")[0].lower()
+    if not app_host or not api_host or app_host == api_host:
+        return
+    _HOST_ONLY_WARNED = True
+    parent = _shared_parent(app_host, api_host)
+    fix = (
+        f"set COOKIE_DOMAIN={parent} and restart"
+        if parent
+        else "serve both from sibling hosts of one parent domain and set COOKIE_DOMAIN"
+    )
+    logger.warning(
+        "Session cookies are host-only: the app (%s) and the API (%s) are different hosts "
+        "and COOKIE_DOMAIN is empty, so the browser never sends dp_access/dp_refresh to the "
+        "app and every page reload will redirect to /login - %s.",
+        app_host,
+        api_host,
+        fix,
+    )
+
+
 def new_csrf_token() -> str:
     return secrets.token_urlsafe(32)
 
 
 def set_session_cookies(
-    response: Response, *, access_token: str, refresh_token: str, csrf_token: str
+    response: Response,
+    *,
+    access_token: str,
+    refresh_token: str,
+    csrf_token: str,
+    request: Request | None = None,
 ) -> None:
+    warn_if_host_only(request)
     access_ttl = settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
     refresh_ttl = settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600
     response.set_cookie(

--- a/backend/app/core/auth/router.py
+++ b/backend/app/core/auth/router.py
@@ -312,6 +312,7 @@ async def _start_session(
         access_token=access_token,
         refresh_token=refresh_token,
         csrf_token=new_csrf_token(),
+        request=request,
     )
     return TokenResponse(access_token=access_token, refresh_token=refresh_token)
 
@@ -429,6 +430,7 @@ async def refresh_token(
         access_token=access_token,
         refresh_token=new_refresh_token,
         csrf_token=request.cookies.get(CSRF_COOKIE) or new_csrf_token(),
+        request=request,
     )
 
     return AuthResponse(

--- a/backend/tests/test_auth_cookies.py
+++ b/backend/tests/test_auth_cookies.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
@@ -295,3 +297,73 @@ async def test_reuse_inside_grace_window_returns_live_successor(
     assert third.status_code == 200, third.text
     rows = await _family_rows(db_session, old_refresh)
     assert any(r.revoked_at is None for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_split_host_login_warns_with_the_cookie_domain_to_set(
+    client: AsyncClient, monkeypatch, caplog
+) -> None:
+    """#444: host-only cookies never reach a separately hosted app, and the
+    only symptom is that every page reload lands on /login. Say it once, at
+    login, with the value to set."""
+    from app.config import settings
+    from app.core.auth import cookies
+
+    await _bootstrap(client)
+    monkeypatch.setattr(cookies, "_HOST_ONLY_WARNED", False)
+    monkeypatch.setattr(settings, "COOKIE_DOMAIN", "")
+    with caplog.at_level(logging.WARNING, logger="app.core.auth.cookies"):
+        resp = await client.post(
+            LOGIN,
+            data={"username": "admin@example.com", "password": "SecurePass1234"},
+            headers={"Host": "api-demo.example.com", "Origin": "https://demo.example.com"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert "COOKIE_DOMAIN=.example.com" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_no_warning_for_one_host_or_when_cookie_domain_is_set(
+    client: AsyncClient, monkeypatch, caplog
+) -> None:
+    from app.config import settings
+    from app.core.auth import cookies
+
+    await _bootstrap(client)
+    creds = {"username": "admin@example.com", "password": "SecurePass1234"}
+
+    # Same host for app and API: nothing to warn about.
+    monkeypatch.setattr(cookies, "_HOST_ONLY_WARNED", False)
+    monkeypatch.setattr(settings, "COOKIE_DOMAIN", "")
+    with caplog.at_level(logging.WARNING, logger="app.core.auth.cookies"):
+        resp = await client.post(
+            LOGIN,
+            data=creds,
+            headers={"Host": "app.example.com", "Origin": "https://app.example.com"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert "COOKIE_DOMAIN" not in caplog.text
+
+    # Split hosts, but the deployment already widened the cookies.
+    caplog.clear()
+    monkeypatch.setattr(cookies, "_HOST_ONLY_WARNED", False)
+    monkeypatch.setattr(settings, "COOKIE_DOMAIN", ".example.com")
+    with caplog.at_level(logging.WARNING, logger="app.core.auth.cookies"):
+        resp = await client.post(
+            LOGIN,
+            data=creds,
+            headers={"Host": "api.example.com", "Origin": "https://app.example.com"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert "COOKIE_DOMAIN" not in caplog.text
+
+
+def test_shared_parent_needs_two_common_labels() -> None:
+    from app.core.auth.cookies import _shared_parent
+
+    assert _shared_parent("demo.dentalpin.com", "api-demo.dentalpin.com") == ".dentalpin.com"
+    assert (
+        _shared_parent("app.clinic.example.org", "api.clinic.example.org") == ".clinic.example.org"
+    )
+    assert _shared_parent("app.example.com", "api.example.net") is None
+    assert _shared_parent("app.com", "api.com") is None  # a public suffix is not a parent

--- a/docs/user-manual/en/operations.md
+++ b/docs/user-manual/en/operations.md
@@ -20,8 +20,10 @@ operator runs — not the Python internals.
   siblings of one parent domain and `.env` must set `COOKIE_DOMAIN` to that
   parent (`COOKIE_DOMAIN=.example.com` for `app.example.com` +
   `api.example.com`). The session cookies are host-only without it, so the
-  server-rendered pages never see the session and every reload logs the
-  user out. The backend logs a warning naming the value to set.
+  server-rendered pages never see the session, every reload logs the user
+  out, and every write fails with "CSRF token missing" because the app
+  cannot read the `dp_csrf` cookie either. The backend logs a warning
+  naming the value to set.
 
 Smoke-check:
 
@@ -334,6 +336,7 @@ DELETE FROM alembic_version;
 | Uninstall blocked: "no Alembic branch" | Fase A legacy module | Not supported; wait for Fase B |
 | Uninstall blocked: "required by ..." | Reverse dependency exists | Uninstall dependents first, or `--force` |
 | Logged out on every page refresh, while clicking around works | App and API on different hosts with `COOKIE_DOMAIN` empty, so the session cookies never reach the app | Set `COOKIE_DOMAIN` to the shared parent domain (e.g. `.example.com`) and restart the backend |
+| Every save answers `403 CSRF token missing or invalid`, while reading works | Same cause: the app cannot read the `dp_csrf` cookie, so the `X-CSRF-Token` header is never sent | Same fix: set `COOKIE_DOMAIN` to the shared parent domain |
 
 ---
 

--- a/docs/user-manual/en/operations.md
+++ b/docs/user-manual/en/operations.md
@@ -16,6 +16,12 @@ operator runs — not the Python internals.
 - Cloned DentalPin repo (or equivalent deploy artefacts).
 - `.env` filled in with `POSTGRES_PASSWORD`, `SECRET_KEY`, etc.
 - A running stack: `docker compose up -d`.
+- **Serving the app and the API from different hosts?** Then they must be
+  siblings of one parent domain and `.env` must set `COOKIE_DOMAIN` to that
+  parent (`COOKIE_DOMAIN=.example.com` for `app.example.com` +
+  `api.example.com`). The session cookies are host-only without it, so the
+  server-rendered pages never see the session and every reload logs the
+  user out. The backend logs a warning naming the value to set.
 
 Smoke-check:
 
@@ -327,6 +333,7 @@ DELETE FROM alembic_version;
 | Community module page 404 | `modules.json` missing the layer path | `./bin/dentalpin modules sync-frontend` + frontend rebuild |
 | Uninstall blocked: "no Alembic branch" | Fase A legacy module | Not supported; wait for Fase B |
 | Uninstall blocked: "required by ..." | Reverse dependency exists | Uninstall dependents first, or `--force` |
+| Logged out on every page refresh, while clicking around works | App and API on different hosts with `COOKIE_DOMAIN` empty, so the session cookies never reach the app | Set `COOKIE_DOMAIN` to the shared parent domain (e.g. `.example.com`) and restart the backend |
 
 ---
 

--- a/docs/user-manual/es/operations.md
+++ b/docs/user-manual/es/operations.md
@@ -16,6 +16,13 @@ Cubre los comandos que ejecuta un operador — no los internos de Python.
 - Repositorio de DentalPin clonado (o artefactos de despliegue equivalentes).
 - `.env` rellenado con `POSTGRES_PASSWORD`, `SECRET_KEY`, etc.
 - Un stack en marcha: `docker compose up -d`.
+- **¿La aplicación y la API en hosts distintos?** Entonces deben ser
+  hermanos de un mismo dominio padre y `.env` debe fijar `COOKIE_DOMAIN` a
+  ese padre (`COOKIE_DOMAIN=.example.com` para `app.example.com` +
+  `api.example.com`). Sin eso las cookies de sesión son de host único, las
+  páginas renderizadas en el servidor no ven la sesión y cada recarga
+  cierra la sesión del usuario. El backend avisa en el log con el valor a
+  poner.
 
 Comprobación rápida:
 
@@ -339,6 +346,7 @@ DELETE FROM alembic_version;
 | Página de módulo comunitario 404 | Falta la ruta de la capa en `modules.json` | `./bin/dentalpin modules sync-frontend` + reconstruir el frontend |
 | Desinstalación bloqueada: "no Alembic branch" | Módulo legacy de la Fase A | No soportado; esperar a la Fase B |
 | Desinstalación bloqueada: "required by ..." | Existe una dependencia inversa | Desinstalar primero los dependientes, o `--force` |
+| Sesión cerrada en cada recarga, aunque navegar funciona | Aplicación y API en hosts distintos con `COOKIE_DOMAIN` vacío: las cookies de sesión nunca llegan a la aplicación | Fijar `COOKIE_DOMAIN` al dominio padre compartido (p. ej. `.example.com`) y reiniciar el backend |
 
 ---
 

--- a/docs/user-manual/es/operations.md
+++ b/docs/user-manual/es/operations.md
@@ -20,9 +20,10 @@ Cubre los comandos que ejecuta un operador — no los internos de Python.
   hermanos de un mismo dominio padre y `.env` debe fijar `COOKIE_DOMAIN` a
   ese padre (`COOKIE_DOMAIN=.example.com` para `app.example.com` +
   `api.example.com`). Sin eso las cookies de sesión son de host único, las
-  páginas renderizadas en el servidor no ven la sesión y cada recarga
-  cierra la sesión del usuario. El backend avisa en el log con el valor a
-  poner.
+  páginas renderizadas en el servidor no ven la sesión, cada recarga
+  cierra la sesión del usuario y toda escritura falla con "CSRF token
+  missing" porque la aplicación tampoco puede leer la cookie `dp_csrf`.
+  El backend avisa en el log con el valor a poner.
 
 Comprobación rápida:
 
@@ -347,6 +348,7 @@ DELETE FROM alembic_version;
 | Desinstalación bloqueada: "no Alembic branch" | Módulo legacy de la Fase A | No soportado; esperar a la Fase B |
 | Desinstalación bloqueada: "required by ..." | Existe una dependencia inversa | Desinstalar primero los dependientes, o `--force` |
 | Sesión cerrada en cada recarga, aunque navegar funciona | Aplicación y API en hosts distintos con `COOKIE_DOMAIN` vacío: las cookies de sesión nunca llegan a la aplicación | Fijar `COOKIE_DOMAIN` al dominio padre compartido (p. ej. `.example.com`) y reiniciar el backend |
+| Cada guardado responde `403 CSRF token missing or invalid`, aunque leer funciona | La misma causa: la aplicación no puede leer la cookie `dp_csrf`, así que nunca envía la cabecera `X-CSRF-Token` | La misma solución: fijar `COOKIE_DOMAIN` al dominio padre compartido |
 
 ---
 


### PR DESCRIPTION
## Overview

#444 (thanks @BabuBahir) is a deployment gap, not an app bug, but it is one nothing in the repository warns about, so it is worth a guard.

The demo serves the app from `demo.dentalpin.com` and the API from `api-demo.dentalpin.com`, and the login response sets the session cookies without a `Domain`:

```
set-cookie: dp_access=…; HttpOnly; Max-Age=900; Path=/; SameSite=lax; Secure
```

A cookie without `Domain` is host-only, so the browser sends the three cookies to the API host and never to the app host. Client-side navigation works; a reload is server-rendered on the app host with no session cookie at all, and the auth middleware redirects to `/login`. Against the live demo:

```
GET https://demo.dentalpin.com/patients                      → 302 → /login
GET https://demo.dentalpin.com/patients  (cookies present)   → 200
```

`COOKIE_DOMAIN` (#394) exists for exactly this and is empty on the demo; setting `COOKIE_DOMAIN=.dentalpin.com` there fixes it. The failure mode is silent at deploy time and only shows up on reload, so:

- `warn_if_host_only()` in `backend/app/core/auth/cookies.py` logs **once per process**, the first time session cookies are issued, when the request's `Origin` (or `Referer`) host differs from the API's own host and `COOKIE_DOMAIN` is empty. It names both hosts and the exact value to set, derived from the longest common suffix of the two hosts (`.dentalpin.com`), or says to put them under one parent domain when there is no shared one.
- `set_session_cookies()` takes the request and calls it, so login and refresh are both covered and it cannot be forgotten at a call site.
- `docs/user-manual/{en,es}/operations.md`: a prerequisite bullet for split-host deployments and a troubleshooting row ("logged out on every page refresh, while clicking around works").

No behaviour change otherwise: no new setting, nothing fails, single-host deployments log nothing.

## Test plan

- `backend/tests/test_auth_cookies.py`: split-host login logs the warning containing `COOKIE_DOMAIN=.example.com`; no warning when both hosts match or when `COOKIE_DOMAIN` is already set; `_shared_parent` unit test (needs two common labels, so `app.com` + `api.com` yields nothing).
- `pytest tests/test_auth_cookies.py` → 14 passed. `ruff check` / `format --check` clean. `check_docs_layout.py` OK.
- Verified by hand against the live demo (both curl lines above).

The deployment side of #444 stays with you: `COOKIE_DOMAIN=.dentalpin.com` on the demo.

Refs #444