### PR TITLE
fix(auth): blob downloads refresh an expired session instead of failing (#440)

### DIFF
--- a/backend/app/modules/accounting_export/frontend/composables/useAccountingExport.ts
+++ b/backend/app/modules/accounting_export/frontend/composables/useAccountingExport.ts
@@ -27,7 +27,6 @@ function qs(filters: ExportFilters, extra: Record<string, string> = {}): string 
 
 export function useAccountingExport() {
   const api = useApi()
-  const config = useRuntimeConfig()
 
   async function preview(filters: ExportFilters): Promise<ApiOk<ExportPreview>> {
     const s = qs(filters)
@@ -36,11 +35,10 @@ export function useAccountingExport() {
     )
   }
 
-  // Authenticated blob download (JWT in header, so a plain <a href> won't do).
+  // Authenticated blob download: a plain <a href> would miss the session
+  // and the 401 refresh, so it goes through api.raw.
   async function download(filters: ExportFilters, separator: ',' | ';' = ';'): Promise<void> {
-    const url = config.public.apiBaseUrl
-      + `/api/v1/accounting_export/run?${qs(filters, { separator })}`
-    const res = await fetch(url, { credentials: 'include' })
+    const res = await api.raw(`/api/v1/accounting_export/run?${qs(filters, { separator })}`)
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const blob = await res.blob()
     const blobUrl = URL.createObjectURL(blob)

--- a/backend/app/modules/billing/frontend/composables/useInvoices.ts
+++ b/backend/app/modules/billing/frontend/composables/useInvoices.ts
@@ -467,11 +467,7 @@ export function useInvoices() {
   // ============================================================================
 
   async function downloadPDF(id: string, locale: string = 'es'): Promise<void> {
-    const baseUrl = config.public.apiBaseUrl
-    const response = await fetch(
-      `${baseUrl}/api/v1/billing/invoices/${id}/pdf?locale=${locale}`,
-      { credentials: 'include' }
-    )
+    const response = await api.raw(`/api/v1/billing/invoices/${id}/pdf?locale=${locale}`)
 
     if (!response.ok) {
       // Raw fetch (blob response) bypasses useApi's error shaping — read

--- a/backend/app/modules/budget/frontend/composables/useBudgets.ts
+++ b/backend/app/modules/budget/frontend/composables/useBudgets.ts
@@ -354,8 +354,7 @@ export function useBudgets() {
   }
 
   async function downloadPDFAt(path: string, fallbackName: string): Promise<void> {
-    const baseUrl = config.public.apiBaseUrl
-    const response = await fetch(`${baseUrl}${path}`, { credentials: 'include' })
+    const response = await api.raw(path)
 
     if (!response.ok) {
       // This path uses raw fetch (blob response), so it bypasses useApi

--- a/backend/app/modules/clinical_notes/frontend/components/NoteCard.vue
+++ b/backend/app/modules/clinical_notes/frontend/components/NoteCard.vue
@@ -135,22 +135,17 @@ const lightboxDocuments = computed<Document[]>(() =>
   }))
 )
 
-// Auth-aware blob URLs for the inline thumbs (server requires bearer).
-const config = useRuntimeConfig()
-const apiBaseUrl = computed(() =>
-  import.meta.server ? config.apiBaseUrlServer : config.public.apiBaseUrl
-)
+// Auth-aware blob URLs for the inline thumbs: the endpoint needs the
+// session, so <img src> cannot fetch them directly.
+const api = useApi()
 const thumbBlobs = ref<Record<string, string>>({})
 
 async function loadThumb(att: NoteAttachment) {
   if (!att.thumb_url || thumbBlobs.value[att.id]) return
   try {
-    const blob = await $fetch<Blob>(att.thumb_url, {
-      baseURL: apiBaseUrl.value,
-      credentials: 'include',
-      responseType: 'blob'
-    })
-    thumbBlobs.value[att.id] = URL.createObjectURL(blob)
+    const response = await api.raw(att.thumb_url)
+    if (!response.ok) return
+    thumbBlobs.value[att.id] = URL.createObjectURL(await response.blob())
   } catch { /* swallow — falls back to icon placeholder */ }
 }
 

--- a/backend/app/modules/documents/frontend/composables/useManagedDocuments.ts
+++ b/backend/app/modules/documents/frontend/composables/useManagedDocuments.ts
@@ -104,12 +104,7 @@ export function useManagedDocuments() {
    * ``Content-Disposition`` filename preserved.
    */
   async function downloadDocument(document_id: string): Promise<void> {
-    const baseUrl = useRuntimeConfig().public.apiBaseUrl
-
-    const response = await fetch(
-      `${baseUrl}/api/v1/documents/${document_id}/download`,
-      { credentials: 'include' }
-    )
+    const response = await api.raw(`/api/v1/documents/${document_id}/download`)
 
     if (!response.ok) {
       const body = await response.json().catch(() => null)

--- a/backend/app/modules/india_gst/frontend/pages/reports/india-gst.vue
+++ b/backend/app/modules/india_gst/frontend/pages/reports/india-gst.vue
@@ -8,7 +8,6 @@ definePageMeta({ layout: 'default' })
 
 const { t } = useI18n()
 const api = useApi()
-const config = useRuntimeConfig()
 const toast = useToast()
 const { can } = usePermissions()
 
@@ -63,14 +62,11 @@ async function load() {
 
 onMounted(load)
 
-// Authenticated blob download (JWT goes in a header, so window.open /
-// a plain <a href> would come back 401) — same pattern as
-// accounting_export's useAccountingExport.download().
+// Authenticated blob download (window.open or a plain <a href> would come
+// back 401) — same pattern as accounting_export's download().
 async function exportCsv() {
   try {
-    const res = await fetch(`${config.public.apiBaseUrl}/api/v1/india_gst/reports/export`, {
-      credentials: 'include'
-    })
+    const res = await api.raw('/api/v1/india_gst/reports/export')
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const blob = await res.blob()
     const blobUrl = URL.createObjectURL(blob)

--- a/backend/app/modules/media/frontend/components/media/PhotoCard.vue
+++ b/backend/app/modules/media/frontend/components/media/PhotoCard.vue
@@ -9,11 +9,7 @@ interface Props {
 const props = defineProps<Props>()
 defineEmits<{ open: [Document], select: [Document] }>()
 
-const config = useRuntimeConfig()
-
-const apiBaseUrl = computed(() =>
-  import.meta.server ? config.apiBaseUrlServer : config.public.apiBaseUrl
-)
+const api = useApi()
 
 // Build a fully-qualified, auth-aware thumb URL. The server returns a
 // relative `/api/v1/...` path; we render it with an Authorization header
@@ -24,13 +20,10 @@ async function loadThumb() {
   const path = props.document.thumb_url ?? props.document.full_url
   if (!path) return
   try {
-    const response = await $fetch<Blob>(path, {
-      baseURL: apiBaseUrl.value,
-      credentials: 'include',
-      responseType: 'blob'
-    })
+    const response = await api.raw(path)
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
     if (thumbBlobUrl.value) URL.revokeObjectURL(thumbBlobUrl.value)
-    thumbBlobUrl.value = URL.createObjectURL(response)
+    thumbBlobUrl.value = URL.createObjectURL(await response.blob())
   } catch {
     thumbBlobUrl.value = null
   }

--- a/backend/app/modules/media/frontend/components/media/PhotoLightbox.vue
+++ b/backend/app/modules/media/frontend/components/media/PhotoLightbox.vue
@@ -18,10 +18,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { pairPhotos, unpair } = usePhotos()
 
-const config = useRuntimeConfig()
-const apiBaseUrl = computed(() =>
-  import.meta.server ? config.apiBaseUrlServer : config.public.apiBaseUrl
-)
+const api = useApi()
 
 const index = ref(0)
 
@@ -51,12 +48,9 @@ const partnerBlobUrl = ref<string | null>(null)
 
 async function fetchBlob(path: string): Promise<string | null> {
   try {
-    const response = await $fetch<Blob>(path, {
-      baseURL: apiBaseUrl.value,
-      credentials: 'include',
-      responseType: 'blob'
-    })
-    return URL.createObjectURL(response)
+    const response = await api.raw(path)
+    if (!response.ok) return null
+    return URL.createObjectURL(await response.blob())
   } catch {
     return null
   }

--- a/backend/app/modules/media/frontend/composables/useDocuments.ts
+++ b/backend/app/modules/media/frontend/composables/useDocuments.ts
@@ -18,6 +18,7 @@ export function useDocuments() {
   const uploadProgress = ref<UploadProgress | null>(null)
   const total = ref(0)
 
+  const api = useApi()
   const apiBaseUrl = computed(() =>
     import.meta.server ? config.apiBaseUrlServer : config.public.apiBaseUrl
   )
@@ -119,17 +120,13 @@ export function useDocuments() {
 
   async function downloadDocument(documentId: string, filename: string) {
     try {
-      const response = await $fetch<Blob>(
-        `/api/v1/media/documents/${documentId}/download`,
-        {
-          baseURL: apiBaseUrl.value,
-          credentials: 'include',
-          responseType: 'blob'
-        }
-      )
+      // api.raw carries the session cookies and refreshes once on 401, so
+      // a download after a long idle still works (#440).
+      const response = await api.raw(`/api/v1/media/documents/${documentId}/download`)
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
 
       // Create download link
-      const url = window.URL.createObjectURL(response)
+      const url = window.URL.createObjectURL(await response.blob())
       const link = document.createElement('a')
       link.href = url
       link.download = filename
@@ -153,15 +150,9 @@ export function useDocuments() {
    */
   async function getDocumentBlobUrl(documentId: string): Promise<string | null> {
     try {
-      const response = await $fetch<Blob>(
-        `/api/v1/media/documents/${documentId}/download`,
-        {
-          baseURL: apiBaseUrl.value,
-          credentials: 'include',
-          responseType: 'blob'
-        }
-      )
-      return URL.createObjectURL(response)
+      const response = await api.raw(`/api/v1/media/documents/${documentId}/download`)
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      return URL.createObjectURL(await response.blob())
     } catch (error) {
       console.error('Error fetching document blob:', error)
       toast.add({

--- a/backend/app/modules/purchase_orders/frontend/composables/useProcurement.ts
+++ b/backend/app/modules/purchase_orders/frontend/composables/useProcurement.ts
@@ -182,7 +182,6 @@ function defined<T>(value: T | undefined | null | ''): T | undefined {
 
 export function useProcurement() {
   const api = useApi()
-  const config = useRuntimeConfig()
 
   // --- suppliers -------------------------------------------------------
   async function listSuppliers(params: SupplierListParams = {}): Promise<PaginatedResponse<ProcurementSupplier>> {
@@ -258,12 +257,11 @@ export function useProcurement() {
   }
 
   async function downloadPurchaseOrderPdf(id: string, locale = 'es'): Promise<void> {
-    // Raw fetch: the PDF needs the bearer token and comes back as a blob, so
-    // it cannot be a plain link (same pattern as billing's downloadPDF).
+    // The PDF comes back as a blob and needs the session, so it cannot be
+    // a plain link; api.raw carries the cookies and refreshes on 401.
     const pdfLocale = locale === 'en' ? 'en' : 'es'
-    const response = await fetch(
-      `${config.public.apiBaseUrl}/api/v1/purchase_orders/${id}/pdf?locale=${pdfLocale}`,
-      { credentials: 'include' }
+    const response = await api.raw(
+      `/api/v1/purchase_orders/${id}/pdf?locale=${pdfLocale}`
     )
     if (!response.ok) {
       const body = await response.json().catch(() => null)

--- a/backend/app/modules/recalls/frontend/pages/recalls/index.vue
+++ b/backend/app/modules/recalls/frontend/pages/recalls/index.vue
@@ -127,21 +127,21 @@ function onChanged(updated: Recall) {
 
 const conversionPct = computed(() => stats.value ? Math.round(stats.value.conversion_rate * 100) : 0)
 
-const config = useRuntimeConfig()
+const api = useApi()
 const isExporting = ref(false)
 
 async function downloadCsv() {
   if (isExporting.value) return
   isExporting.value = true
   try {
-    const url = config.public.apiBaseUrl + recallsApi.exportCsvUrl({
+    const path = recallsApi.exportCsvUrl({
       month: month.value || undefined,
       reason: reason.value === ANY ? undefined : reason.value || undefined,
       status: status.value === ANY ? undefined : status.value || undefined,
       priority: priority.value === ANY ? undefined : priority.value || undefined,
       overdue: overdue.value || undefined
     })
-    const res = await fetch(url, { credentials: 'include' })
+    const res = await api.raw(path)
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const blob = await res.blob()
     const blobUrl = URL.createObjectURL(blob)

--- a/frontend/app/composables/useApi.ts
+++ b/frontend/app/composables/useApi.ts
@@ -182,14 +182,30 @@ export function useApi() {
    * Raw ``fetch`` against the API with the session cookies attached —
    * for blob downloads and streams where ``$fetch``'s JSON handling gets
    * in the way. Returns the ``Response``; the caller checks ``ok``.
+   *
+   * A 401 is refreshed and retried once, exactly like ``$api``: a blob
+   * download is a plain fetch, so without this an idle longer than the
+   * access cookie's lifetime turns "Download PDF" into "Not
+   * authenticated" while the rest of the page recovers silently (#440).
    */
   async function raw(path: string, init: RequestInit = {}): Promise<Response> {
     const method = (init.method || 'GET').toUpperCase()
-    return await fetch(`${apiBaseUrl.value}${path}`, {
+    const send = () => fetch(`${apiBaseUrl.value}${path}`, {
       ...init,
       credentials: 'include',
-      headers: { ...csrfHeaders(method), ...(init.headers as Record<string, string> | undefined) }
+      headers: {
+        ...csrfHeaders(method),
+        ...cookieHeaders(),
+        ...(init.headers as Record<string, string> | undefined)
+      }
     })
+    const response = await send()
+    if (response.status !== 401) return response
+    if (await auth.refresh()) return await send()
+    // The family is gone: end the session as $api does, and hand the 401
+    // back so the caller still shows its own message.
+    await auth.logout()
+    return response
   }
 
   // Convenience methods

--- a/frontend/tests/composables/useApiRaw.test.ts
+++ b/frontend/tests/composables/useApiRaw.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+/**
+ * #440: blob downloads go through ``useApi().raw``, which must recover
+ * from an expired access cookie the same way ``$api`` does — otherwise
+ * "Download PDF" after an idle answers "Not authenticated" while the
+ * rest of the page refreshes silently.
+ */
+const refresh = vi.fn(async () => true)
+const logout = vi.fn(async () => {})
+
+mockNuxtImport('useAuth', () => () => ({ refresh, logout }))
+mockNuxtImport('useToast', () => () => ({ add: vi.fn() }))
+mockNuxtImport('useI18n', () => () => ({ t: (key: string, fallback?: string) => fallback ?? key }))
+
+async function raw(path: string) {
+  const { useApi } = await import('~/composables/useApi')
+  return await useApi().raw(path)
+}
+
+describe('useApi().raw', () => {
+  beforeEach(() => {
+    refresh.mockClear()
+    refresh.mockResolvedValue(true)
+    logout.mockClear()
+  })
+
+  it('returns the response untouched when the session is valid', async () => {
+    const fetchMock = vi.fn(async () => new Response('pdf', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const res = await raw('/api/v1/billing/invoices/1/pdf')
+
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('refreshes once and retries when the access cookie has expired', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('', { status: 401 }))
+      .mockResolvedValueOnce(new Response('pdf', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const res = await raw('/api/v1/billing/invoices/1/pdf')
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(res.status).toBe(200)
+    expect(logout).not.toHaveBeenCalled()
+  })
+
+  it('ends the session and hands back the 401 when the refresh fails', async () => {
+    refresh.mockResolvedValue(false)
+    const fetchMock = vi.fn(async () => new Response('', { status: 401 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const res = await raw('/api/v1/billing/invoices/1/pdf')
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(logout).toHaveBeenCalledTimes(1)
+    expect(res.status).toBe(401)
+  })
+})


### PR DESCRIPTION
## Overview

Closes #440. `useApi().raw()` was added in #394 and never used; it now does what the issue asks and every blob call site goes through it.

- **`frontend/app/composables/useApi.ts`**: `raw()` retries once through `auth.refresh()` on a 401 and replays the request with the rotated cookies, exactly like `$api`. If the refresh fails it ends the session the way `$api` does and hands the 401 back, so the caller still shows its own message. It also forwards `cookieHeaders()` now, so an SSR-side call would authenticate like the rest.
- **Eleven call sites** moved off raw `fetch`/`$fetch` onto `api.raw()`: invoice PDF (`billing/useInvoices`), budget PDF and signed PDF (`budget/useBudgets`), purchase-order PDF (`purchase_orders/useProcurement`), managed-document download (`documents/useManagedDocuments`), media document download and inline preview (`media/useDocuments`), the accounting-export ZIP, the India GST CSV, the recalls CSV, and the photo and clinical-note thumbnails (`media/PhotoCard`, `media/PhotoLightbox`, `clinical_notes/NoteCard`). Each one loses its hand-built `${apiBaseUrl}${path}` and its own `credentials: 'include'`.

Two things deliberately left alone:

- `budget/usePublicBudget.ts` — the public token flow has no session to refresh.
- `copilot/useCopilotStream.ts` — an SSE stream, not a blob; a mid-stream 401 needs its own handling.

Also still on raw `$fetch` with `credentials: 'include'`: the list, upload, delete and update calls in `media/useDocuments`. They have the same gap, but the upload carries FormData with progress callbacks that `useApi` does not model, so converting them is a separate piece of work rather than a rename. Happy to file it if you want it tracked.

## Test plan

- New `frontend/tests/composables/useApiRaw.test.ts`: a valid session passes through untouched with no refresh; a 401 refreshes once, retries and returns the 200; a failed refresh logs out and returns the 401. 3 passed.
- `npx nuxt typecheck` with the module layers loaded: clean. eslint over every touched layer and `app/composables/useApi.ts`: clean.
- Manual pass worth doing on the dev stack with `ACCESS_TOKEN_EXPIRE_MINUTES=1`: open an invoice, wait past the minute, click Download PDF — the file arrives and the session rotates instead of the "Not authenticated" toast. Same for a media photo thumbnail after idle (it used to silently fall back to the placeholder icon).

Closes #440